### PR TITLE
opt-in to MTE async mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
     <application
         tools:replace="android:label"
         android:allowBackup="false"
+        android:memtagMode="async"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name_en"


### PR DESCRIPTION
currently only benefits GrapheneOS users on Pixel 8 and 9 who don't turn on MTE for all apps. hopefully will be extended to all Pixel users and then more devices