### PR TITLE
Support arbitrary emoji reactions from newer iOS

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
@@ -31,7 +31,7 @@ class ReactionObserver extends StatelessWidget {
       final isFromMe = state.isFromMe.value;
       final associatedMessages = state.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.isValidReaction(e.associatedMessageType))
           .toList();
       final reactionList = messageParts.length == 1 ? reactions : reactionsForPart(part.part, reactions).toList();
       return Positioned(
@@ -96,7 +96,7 @@ class ReactionSpacing extends StatelessWidget {
       // Directly observe MessageState associatedMessages for reactivity
       final associatedMessages = state.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.isValidReaction(e.associatedMessageType))
           .cast<Message>()
           .toList();
       if ((messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part.part, reactions).isNotEmpty) {

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
@@ -32,7 +32,7 @@ class SamsungTimestampObserver extends StatelessWidget {
       final isFromMe = ms.isFromMe.value;
       final associatedMessages = ms.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.isValidReaction(e.associatedMessageType))
           .toList();
       return Padding(
         padding: (messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part.part, reactions).isNotEmpty

--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -149,7 +149,7 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
       currentlySelectedReaction = null;
       reactions = getUniqueReactionMessages(message.associatedMessages
           .where((e) =>
-              ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")) &&
+              ReactionTypes.isValidReaction(e.associatedMessageType) &&
               (e.associatedMessagePart ?? 0) == part.part)
           .toList());
       final self = reactions.firstWhereOrNull((e) => e.isFromMe!)?.associatedMessageType;
@@ -1240,7 +1240,7 @@ class ReactionDetails extends StatelessWidget {
                                 ? const EdgeInsets.only(top: 8.0, left: 7.0, right: 7.0, bottom: 7.0)
                                     .add(EdgeInsets.only(right: message.associatedMessageType == "emphasize" ? 1 : 0))
                                 : EdgeInsets.zero,
-                            child: SettingsSvc.settings.skin.value == Skins.iOS
+                            child: SettingsSvc.settings.skin.value == Skins.iOS && !ReactionTypes.isEmojiReaction(message.associatedMessageType)
                                 ? SvgPicture.asset(
                                     'assets/reactions/${message.associatedMessageType}-black.svg',
                                     colorFilter: ColorFilter.mode(
@@ -1254,7 +1254,7 @@ class ReactionDetails extends StatelessWidget {
                                 : Center(
                                     child: Builder(builder: (context) {
                                       final text = Text(
-                                        ReactionTypes.reactionToEmoji[message.associatedMessageType] ?? "X",
+                                        ReactionTypes.getReactionEmoji(message.associatedMessageType),
                                         style: const TextStyle(fontSize: 18, fontFamily: 'Apple Color Emoji'),
                                         textAlign: TextAlign.center,
                                       );

--- a/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
@@ -163,7 +163,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
               child: Center(
                 child: Builder(builder: (context) {
                   final text = Text(
-                    ReactionTypes.reactionToEmoji[reactionType] ?? "X",
+                    ReactionTypes.getReactionEmoji(reactionType),
                     style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
                     textAlign: TextAlign.center,
                   );
@@ -219,16 +219,22 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
                           child: Padding(
                         padding:
                             const EdgeInsets.all(6.5).add(EdgeInsets.only(right: reactionType == "emphasize" ? 1 : 0)),
-                        child: SvgPicture.asset(
-                          'assets/reactions/$reactionType-black.svg',
-                          colorFilter: ColorFilter.mode(
-                              reactionType == "love"
-                                  ? Colors.pink
-                                  : (reactionIsFromMe
-                                      ? context.theme.colorScheme.onPrimary
-                                      : context.theme.colorScheme.properOnSurface),
-                              BlendMode.srcIn),
-                        ),
+                        child: ReactionTypes.isEmojiReaction(reactionType)
+                            ? Text(
+                                reactionType,
+                                style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
+                                textAlign: TextAlign.center,
+                              )
+                            : SvgPicture.asset(
+                                'assets/reactions/$reactionType-black.svg',
+                                colorFilter: ColorFilter.mode(
+                                    reactionType == "love"
+                                        ? Colors.pink
+                                        : (reactionIsFromMe
+                                            ? context.theme.colorScheme.onPrimary
+                                            : context.theme.colorScheme.properOnSurface),
+                                    BlendMode.srcIn),
+                              ),
                       )),
                     ));
               })),
@@ -306,7 +312,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
         child: Center(
           child: Builder(builder: (ctx) {
             final text = Text(
-              ReactionTypes.reactionToEmoji[rType] ?? "X",
+              ReactionTypes.getReactionEmoji(rType),
               style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
               textAlign: TextAlign.center,
             );
@@ -356,17 +362,23 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
               child: Center(
                 child: Padding(
                   padding: const EdgeInsets.all(6.5).add(EdgeInsets.only(right: rType == "emphasize" ? 1 : 0)),
-                  child: SvgPicture.asset(
-                    'assets/reactions/$rType-black.svg',
-                    colorFilter: ColorFilter.mode(
-                      rType == "love"
-                          ? Colors.pink
-                          : (isFromMe
-                              ? context.theme.colorScheme.onPrimary
-                              : context.theme.colorScheme.properOnSurface),
-                      BlendMode.srcIn,
-                    ),
-                  ),
+                  child: ReactionTypes.isEmojiReaction(rType)
+                      ? Text(
+                          rType,
+                          style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
+                          textAlign: TextAlign.center,
+                        )
+                      : SvgPicture.asset(
+                          'assets/reactions/$rType-black.svg',
+                          colorFilter: ColorFilter.mode(
+                            rType == "love"
+                                ? Colors.pink
+                                : (isFromMe
+                                    ? context.theme.colorScheme.onPrimary
+                                    : context.theme.colorScheme.properOnSurface),
+                            BlendMode.srcIn,
+                          ),
+                        ),
                 ),
               ),
             ),

--- a/lib/database/html/chat.dart
+++ b/lib/database/html/chat.dart
@@ -255,7 +255,7 @@ class Chat {
       return true;
     }
     return !SettingsSvc.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.isValidReaction(message?.associatedMessageType);
   }
 
   static void unDelete(Chat chat) {

--- a/lib/database/html/message.dart
+++ b/lib/database/html/message.dart
@@ -383,7 +383,7 @@ class Message {
       attachments.where((e) => e != null && e.mimeType == null).cast<Attachment>().toList();
 
   List<Message> get reactions => associatedMessages
-      .where((item) => ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", "")))
+      .where((item) => ReactionTypes.isValidReaction(item.associatedMessageType))
       .toList();
 
   MessageStatusIndicator get indicatorToShow {

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -299,7 +299,7 @@ class Chat {
 
     /// If reaction and notify reactions off, then don't notify, otherwise notify
     return !SettingsSvc.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.isValidReaction(message?.associatedMessageType);
   }
 
   /// Toggle unread status - pure DB operation

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -676,7 +676,7 @@ class Message {
       attachments.where((e) => e != null && e.mimeType == null).cast<Attachment>().toList();
 
   List<Message> get reactions => associatedMessages
-      .where((item) => ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", "")))
+      .where((item) => ReactionTypes.isValidReaction(item.associatedMessageType))
       .toList();
 
   MessageStatusIndicator get indicatorToShow {

--- a/lib/helpers/types/extensions/extensions.dart
+++ b/lib/helpers/types/extensions/extensions.dart
@@ -340,7 +340,7 @@ extension MessageNotificationExtension on Message {
         Message? associatedMessage = Message.findOne(guid: associatedMessageGuid);
         if (associatedMessage != null) {
           // grab the verb we'll use from the reactionToVerb map
-          String? verb = ReactionTypes.reactionToVerb[associatedMessageType];
+          String? verb = ReactionTypes.getReactionVerb(associatedMessageType);
           // we need to check balloonBundleId first because for some reason
           // game pigeon messages have the text "�"
           if (associatedMessage.isInteractive) {

--- a/lib/helpers/types/helpers/message_helper.dart
+++ b/lib/helpers/types/helpers/message_helper.dart
@@ -54,7 +54,7 @@ class MessageHelper {
     List<Message> normalized = [];
 
     for (Message message in associatedMessages.reversed.toList()) {
-      if (!ReactionTypes.toList().contains(message.associatedMessageType)) {
+      if (!ReactionTypes.isValidReaction(message.associatedMessageType)) {
         normalized.add(message);
       } else if (guids.remove(message.guid)) {
         normalized.add(message);

--- a/lib/helpers/ui/reaction_helpers.dart
+++ b/lib/helpers/ui/reaction_helpers.dart
@@ -58,6 +58,73 @@ class ReactionTypes {
     "❗": EMPHASIZE,
     "❓": QUESTION,
   };
+
+  /// Regex matching Unicode emoji: emoji presentation sequences, modifier sequences,
+  /// keycap sequences, regional indicators, and common emoji codepoint ranges.
+  static final RegExp _emojiRegex = RegExp(
+    r'[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|'
+    r'[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{27BF}]|[\u{FE00}-\u{FE0F}]|'
+    r'[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}]|[\u{1F700}-\u{1F8FF}]|'
+    r'[\u{200D}]|[\u{20E3}]|[\u{E0020}-\u{E007F}]|[\u{2702}-\u{27B0}]|'
+    r'[\u{231A}-\u{231B}]|[\u{23E9}-\u{23F3}]|[\u{23F8}-\u{23FA}]|'
+    r'[\u{25AA}-\u{25AB}]|[\u{25B6}]|[\u{25C0}]|[\u{25FB}-\u{25FE}]|'
+    r'[\u{2614}-\u{2615}]|[\u{2648}-\u{2653}]|[\u{267F}]|[\u{2693}]|'
+    r'[\u{26A1}]|[\u{26AA}-\u{26AB}]|[\u{26BD}-\u{26BE}]|[\u{26C4}-\u{26C5}]|'
+    r'[\u{26CE}]|[\u{26D4}]|[\u{26EA}]|[\u{26F2}-\u{26F3}]|[\u{26F5}]|'
+    r'[\u{26FA}]|[\u{26FD}]|[\u{2702}]|[\u{2705}]|[\u{2708}-\u{270D}]|'
+    r'[\u{270F}]|[\u{2712}]|[\u{2714}]|[\u{2716}]|[\u{271D}]|[\u{2721}]|'
+    r'[\u{2728}]|[\u{2733}-\u{2734}]|[\u{2744}]|[\u{2747}]|[\u{274C}]|'
+    r'[\u{274E}]|[\u{2753}-\u{2755}]|[\u{2757}]|[\u{2763}-\u{2764}]|'
+    r'[\u{2795}-\u{2797}]|[\u{27A1}]|[\u{2934}-\u{2935}]|[\u{2B05}-\u{2B07}]|'
+    r'[\u{2B1B}-\u{2B1C}]|[\u{2B50}]|[\u{2B55}]|[\u{3030}]|[\u{303D}]|'
+    r'[\u{3297}]|[\u{3299}]|[\u{00A9}]|[\u{00AE}]',
+    unicode: true,
+  );
+
+  static final RegExp _asciiLetterRegex = RegExp(r'[a-zA-Z]');
+
+  /// Returns true if [text] contains at least one emoji character and no ASCII letters.
+  static bool _looksLikeEmoji(String text) {
+    if (text.isEmpty) return false;
+    if (_asciiLetterRegex.hasMatch(text)) return false;
+    return _emojiRegex.hasMatch(text);
+  }
+
+  /// Strips the removal prefix ("-") if present.
+  static String _stripRemovalPrefix(String type) {
+    return type.startsWith("-") ? type.substring(1) : type;
+  }
+
+  /// Returns true if [type] is a classic tapback or an emoji reaction.
+  static bool isValidReaction(String? type) {
+    if (type == null || type.isEmpty) return false;
+    final cleaned = _stripRemovalPrefix(type);
+    return toList().contains(cleaned) || isEmojiReaction(cleaned);
+  }
+
+  /// Returns true if [type] is an emoji reaction (not a classic tapback or sticker).
+  static bool isEmojiReaction(String? type) {
+    if (type == null || type.isEmpty) return false;
+    final cleaned = _stripRemovalPrefix(type);
+    if (toList().contains(cleaned) || cleaned == "sticker") return false;
+    return _looksLikeEmoji(cleaned);
+  }
+
+  /// Returns the emoji to display for a reaction type.
+  /// Classic tapbacks map to their emoji; emoji reactions ARE the emoji.
+  static String getReactionEmoji(String? type) {
+    if (type == null || type.isEmpty) return "";
+    return reactionToEmoji[type] ?? type;
+  }
+
+  /// Returns a verb phrase for notification text.
+  /// Classic tapbacks use the verb map; emoji reactions use "reacted [emoji] to".
+  static String getReactionVerb(String? type) {
+    if (type == null || type.isEmpty) return "reacted to";
+    if (reactionToVerb.containsKey(type)) return reactionToVerb[type]!;
+    if (type.startsWith("-")) return "removed a ${type.substring(1)} reaction from";
+    return "reacted $type to";
+  }
 }
 
 List<Message> getUniqueReactionMessages(List<Message> messages) {


### PR DESCRIPTION
## Summary

Newer iOS versions allow reacting with any emoji, not just the 6 classic tapbacks. The `associatedMessageType` for these contains the raw emoji character. Previously these were filtered out or rendered as null.

Closes #2829
Closes #2823

- Add `isValidReaction`/`isEmojiReaction` helpers to `ReactionTypes` with proper Unicode emoji validation
- Update all reaction filter points to recognize emoji reactions
- Render emoji reactions as text instead of SVG on iOS skin
- Fix notification text for emoji reactions
- Fix dedup logic for emoji reactions in `normalizedAssociatedMessages`
- Null-safe `getReactionEmoji` and `getReactionVerb` to prevent force-unwrap crashes

## Changes

- `lib/helpers/ui/reaction_helpers.dart` — New helpers: `_emojiRegex`, `_looksLikeEmoji`, `_stripRemovalPrefix`, `isValidReaction`, `isEmojiReaction`, `getReactionEmoji`, `getReactionVerb`
- `lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart` — iOS skin renders emoji reactions as Text instead of SVG
- `lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart` — Reaction popup uses new helpers, null-safe emoji lookup
- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — Reaction filtering uses `isValidReaction`
- `lib/database/html/chat.dart`, `lib/database/io/chat.dart` — Notification suppression uses `isValidReaction`
- `lib/database/html/message.dart`, `lib/database/io/message.dart` — Reactions getter uses `isValidReaction`
- `lib/helpers/types/helpers/message_helper.dart` — Notification text and dedup logic updated

## Test plan

- [ ] Receive a classic tapback (love, like, dislike, laugh, emphasize, question) and verify it renders correctly
- [ ] Receive an emoji reaction (e.g. thumbs up emoji, heart emoji, custom emoji) from a newer iOS device and verify it renders as the emoji character
- [ ] Verify reaction removal notifications show correct text
- [ ] Verify notification suppression works for both classic tapbacks and emoji reactions when "notify reactions" is off
- [ ] Test across all default themes and all skins (iOS, Material, Samsung)