### PR TITLE
Fix spelling error

### DIFF
--- a/lib/layouts/settings/misc_panel.dart
+++ b/lib/layouts/settings/misc_panel.dart
@@ -354,7 +354,7 @@ class MiscPanel extends StatelessWidget {
                             ]);
                           },
                           initialVal: SettingsManager().settings.allowUpsideDownRotation.value,
-                          title: "Alllow Upside-Down Rotation",
+                          title: "Allow Upside-Down Rotation",
                           backgroundColor: tileColor,
                         )),
                   if (Platform.isAndroid)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: Send iMessages on Android using BlueBubbles!
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.10.1+36
+version: 1.10.1+37
 publish_to: none
 
 environment:


### PR DESCRIPTION
The settings page has "Alllow Upside-Down Rotation". Should be "Allow".
