### PR TITLE
Trust user installed certificates

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,7 +63,8 @@
         android:requestLegacyExternalStorage="true"
         android:debuggable="false"
         android:usesCleartextTraffic="true"
-        android:extractNativeLibs="true">
+        android:extractNativeLibs="true"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <receiver android:name=".services.intents.InternalIntentReceiver" />
 

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <!-- Trust system CA store (including user-installed certs) -->
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/lib/services/network/socket_service.dart
+++ b/lib/services/network/socket_service.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:socket_io_client/socket_io_client.dart';
+import 'websocket_adapter.dart';
 
 SocketService socket = Get.isRegistered<SocketService>() ? Get.find<SocketService>() : Get.put(SocketService());
 
@@ -63,6 +64,9 @@ class SocketService extends GetxService {
         .setQuery({"guid": password})
         .setTransports(['websocket', 'polling'])
         .setExtraHeaders(http.headers)
+        // WebsocketAdapter allows socket io client
+        // to trust user certificates on Android
+        .setHttpClientAdapter(WebsocketAdapter())
         // Disable so that we can create the listeners first
         .disableAutoConnect()
         .enableReconnection();
@@ -195,7 +199,6 @@ class SocketService extends GetxService {
         if (data is SocketException) {
           handleSocketException(data);
         }
-
         state.value = SocketState.error;
         // After 5 seconds of an error, we should retry the connection
         _reconnectTimer = Timer(const Duration(seconds: 5), () async {

--- a/lib/services/network/user_certificates.dart
+++ b/lib/services/network/user_certificates.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter_user_certificates_android/flutter_user_certificates_android.dart';
+
+
+class UserCertificates {
+  Future<SecurityContext> getContext() async {
+    final ctx = SecurityContext();
+
+    // return default if platform is not android
+    if (!Platform.isAndroid){
+      return ctx;
+    }
+
+    final certs = await FlutterUserCertificatesAndroid().getUserCertificates();
+
+    // return default if no user certs
+    if (certs == null) {
+      return ctx;
+    }
+
+    // loop over certs and add them to context
+    for (var c in certs.entries) {
+      ctx.setTrustedCertificatesBytes(utf8.encode(c.value.toPEM()));
+    }
+
+    return ctx;
+  }
+}

--- a/lib/services/network/websocket_adapter.dart
+++ b/lib/services/network/websocket_adapter.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+import 'package:bluebubbles/services/network/user_certificates.dart';
+import 'package:socket_io_client/socket_io_client.dart';
+
+class WebsocketAdapter implements HttpClientAdapter {
+  @override
+  Future<WebSocket?> connect(String uri, {Map<String, dynamic>? headers}) async {
+    return WebSocket.connect(
+      uri,
+      headers: headers?.map((key, value) => MapEntry(key, value.toString())) ?? {},
+      customClient: HttpClient(context: await UserCertificates().getContext()),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1091,6 +1091,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  flutter_user_certificates_android:
+    dependency: "direct main"
+    description:
+      name: flutter_user_certificates_android
+      sha256: "084b44d1a1bed7fce7b39873d7ab67cbc3892677840899ef495d8827ef0422e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -2852,18 +2860,18 @@ packages:
     dependency: "direct main"
     description:
       name: socket_io_client
-      sha256: "180fdbc7685e32a849511bbf8b1c7bcc46ab0ff116f7024aa204b425bb3a1ffe"
+      sha256: c8471c2c6843cf308a5532ff653f2bcdb7fa9ae79d84d1179920578a06624f0d
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.2"
   socket_io_common:
     dependency: transitive
     description:
       name: socket_io_common
-      sha256: a914df90f25003fea62dbd0b186d98b745b1b72c16be87418e15a2511d25dadb
+      sha256: "162fbaecbf4bf9a9372a62a341b3550b51dcef2f02f3e5830a297fd48203d45b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   sortedmap:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -159,7 +159,7 @@ dependencies:
   sliding_up_panel2: ^3.3.0+1
   slugify: ^2.0.0
   smooth_page_indicator: ^1.2.1
-  socket_io_client: ^3.0.2
+  socket_io_client: ^3.1.2
   sprung: ^3.0.1
   store_checker: ^1.8.0
   synchronized: ^3.3.0+3
@@ -184,6 +184,7 @@ dependencies:
   win32: ^5.10.1
   window_manager: ^0.4.3
   windows_taskbar: ^1.1.2
+  flutter_user_certificates_android: ^0.0.1
 
 dependency_overrides:
   # overrides for packages stuck on outdated versions


### PR DESCRIPTION
## What does this PR do?
It adds support for trusting user installed CA certificates **on Android**. 

## How does it accomplish this?
There are three components that need to trust the system user certificate store for the application to work correctly

1. The HTTP client
2. The socket client
3. The foreground notification socket client

In order for _all_ of them to work, the first thing that's required is the `network_security_config.xml` file that allows the app to trust user certificates:
```
<network-security-config>
    <base-config>
        <trust-anchors>
            <!-- Trust system CA store (including user-installed certs) -->
            <certificates src="system" />
            <certificates src="user" />
        </trust-anchors>
    </base-config>
</network-security-config>
```

### HTTP Client
User certificate support was added in https://github.com/BlueBubblesApp/bluebubbles-app/pull/2894 by offloading the HTTP requests to [cronet_http](https://pub.dev/packages/cronet_http).

### Socket Client

[socket_io_client](https://pub.dev/packages/socket_io_client/changelog) added support for a custom HTTP client (used to initialize the web socket upgrade) in version 3.1.1. I  took advantage of that by using the [flutter_user_certificates_android](https://pub.dev/packages/flutter_user_certificates_android) to load user certificates into the HTTP client's `SecurityContext` directly.

### Foreground Socket Client
Works by default because it uses the system's websocket library, which trusts user certificates.