### PR TITLE
Bugfix for the linux installer

### DIFF
--- a/linux/Bluebubbles.desktop
+++ b/linux/Bluebubbles.desktop
@@ -3,6 +3,6 @@ Encoding=UTF-8
 Version=1.0
 Type=Application
 Terminal=false
-Exec=/path/to/bundle/bluebubbles_app
+Exec=bluebubbles
 Name=Bluebubbles
 Icon=/path/to/bundle/data/flutter_assets/assets/icon/icon.png

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -29,15 +29,15 @@ mkdir -p /opt/bluebubbles_app/
 unzip ./bluebubbles_linux.zip -d /opt/bluebubbles_app/
 
 # Symlink libobjectbox to the correct place
-ls -s /opt/bluebubbles_app/bundle/lib/libobjectbox.so /usr/lib
+ln -s /opt/bluebubbles_app/bundle/lib/libobjectbox.so /usr/lib/libobjectbox.so
 
 # Make the binary executable and add it to a location on PATH
 echo 'Making the Binary executable'
-chmod +x /opt/bluebubbles_app/bundle/bluebubbles_app
+chmod +x /opt/bluebubbles_app/bundle/bluebubbles*
 chmod -R 755 /opt/bluebubbles_app
-rm -f /usr/local/bin/bluebubbles_app
-ln -s /opt/bluebubbles_app/bundle/bluebubbles_app /usr/local/bin/bluebubbles_app
-chmod +x /usr/local/bin/bluebubbles_app
+rm -f /usr/local/bin/bluebubbles*
+ln -s /opt/bluebubbles_app/bundle/bluebubbles* /usr/local/bin/bluebubbles
+chmod +x /usr/local/bin/bluebubbles
 
 # Setup the .desktop file
 echo 'Setting up Bluebubbles.destkop file'


### PR DESCRIPTION
This PR updates the linux installer with the following fixes:
- Fixes a typo where `ls` is used instead of `ln`
- Looks for the bluebubbles binary at `/opt/bluebubbles_app/bundle/bluebubbles` AND `/opt/bluebubbles_app/bundle/bluebubbles_app` (since in the most recent release this location changed)
- Changes the Bluebubbles.desktop file to call bluebubbles from PATH which is better practice. 