### PR TITLE
Update pluginhandle to return 0 if no isolate value set

### DIFF
--- a/android/app/src/main/java/com/bluebubbles/messaging/services/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/android/app/src/main/java/com/bluebubbles/messaging/services/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -188,7 +188,7 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
             if (callbackHandle != 0) {
                 Log.i(TAG, "Found background isolate callback handle");
                 startBackgroundIsolate(callbackHandle, null);
-            }else {
+            } else {
                 Log.i(TAG, "No callback handler available for background isolate");
             }
         }

--- a/android/app/src/main/java/com/bluebubbles/messaging/services/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/android/app/src/main/java/com/bluebubbles/messaging/services/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -185,8 +185,8 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
     public void startBackgroundIsolate() {
         if (isNotRunning()) {
             long callbackHandle = getPluginCallbackHandle();
-            Log.i(TAG, "Starting background isolate");
             if (callbackHandle != 0) {
+                Log.i(TAG, "Found background isolate callback handle");
                 startBackgroundIsolate(callbackHandle, null);
             }else {
                 Log.i(TAG, "No callback handler available for background isolate");

--- a/android/app/src/main/java/com/bluebubbles/messaging/services/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/android/app/src/main/java/com/bluebubbles/messaging/services/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -184,9 +184,12 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
      */
     public void startBackgroundIsolate() {
         if (isNotRunning()) {
-            Long callbackHandle = getPluginCallbackHandle();
-            if (callbackHandle != null && callbackHandle != 0) {
+            long callbackHandle = getPluginCallbackHandle();
+            Log.i(TAG, "Starting background isolate");
+            if (callbackHandle != 0) {
                 startBackgroundIsolate(callbackHandle, null);
+            }else {
+                Log.i(TAG, "No callback handler available for background isolate");
             }
         }
     }
@@ -317,7 +320,7 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
         }
         SharedPreferences prefs =
                 ContextHolder.getApplicationContext().getSharedPreferences(BACKGROUND_SERVICE_SHARED_PREF, Context.MODE_PRIVATE);
-        return prefs.getLong(BACKGROUND_HANDLE_SHARED_PREF_KEY, -1);
+        return prefs.getLong(BACKGROUND_HANDLE_SHARED_PREF_KEY, 0);
     }
 
     private void initializeMethodChannel(BinaryMessenger isolate) {


### PR DESCRIPTION
Currently, the code returns -1 if no isolate set but adjusting it the shared prefs to return 0 if not found as the second parameter of `getLong` is the default parameter if not found