### PR TITLE
Fix build after `chipweinberger/flutter_isolate` repo was deleted

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -906,9 +906,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "user/chip/update-examples"
+      ref: bf7deabbb1aaa3cff785b636d9f4717d4fe202d9
       resolved-ref: bf7deabbb1aaa3cff785b636d9f4717d4fe202d9
-      url: "https://github.com/chipweinberger/flutter_isolate.git"
+      url: "https://github.com/rmawatson/flutter_isolate.git"
     source: git
     version: "2.0.5-pre"
   flutter_keyboard_visibility:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,10 +71,10 @@ dependencies:
   flutter_dotenv: ^5.1.0
   flutter_image_compress: ^2.2.0
   flutter_improved_scrolling: ^0.0.3
-  flutter_isolate: # gradle namespace issue
+  flutter_isolate: # gradle namespace issue, https://github.com/rmawatson/flutter_isolate/pull/152
     git:
-      url: https://github.com/chipweinberger/flutter_isolate.git
-      ref: user/chip/update-examples
+      url: https://github.com/rmawatson/flutter_isolate.git
+      ref: bf7deabbb1aaa3cff785b636d9f4717d4fe202d9
   flutter_keyboard_visibility: ^6.0.0 # no desktop support
   flutter_local_notifications: ^17.2.1+2 # mobile only
   flutter_map: ^7.0.1


### PR DESCRIPTION
Fixes below error:
```
[package:bluebubbles] flutter pub get --no-example
Resolving dependencies...
Git error. Command: `git clone --mirror https://github.com/chipweinberger/flutter_isolate.git C:\Users\qaisjp\AppData\Local\Pub\Cache\_temp\dir2a77a5dc`
stdout:
stderr: Cloning into bare repository 'C:\Users\qaisjp\AppData\Local\Pub\Cache\_temp\dir2a77a5dc'...
remote: Repository not found.
fatal: repository 'https://github.com/chipweinberger/flutter_isolate.git/' not found

exit code: 128
Failed to update packages.
exit code 69
```

The commit still exists on the upstream repo and can be accessed directly from its sha.

The commit will never be garbage collected because it's a part of the pull request commit list here: https://github.com/rmawatson/flutter_isolate/pull/152