### PR TITLE
support arbitrary emoji reactions from newer iOS

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
@@ -31,7 +31,7 @@ class ReactionObserver extends StatelessWidget {
       final isFromMe = state.isFromMe.value;
       final associatedMessages = state.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.isValidReaction(e.associatedMessageType, emoji: e.associatedMessageEmoji))
           .toList();
       final reactionList = messageParts.length == 1 ? reactions : reactionsForPart(part.part, reactions).toList();
       return Positioned(
@@ -101,7 +101,7 @@ class ReactionSpacing extends StatelessWidget {
       // Directly observe MessageState associatedMessages for reactivity
       final associatedMessages = state.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.isValidReaction(e.associatedMessageType, emoji: e.associatedMessageEmoji))
           .cast<Message>()
           .toList();
       if ((messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part.part, reactions).isNotEmpty) {

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
@@ -32,7 +32,7 @@ class SamsungTimestampObserver extends StatelessWidget {
       final isFromMe = ms.isFromMe.value;
       final associatedMessages = ms.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.isValidReaction(e.associatedMessageType, emoji: e.associatedMessageEmoji))
           .toList();
       return Padding(
         padding: (messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part.part, reactions).isNotEmpty

--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -149,7 +149,7 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
       currentlySelectedReaction = null;
       reactions = getUniqueReactionMessages(message.associatedMessages
           .where((e) =>
-              ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")) &&
+              ReactionTypes.isValidReaction(e.associatedMessageType, emoji: e.associatedMessageEmoji) &&
               (e.associatedMessagePart ?? 0) == part.part)
           .toList());
       final self = reactions.firstWhereOrNull((e) => e.isFromMe!)?.associatedMessageType;
@@ -1240,7 +1240,7 @@ class ReactionDetails extends StatelessWidget {
                                 ? const EdgeInsets.only(top: 8.0, left: 7.0, right: 7.0, bottom: 7.0)
                                     .add(EdgeInsets.only(right: message.associatedMessageType == "emphasize" ? 1 : 0))
                                 : EdgeInsets.zero,
-                            child: SettingsSvc.settings.skin.value == Skins.iOS
+                            child: SettingsSvc.settings.skin.value == Skins.iOS && !ReactionTypes.isEmojiReaction(message.associatedMessageEmoji)
                                 ? SvgPicture.asset(
                                     'assets/reactions/${message.associatedMessageType}-black.svg',
                                     colorFilter: ColorFilter.mode(
@@ -1254,7 +1254,7 @@ class ReactionDetails extends StatelessWidget {
                                 : Center(
                                     child: Builder(builder: (context) {
                                       final text = Text(
-                                        ReactionTypes.reactionToEmoji[message.associatedMessageType] ?? "X",
+                                        ReactionTypes.getReactionEmoji(message.associatedMessageType, emoji: message.associatedMessageEmoji),
                                         style: const TextStyle(fontSize: 18, fontFamily: 'Apple Color Emoji'),
                                         textAlign: TextAlign.center,
                                       );

--- a/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
@@ -85,6 +85,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
   /// Guard against associatedMessageType being null.
   /// An empty string produces no SVG match, which is handled in build().
   String get reactionType => reaction.associatedMessageType ?? '';
+  String? get reactionEmoji => reaction.associatedMessageEmoji;
 
   MessageState? get reactionController {
     // Use same resolution order as reaction getter
@@ -176,7 +177,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
               child: Center(
                 child: Builder(builder: (context) {
                   final text = Text(
-                    ReactionTypes.reactionToEmoji[reactionType] ?? "X",
+                    ReactionTypes.getReactionEmoji(reactionType, emoji: reactionEmoji),
                     style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
                     textAlign: TextAlign.center,
                   );
@@ -232,16 +233,22 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
                           child: Padding(
                         padding:
                             const EdgeInsets.all(6.5).add(EdgeInsets.only(right: reactionType == "emphasize" ? 1 : 0)),
-                        child: SvgPicture.asset(
-                          'assets/reactions/$reactionType-black.svg',
-                          colorFilter: ColorFilter.mode(
-                              reactionType == "love"
-                                  ? Colors.pink
-                                  : (reactionIsFromMe
-                                      ? context.theme.colorScheme.onPrimary
-                                      : context.theme.colorScheme.properOnSurface),
-                              BlendMode.srcIn),
-                        ),
+                        child: ReactionTypes.isEmojiReaction(reactionEmoji)
+                            ? Text(
+                                reactionEmoji!,
+                                style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
+                                textAlign: TextAlign.center,
+                              )
+                            : SvgPicture.asset(
+                                'assets/reactions/$reactionType-black.svg',
+                                colorFilter: ColorFilter.mode(
+                                    reactionType == "love"
+                                        ? Colors.pink
+                                        : (reactionIsFromMe
+                                            ? context.theme.colorScheme.onPrimary
+                                            : context.theme.colorScheme.properOnSurface),
+                                    BlendMode.srcIn),
+                              ),
                       )),
                     ));
               })),
@@ -303,11 +310,12 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
   /// subscribing to any RxList so GetX never fires the "improper use" warning.
   Widget _buildStatic(BuildContext context, Message reaction) {
     final rType = reaction.associatedMessageType ?? '';
+    final rEmoji = reaction.associatedMessageEmoji;
     final isFromMe = reaction.isFromMe ?? false;
     final tailDirection = widget.tailDirection ?? (isFromMe ? ReactionTailDirection.left : ReactionTailDirection.right);
     final tailIsRight = tailDirection == ReactionTailDirection.right;
 
-    if (rType.isEmpty) return const SizedBox.shrink();
+    if (rType.isEmpty && !ReactionTypes.isEmojiReaction(rEmoji)) return const SizedBox.shrink();
 
     if (SettingsSvc.settings.skin.value != Skins.iOS) {
       return Container(
@@ -329,7 +337,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
         child: Center(
           child: Builder(builder: (ctx) {
             final text = Text(
-              ReactionTypes.reactionToEmoji[rType] ?? "X",
+              ReactionTypes.getReactionEmoji(rType, emoji: rEmoji),
               style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
               textAlign: TextAlign.center,
             );
@@ -392,17 +400,23 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
               child: Center(
                 child: Padding(
                   padding: const EdgeInsets.all(6.5).add(EdgeInsets.only(right: rType == "emphasize" ? 1 : 0)),
-                  child: SvgPicture.asset(
-                    'assets/reactions/$rType-black.svg',
-                    colorFilter: ColorFilter.mode(
-                      rType == "love"
-                          ? Colors.pink
-                          : (isFromMe
-                              ? context.theme.colorScheme.onPrimary
-                              : context.theme.colorScheme.properOnSurface),
-                      BlendMode.srcIn,
-                    ),
-                  ),
+                  child: ReactionTypes.isEmojiReaction(rEmoji)
+                      ? Text(
+                          rEmoji!,
+                          style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
+                          textAlign: TextAlign.center,
+                        )
+                      : SvgPicture.asset(
+                          'assets/reactions/$rType-black.svg',
+                          colorFilter: ColorFilter.mode(
+                            rType == "love"
+                                ? Colors.pink
+                                : (isFromMe
+                                    ? context.theme.colorScheme.onPrimary
+                                    : context.theme.colorScheme.properOnSurface),
+                            BlendMode.srcIn,
+                          ),
+                        ),
                 ),
               ),
             ),

--- a/lib/database/html/chat.dart
+++ b/lib/database/html/chat.dart
@@ -255,7 +255,7 @@ class Chat {
       return true;
     }
     return !SettingsSvc.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.isValidReaction(message?.associatedMessageType, emoji: message?.associatedMessageEmoji);
   }
 
   static void unDelete(Chat chat) {

--- a/lib/database/html/message.dart
+++ b/lib/database/html/message.dart
@@ -36,6 +36,7 @@ class Message {
   String? associatedMessageGuid;
   int? associatedMessagePart;
   String? associatedMessageType;
+  String? associatedMessageEmoji;
   String? expressiveSendStyleId;
   Handle? handle;
   bool hasAttachments;
@@ -97,6 +98,7 @@ class Message {
     this.associatedMessageGuid,
     this.associatedMessagePart,
     this.associatedMessageType,
+    this.associatedMessageEmoji,
     this.expressiveSendStyleId,
     this.handle,
     this.hasAttachments = false,
@@ -190,6 +192,7 @@ class Message {
       associatedMessagePart: json["associatedMessagePart"] ??
           int.tryParse(json["associatedMessageGuid"].toString().replaceAll("p:", "").split("/").first),
       associatedMessageType: json["associatedMessageType"],
+      associatedMessageEmoji: json["associatedMessageEmoji"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
       handle: json['handle'] != null ? Handle.fromMap(json['handle']) : null,
       hasAttachments: attachments.isNotEmpty || json['hasAttachments'] == true,
@@ -383,7 +386,7 @@ class Message {
       attachments.where((e) => e != null && e.mimeType == null).cast<Attachment>().toList();
 
   List<Message> get reactions => associatedMessages
-      .where((item) => ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", "")))
+      .where((item) => ReactionTypes.isValidReaction(item.associatedMessageType, emoji: item.associatedMessageEmoji))
       .toList();
 
   MessageStatusIndicator get indicatorToShow {
@@ -652,6 +655,7 @@ class Message {
       "associatedMessageGuid": associatedMessageGuid,
       "associatedMessagePart": associatedMessagePart,
       "associatedMessageType": associatedMessageType,
+      "associatedMessageEmoji": associatedMessageEmoji,
       "expressiveSendStyleId": expressiveSendStyleId,
       "handle": handle?.toMap(),
       "hasAttachments": hasAttachments,

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -299,7 +299,7 @@ class Chat {
 
     /// If reaction and notify reactions off, then don't notify, otherwise notify
     return !SettingsSvc.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.isValidReaction(message?.associatedMessageType, emoji: message?.associatedMessageEmoji);
   }
 
   /// Toggle unread status - pure DB operation

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -47,6 +47,7 @@ class Message {
   String? associatedMessageGuid;
   int? associatedMessagePart;
   String? associatedMessageType;
+  String? associatedMessageEmoji;
   String? expressiveSendStyleId;
   Handle? handle;
   bool hasAttachments;
@@ -166,6 +167,7 @@ class Message {
     this.associatedMessageGuid,
     this.associatedMessagePart,
     this.associatedMessageType,
+    this.associatedMessageEmoji,
     this.expressiveSendStyleId,
     this.handle,
     this.hasAttachments = false,
@@ -266,6 +268,7 @@ class Message {
       associatedMessagePart: json["associatedMessagePart"] ??
           int.tryParse(json["associatedMessageGuid"].toString().replaceAll("p:", "").split("/").first),
       associatedMessageType: json["associatedMessageType"],
+      associatedMessageEmoji: json["associatedMessageEmoji"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
       handle: json['handle'] != null ? Handle.fromMap(json['handle']!.cast<String, Object>()) : null,
       hasAttachments: attachments.isNotEmpty || json['hasAttachments'] == true,
@@ -679,7 +682,7 @@ class Message {
       attachments.where((e) => e != null && e.mimeType == null).cast<Attachment>().toList();
 
   List<Message> get reactions => associatedMessages
-      .where((item) => ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", "")))
+      .where((item) => ReactionTypes.isValidReaction(item.associatedMessageType, emoji: item.associatedMessageEmoji))
       .toList();
 
   MessageStatusIndicator get indicatorToShow {
@@ -1082,6 +1085,7 @@ class Message {
       "associatedMessageGuid": associatedMessageGuid,
       "associatedMessagePart": associatedMessagePart,
       "associatedMessageType": associatedMessageType,
+      "associatedMessageEmoji": associatedMessageEmoji,
       "expressiveSendStyleId": expressiveSendStyleId,
       "handle": handle?.toMap(),
       "hasAttachments": hasAttachments,

--- a/lib/helpers/types/extensions/extensions.dart
+++ b/lib/helpers/types/extensions/extensions.dart
@@ -341,7 +341,7 @@ extension MessageNotificationExtension on Message {
         Message? associatedMessage = Message.findOne(guid: associatedMessageGuid);
         if (associatedMessage != null) {
           // grab the verb we'll use from the reactionToVerb map
-          String? verb = ReactionTypes.reactionToVerb[associatedMessageType];
+          String? verb = ReactionTypes.getReactionVerb(associatedMessageType, emoji: associatedMessageEmoji);
           // we need to check balloonBundleId first because for some reason
           // game pigeon messages have the text "�"
           if (associatedMessage.isInteractive) {

--- a/lib/helpers/types/helpers/message_helper.dart
+++ b/lib/helpers/types/helpers/message_helper.dart
@@ -54,7 +54,7 @@ class MessageHelper {
     List<Message> normalized = [];
 
     for (Message message in associatedMessages.reversed.toList()) {
-      if (!ReactionTypes.toList().contains(message.associatedMessageType)) {
+      if (!ReactionTypes.isValidReaction(message.associatedMessageType, emoji: message.associatedMessageEmoji)) {
         normalized.add(message);
       } else if (guids.remove(message.guid)) {
         normalized.add(message);

--- a/lib/helpers/ui/reaction_helpers.dart
+++ b/lib/helpers/ui/reaction_helpers.dart
@@ -58,6 +58,34 @@ class ReactionTypes {
     "❗": EMPHASIZE,
     "❓": QUESTION,
   };
+
+  static bool isValidReaction(String? type, {String? emoji}) {
+    if (emoji != null && emoji.isNotEmpty) return true;
+    if (type == null || type.isEmpty) return false;
+    final cleaned = type.startsWith("-") ? type.substring(1) : type;
+    return toList().contains(cleaned);
+  }
+
+  static bool isEmojiReaction(String? emoji) {
+    return emoji != null && emoji.isNotEmpty;
+  }
+
+  static String getReactionEmoji(String? type, {String? emoji}) {
+    if (emoji != null && emoji.isNotEmpty) return emoji;
+    if (type == null || type.isEmpty) return "";
+    return reactionToEmoji[type] ?? type;
+  }
+
+  static String getReactionVerb(String? type, {String? emoji}) {
+    if (emoji != null && emoji.isNotEmpty) {
+      if (type != null && type.startsWith("-")) return "removed a $emoji reaction from";
+      return "reacted $emoji to";
+    }
+    if (type == null || type.isEmpty) return "reacted to";
+    if (reactionToVerb.containsKey(type)) return reactionToVerb[type]!;
+    if (type.startsWith("-")) return "removed a ${type.substring(1)} reaction from";
+    return "reacted to";
+  }
 }
 
 List<Message> getUniqueReactionMessages(List<Message> messages) {


### PR DESCRIPTION
- Adds associatedMessageEmoji field to Message model (io + html)
- Client reads the new field and displays raw emoji when present, falls back to classic tapback behavior when null
- All reaction filtering, display, and notification text updated to use new ReactionTypes helpers (isValidReaction, isEmojiReaction, getReactionEmoji, getReactionVerb)
- Requires server changes to read and send the associated_message_emoji column from iMessage DB
- fix from https://github.com/BlueBubblesApp/bluebubbles-app/pull/2982
- have this running on a fold7 but there is another issue in this branch with the reaction popup not appearing on long-press
