### PR TITLE
Fix issues when app is packaged as MSIX

### DIFF
--- a/lib/app/layouts/settings/pages/misc/about_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/about_panel.dart
@@ -439,7 +439,7 @@ class _AboutPanelState extends OptimizedState<AboutPanel> {
                                                           style: context.theme.textTheme.bodyLarge),
                                                     if (kIsDesktop)
                                                       Text(
-                                                        "${fs.packageInfo.version}_${Platform.operatingSystem.capitalizeFirst!}${isSnap ? "_Snap" : isFlatpak ? "_Flatpak" : ""}",
+                                                        "${fs.packageInfo.version}_${Platform.operatingSystem.capitalizeFirst!}${isSnap ? "_Snap" : isFlatpak ? "_Flatpak" : isMsix ? "_Msix": ""}",
                                                         style: context.theme.textTheme.bodyLarge,
                                                       ),
                                                   ],

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -7,6 +7,7 @@ import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:io/io.dart';
 import 'package:path/path.dart';
 
 class Database {
@@ -123,7 +124,7 @@ class Database {
         Directory oldCustom = Directory(join(ss.prefs.getString('custom-path')!, 'objectbox'));
         if (oldCustom.existsSync()) {
           Logger.info("Detected prior use of custom path option. Migrating...");
-          fs.copyDirectory(oldCustom, objectBoxDirectory);
+          await copyPath(oldCustom.path, objectBoxDirectory.path);
         }
         await ss.prefs.remove('use-custom-path');
         await ss.prefs.remove('custom-path');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -308,7 +308,7 @@ msix_config:
   display_name: BlueBubbles
   publisher_display_name: BlueBubbles
   identity_name: 23344BlueBubbles.BlueBubbles
-  msix_version: 1.15.1.0
+  msix_version: 1.15.2.0
   publisher: CN=BEC9154D-191E-4375-BF30-698BD4C141C4
   vs_generated_images_folder_path: windows/icons
   logo_path: assets/icon/icon.ico

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -59,8 +59,8 @@ IDI_APP_ICON            ICON                    "resources\\app_icon.ico"
 //
 // Version
 //
-#define VERSION_AS_NUMBER 1,15,1,0
-#define VERSION_AS_STRING "1.15.1.0"
+#define VERSION_AS_NUMBER 1,15,2,0
+#define VERSION_AS_STRING "1.15.2.0"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION VERSION_AS_NUMBER


### PR DESCRIPTION
- Fix notifications not having avatars
- Fix "Open App Data Location" and other buttons not functioning correctly
- Ensure `AppData/Local/Packages` location is used when app is packaged
- Indicate when the app has been packaged as MSIX in the About section, by appending "_Msix" to the version number

These changes only affect the Microsoft Store app