### PR TITLE
Display vetted aliases in server management panel

### DIFF
--- a/lib/app/layouts/settings/pages/server/server_management_panel.dart
+++ b/lib/app/layouts/settings/pages/server/server_management_panel.dart
@@ -113,8 +113,6 @@ class ServerManagementPanelController extends StatefulController {
       }
 
       Future.wait(subsequentRequests)
-        .then((value) {})
-        .catchError((_) { })
         .whenComplete(() => opacity.value = 1.0);
     }).catchError((_) {
       showSnackbar("Error", "Failed to load server details!");

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -1081,6 +1081,17 @@ class HttpService extends GetxService {
     });
   }
 
+  Future<Response> getAccountInfo({CancelToken? cancelToken}) async {
+    return runApiGuarded(() async {
+      final response = await dio.get(
+        "$apiRoot/icloud/account",
+        queryParameters: buildQueryParams(),
+        cancelToken: cancelToken,
+      );
+      return returnSuccessOrError(response);
+    });
+  }
+
   Future<Response> downloadFromUrl(String url, {Function(int, int)? progress, CancelToken? cancelToken}) async {
     return runApiGuarded(() async {
       final response = await dio.get(


### PR DESCRIPTION
Change uses the account info API to query the vetted aliases to display them in the server management panel. Future PR will handle implement aliases-removed event.