### PR TITLE
Display invisible ink by default

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
@@ -46,6 +46,17 @@ class _BubbleEffectsState extends OptimizedState<BubbleEffects> {
   void initState() {
     getTween();
 
+    if (effect == MessageEffect.invisibleInk) {
+      controller = Control.play;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            size = widget.globalKey?.currentContext?.size ?? Size.zero;
+          });
+        }
+      });
+    }
+
     eventDispatcher.stream.listen((event) async {
       if (event.item1 == 'play-bubble-effect' && event.item2 == '${widget.part}/${widget.message.guid}') {
         size = widget.globalKey?.currentContext?.size ?? Size.zero;


### PR DESCRIPTION
## Problem: #2413 Messages sent with invisible ink show up without the invisible ink effect when opening a chat.

This PR makes the effect show up right away without needing to tap the "sent with invisible ink" message.

I'm very new to frontend and flutter, so feel free to leave suggestions on how to improve the change!

