### PR TITLE
Update `flutter_slidable` to 3.1.2

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1051,7 +1051,7 @@ packages:
       sha256: "2c5611c0b44e20d180e4342318e1bbc28b0a44ad2c442f5df16962606fd3e8e3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   flutter_staggered_grid_view:
     dependency: "direct main"
     description:


### PR DESCRIPTION
`flutter_slidable` 3.1.1 breaks while building for Linux.  

```dart
../../../.pub-cache/hosted/pub.dev/flutter_slidable-3.1.1/lib/src/notifications_old.dart:88:23: Error: The method 'hashValues' isn't defined for the class 'SlidableRatioNotification'.
 - 'SlidableRatioNotification' is from 'package:flutter_slidable/src/notifications_old.dart' ('../../../.pub-cache/hosted/pub.dev/flutter_slidable-3.1.1/lib/src/notifications_old.dart').
Try correcting the name to the name of an existing method, or defining a method named 'hashValues'.
  int get hashCode => hashValues(tag, ratio);
                      ^^^^^^^^^^
```

https://github.com/letsar/flutter_slidable/issues/488

Updating to 3.1.2 fixed the issue.