### PR TITLE
final 1.8 desktop fixes

### DIFF
--- a/lib/helpers/attachment_helper.dart
+++ b/lib/helpers/attachment_helper.dart
@@ -24,6 +24,7 @@ import 'package:image/image.dart' as img;
 import 'package:image_gallery_saver/image_gallery_saver.dart';
 import 'package:image_size_getter/image_size_getter.dart' as isg;
 import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:universal_html/html.dart' as html;
 import 'package:universal_io/io.dart' hide File;
@@ -148,6 +149,7 @@ class AttachmentHelper {
     }
     if (kIsDesktop) {
       String? savePath = await FilePicker.platform.saveFile(
+        initialDirectory: (await getDownloadsDirectory())?.path,
         dialogTitle: 'Choose a location to save this file',
         fileName: file.name,
       );

--- a/lib/helpers/ui_helpers.dart
+++ b/lib/helpers/ui_helpers.dart
@@ -1,9 +1,7 @@
 import 'package:bluebubbles/blocs/chat_bloc.dart';
 import 'package:bluebubbles/helpers/attachment_helper.dart';
 import 'package:bluebubbles/helpers/constants.dart';
-import 'package:bluebubbles/helpers/utils.dart';
 import 'package:bluebubbles/managers/event_dispatcher.dart';
-import 'package:bluebubbles/managers/method_channel_interface.dart';
 import 'package:bluebubbles/managers/settings_manager.dart';
 import 'package:bluebubbles/repository/models/models.dart';
 import 'package:flutter/cupertino.dart';

--- a/lib/layouts/settings/redacted_mode_panel.dart
+++ b/lib/layouts/settings/redacted_mode_panel.dart
@@ -5,7 +5,6 @@ import 'package:bluebubbles/helpers/hex_color.dart';
 import 'package:bluebubbles/helpers/themes.dart';
 import 'package:bluebubbles/layouts/settings/settings_widgets.dart';
 import 'package:bluebubbles/layouts/widgets/message_widget/message_widget.dart';
-import 'package:bluebubbles/managers/contact_manager.dart';
 import 'package:bluebubbles/managers/settings_manager.dart';
 import 'package:bluebubbles/repository/models/models.dart';
 import 'package:flutter/material.dart';

--- a/lib/layouts/settings/settings_panel.dart
+++ b/lib/layouts/settings/settings_panel.dart
@@ -37,6 +37,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:universal_html/html.dart' as html;
 import 'package:universal_io/io.dart';
 
@@ -864,9 +865,7 @@ class _SettingsPanelState extends State<SettingsPanel> {
                                         onPressed: () async {
                                           String directoryPath = "/storage/emulated/0/Download/BlueBubbles-settings-";
                                           DateTime now = DateTime.now().toLocal();
-                                          String filePath = directoryPath +
-                                              "${now.year}${now.month}${now.day}_${now.hour}${now.minute}${now.second}" +
-                                              ".json";
+                                          String filePath = "$directoryPath${now.year}${now.month}${now.day}_${now.hour}${now.minute}${now.second}.json";
                                           Map<String, dynamic> json = SettingsManager().settings.toMap();
                                           if (kIsWeb) {
                                             final bytes = utf8.encode(jsonEncode(json));
@@ -877,6 +876,18 @@ class _SettingsPanelState extends State<SettingsPanel> {
                                               ..click();
                                             return;
                                           }
+                                          if (kIsDesktop) {
+                                            String? _filePath = await FilePicker.platform.saveFile(
+                                              initialDirectory: (await getDownloadsDirectory())?.path,
+                                              dialogTitle: 'Choose a location to save this file',
+                                              fileName: "BlueBubbles-settings-${now.year}${now.month}${now.day}_${now
+                                                  .hour}${now.minute}${now.second}.json",
+                                            );
+                                            if (_filePath == null) {
+                                              return showSnackbar('Failed', 'You didn\'t select a file path!');
+                                            }
+                                            filePath = _filePath;
+                                          }
                                           File file = File(filePath);
                                           await file.create(recursive: true);
                                           String jsonString = jsonEncode(json);
@@ -884,7 +895,7 @@ class _SettingsPanelState extends State<SettingsPanel> {
                                           Get.back();
                                           showSnackbar(
                                             "Success",
-                                            "Settings exported successfully to downloads folder",
+                                            "Settings exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
                                             durationMs: 2000,
                                             button: TextButton(
                                               style: TextButton.styleFrom(
@@ -893,7 +904,7 @@ class _SettingsPanelState extends State<SettingsPanel> {
                                               onPressed: () {
                                                 Share.file("BlueBubbles Settings", filePath);
                                               },
-                                              child: Text("SHARE", style: TextStyle(color: Theme.of(context).primaryColor)),
+                                              child: kIsDesktop ? SizedBox.shrink() : Text("SHARE", style: TextStyle(color: Theme.of(context).primaryColor)),
                                             ),
                                           );
                                         },
@@ -988,13 +999,25 @@ class _SettingsPanelState extends State<SettingsPanel> {
                                               ..click();
                                             return;
                                           }
+                                          if (kIsDesktop) {
+                                            String? _filePath = await FilePicker.platform.saveFile(
+                                              initialDirectory: (await getDownloadsDirectory())?.path,
+                                              dialogTitle: 'Choose a location to save this file',
+                                              fileName: "BlueBubbles-theming-${now.year}${now.month}${now.day}_${now
+                                                  .hour}${now.minute}${now.second}.json",
+                                            );
+                                            if (_filePath == null) {
+                                              return showSnackbar('Failed', 'You didn\'t select a file path!');
+                                            }
+                                            filePath = _filePath;
+                                          }
                                           File file = File(filePath);
                                           await file.create(recursive: true);
                                           await file.writeAsString(jsonStr);
                                           Get.back();
                                           showSnackbar(
                                             "Success",
-                                            "Theming exported successfully to downloads folder",
+                                            "Theming exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
                                             durationMs: 2000,
                                             button: TextButton(
                                               style: TextButton.styleFrom(
@@ -1003,7 +1026,7 @@ class _SettingsPanelState extends State<SettingsPanel> {
                                               onPressed: () {
                                                 Share.file("BlueBubbles Theming", filePath);
                                               },
-                                              child: Text("SHARE", style: TextStyle(color: Theme.of(context).primaryColor)),
+                                              child: kIsDesktop ? SizedBox.shrink() : Text("SHARE", style: TextStyle(color: Theme.of(context).primaryColor)),
                                             ),
                                           );
                                         },

--- a/lib/layouts/widgets/message_widget/message_content/media_players/regular_file_opener.dart
+++ b/lib/layouts/widgets/message_widget/message_content/media_players/regular_file_opener.dart
@@ -9,6 +9,7 @@ import 'package:file_picker/file_picker.dart' hide PlatformFile;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:universal_html/html.dart' as html;
 import 'package:universal_io/io.dart';
 
@@ -36,6 +37,7 @@ class RegularFileOpener extends StatelessWidget {
         } else {
           if (kIsDesktop) {
             String? savePath = await FilePicker.platform.saveFile(
+              initialDirectory: (await getDownloadsDirectory())?.path,
               dialogTitle: 'Choose a location to save this file',
               fileName: file.name,
             );

--- a/lib/layouts/widgets/message_widget/received_message.dart
+++ b/lib/layouts/widgets/message_widget/received_message.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:bluebubbles/blocs/chat_bloc.dart';
 import 'package:bluebubbles/blocs/message_bloc.dart';
 import 'package:bluebubbles/helpers/constants.dart';
 import 'package:bluebubbles/helpers/darty.dart';
@@ -316,13 +315,6 @@ class _ReceivedMessageState extends State<ReceivedMessage> with MessageWidgetMix
                     builder: (context, child, anim) {
                       double value = anim.get("size");
                       return StatefulBuilder(builder: (context, setState) {
-                        final bool generateContent = SettingsManager().settings.redactedMode.value &&
-                            SettingsManager().settings.generateFakeMessageContent.value;
-                        final bool hideContent = (SettingsManager().settings.redactedMode.value &&
-                            SettingsManager().settings.hideMessageContent.value &&
-                            !generateContent);
-                        final subject = generateContent ? widget.fakeSubject : message.subject;
-                        final text = generateContent ? widget.fakeText : message.text;
                         return GestureDetector(
                           onHorizontalDragUpdate: (DragUpdateDetails details) {
                             if (effect != MessageEffect.invisibleInk) return;

--- a/lib/repository/models/io/chat.dart
+++ b/lib/repository/models/io/chat.dart
@@ -27,9 +27,6 @@ import 'package:metadata_fetch/metadata_fetch.dart';
 import 'package:objectbox/objectbox.dart';
 import 'package:universal_io/io.dart';
 
-import 'handle.dart';
-import 'message.dart';
-
 String getFullChatTitle(Chat _chat) {
   String? title = "";
   if (isNullOrEmpty(_chat.displayName)!) {


### PR DESCRIPTION
Fix file paths on desktop for local backups. Make default save directory downloads in desktop file pickers. Hide share button on desktop snackbar. Remove unused imports. Clean up code.