### PR TITLE
fix: lifecycle crash when ChatsService isn't registered yet

### DIFF
--- a/lib/services/backend/lifecycle/lifecycle_service.dart
+++ b/lib/services/backend/lifecycle/lifecycle_service.dart
@@ -76,7 +76,7 @@ class LifecycleService with WidgetsBindingObserver {
       // "chat is active" notification guard. setActiveToDead() is idempotent
       // (equality-checked inside) and will run again in close() when paused fires.
       // Also handles Samsung One UI which emits `hidden` before `paused`.
-      if (Platform.isAndroid) {
+      if (Platform.isAndroid && GetIt.I.isRegistered<ChatsService>()) {
         ChatsSvc.setActiveToDead();
       }
     } else {
@@ -119,6 +119,10 @@ class LifecycleService with WidgetsBindingObserver {
   void open() {
     // If we haven't finished setup, don't do anything
     if (!SettingsSvc.settings.finishedSetup.value) return;
+    // Lifecycle events can fire before StartupTasks.init() has registered
+    // ChatsService (e.g. window-focus on cold start). Skip until services exist;
+    // startup_tasks will set the active state itself when it finishes.
+    if (!GetIt.I.isRegistered<ChatsService>()) return;
     StartupTasks.onAppResume();
   }
 
@@ -134,10 +138,12 @@ class LifecycleService with WidgetsBindingObserver {
     // Leaving this commented out as a reminder.
     // WidgetsBinding.instance.removeObserver(this);
 
-    if (kIsDesktop) {
+    // Pause/hide can fire before ChatsService is registered on cold start.
+    final chatsReady = GetIt.I.isRegistered<ChatsService>();
+    if (kIsDesktop && chatsReady) {
       wasActiveAliveBefore = ChatsSvc.activeChat?.isAlive.value;
     }
-    if (!kIsDesktop || wasActiveAliveBefore != false) {
+    if (chatsReady && (!kIsDesktop || wasActiveAliveBefore != false)) {
       ChatsSvc.setActiveToDead();
     }
     if (!kIsDesktop && !kIsWeb) {
@@ -151,10 +157,12 @@ class LifecycleService with WidgetsBindingObserver {
         unawaited(GetIt.I<GlobalIsolate>().drainAndStop(timeout: const Duration(seconds: 30)));
       }
     }
-    final activeChat = ChatsSvc.activeChat;
-    if (activeChat != null) {
-      ConversationViewController _cvc = cvc(activeChat.chat);
-      _cvc.lastFocusedNode.unfocus();
+    if (chatsReady) {
+      final activeChat = ChatsSvc.activeChat;
+      if (activeChat != null) {
+        ConversationViewController _cvc = cvc(activeChat.chat);
+        _cvc.lastFocusedNode.unfocus();
+      }
     }
     if (kIsDesktop) {
       windowFocused = false;


### PR DESCRIPTION
## Problem

on a cold-start desktop launch, the OS sometimes fires a focus/resume lifecycle event before \`StartupTasks.init()\` has gotten to \`GetIt.I.registerSingleton<ChatsService>()\`. \`LifecycleService.open()\` then runs \`StartupTasks.onAppResume()\` which calls \`ChatsSvc\`, throwing:

\`\`\`
Failure during app initialization: Bad state: GetIt: Object/factory with type ChatsService is not registered inside GetIt.
#0  throwIfNot (package:get_it/get_it_impl.dart:14)
...
#5  ChatsSvc (package:bluebubbles/services/ui/chat/chats_service.dart:24)
#6  StartupTasks.onAppResume (package:bluebubbles/helpers/backend/startup_tasks.dart:529)
#7  LifecycleService.open (package:bluebubbles/services/backend/lifecycle/lifecycle_service.dart:115)
#8  LifecycleService.didChangeAppLifecycleState (...:74)
\`\`\`

reproducible on Linux desktop, every cold start. probably also reachable on Windows depending on how fast the toplevel window grabs focus relative to startup.

## Solution

guard the three \`ChatsSvc\` paths in \`LifecycleService\` on \`GetIt.I.isRegistered<ChatsService>()\`:

- \`open()\` — bail before \`StartupTasks.onAppResume()\` if services aren't up yet
- \`close()\` — capture a single \`chatsReady\` bool and gate every \`ChatsSvc\` call (the active-chat capture, \`setActiveToDead()\`, and the focus-unfocus block)
- the new android \`inactive\`/\`hidden\` \`setActiveToDead()\` block in \`didChangeAppLifecycleState\`

same pattern already used for \`GlobalIsolate\` further down in \`close()\`. \`startup_tasks\` sets the active state itself when \`onStartup\` finishes, so dropping these early lifecycle events doesn't lose state.

## Testing

- linux desktop, cold start: no more \`Bad state\` failure during init; window opens cleanly
- linux desktop, focus/blur cycles after startup completes: \`ChatsSvc.setActiveToAlive\`/\`...ToDead\` still fire as before
- normal pause/resume on android emulator: unchanged