### PR TITLE
feat: add wearable actions to notifications

### DIFF
--- a/android/app/src/main/java/com/bluebubbles/messaging/method_call_handler/handlers/NewMessageNotification.java
+++ b/android/app/src/main/java/com/bluebubbles/messaging/method_call_handler/handlers/NewMessageNotification.java
@@ -304,6 +304,12 @@ public class NewMessageNotification implements Handler {
         // Disable the alert if it's from you
         notificationBuilder.setOnlyAlertOnce(messageIsFromMe);
 
+        // Add the "reply" and "mark as read" actions for wearable devices.
+        NotificationCompat.WearableExtender wearableExtender = new NotificationCompat.WearableExtender()
+                .addAction(dismissAction)
+                .addAction(replyActionBuilder.build());
+        notificationBuilder.extend(wearableExtender);
+
         // Generate contextual interactive buttons
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             notificationBuilder.setAllowSystemGeneratedContextualActions(true);


### PR DESCRIPTION
Resolves #2128


## The problem
"Reply" and "Mark As Read" actions don't work on wearable devices.

## What your code solves
Adds wearable actions to notifications.

## How you fixed it
Using [ `NotificationCompat.WearableExtender`](https://developer.android.com/training/wearables/notifications#add-wearable-features) I added the actions.

---

I'm not an Android dev at all so hopefully this change makes sense.

I don't have a WearOS device to test this on, but here is it working on my Pebble 😄 
<img src="https://user-images.githubusercontent.com/3537963/173187409-7772f95f-e184-45ca-80b9-be6c81aed95d.jpg" width="400" alt="Screenshot of a Pebble showing the Reply and Mark as read actions" />

