### PR TITLE
Fix custom headers not working correctly on desktop

### DIFF
--- a/lib/app/layouts/setup/pages/sync/server_credentials.dart
+++ b/lib/app/layouts/setup/pages/sync/server_credentials.dart
@@ -512,12 +512,6 @@ class _ServerCredentialsState extends OptimizedState<ServerCredentials> {
                                     minimumSize: WidgetStateProperty.all(const Size(30, 30)),
                                   ),
                                   onPressed: () async {
-                                    ss.settings.customHeaders.value = {};
-                                    http.onInit();
-                                    connect(urlController.text, passwordController.text);
-                                  },
-                                  onLongPress: () async {
-                                    await showCustomHeadersDialog(context);
                                     connect(urlController.text, passwordController.text);
                                   },
                                   child: Row(


### PR DESCRIPTION
Fix bug where populating custom headers (using the"Custom Headers" button that's next to URL + password) wouldn't actually work when pressing the Connect button.

I assume the idea was to _not_ have a custom headers button, and instead reveal custom headers behind a long press. In that world, it would have made sense to ignore custom headers for regular presses. I don't think we should stick with that idea as it affects discoverability of custom headers.

Note that the `http.onInit` was only required because we were changing `ss.settings.customHeaders.value`. That's no longer required and we're returning the implementation [back to what it originally was](https://github.com/BlueBubblesApp/bluebubbles-app/blame/7dabf661a2f3ddd7e5ead6321dd857c0e81c6050/lib/app/layouts/setup/pages/sync/server_credentials.dart#L273-L275) prior to https://github.com/BlueBubblesApp/bluebubbles-app/commit/3e5690bc513cd523eeb8ed1dd4f6892039ecc881.

Fix #2887

**Test plan**

I built this locally and confirmed that connecting normally with headers worked.