### PR TITLE
fix: handle ObjectBox intra-process double-open on Linux desktop

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -143,17 +143,24 @@ class Database {
         await PrefsSvc.i.remove('custom-path');
       }
 
-      Logger.info("Opening ObjectBox store from path: ${objectBoxDirectory.path}");
-      store = await openStore(directory: objectBoxDirectory.path);
+      if (Store.isOpen(objectBoxDirectory.path)) {
+        Logger.info("ObjectBox store already open in this process, attaching: ${objectBoxDirectory.path}");
+        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
+      } else {
+        Logger.info("Opening ObjectBox store from path: ${objectBoxDirectory.path}");
+        store = await openStore(directory: objectBoxDirectory.path);
+      }
     } catch (e) {
-      if (Platform.isLinux) {
+      // Intra-process double-open: another isolate already opened the store. Attach to it.
+      if (e.toString().contains("another store is still open using the same path")) {
+        Logger.debug("Retrying to attach to an existing ObjectBox store");
+        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
+      } else if (Platform.isLinux) {
+        // Cross-process: another running instance owns the LMDB lock. Signal it and exit.
         Logger.debug("Another instance is probably running. Sending foreground signal");
         final instanceFile = File(join(FilesystemSvc.appDocDir.path, '.instance'));
         instanceFile.openSync(mode: FileMode.write).closeSync();
         exit(0);
-      } else if (Platform.isWindows && e.toString().contains("another store is still open using the same path")) {
-        Logger.debug("Retrying to attach to an existing ObjectBox store");
-        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
       }
     }
   }


### PR DESCRIPTION
## Problem

\`_initDatabaseDesktop\` distinguishes between cross-process (Linux: signal the running instance and exit) and intra-process (Windows: \`Store.attach\`) collisions when \`openStore()\` fails. but on Linux, when an isolate or another entry point in the same process opens the store first, the main thread's \`openStore()\` raises:

\`\`\`
another store is still open using the same path
\`\`\`

…which currently falls into the \`Platform.isLinux\` branch and silently \`exit(0)\`s the app — even though there's no second process to signal. \`_initDatabaseMobile\` already handles this case correctly with \`Store.isOpen()\` + attach; desktop didn't.

## Solution

- check \`Store.isOpen()\` upfront and attach if true (mirroring \`_initDatabaseMobile\`)
- in the catch, treat the \"another store is still open\" exception as the intra-process signal **regardless of platform**, attaching to the existing store
- the \`Platform.isLinux\` exit path now only fires for genuine cross-process collisions (i.e. a different running instance owns the LMDB lock)

## Testing

- Linux desktop: the exit-on-isolate-collision regression is gone; main thread now attaches cleanly
- second-instance launch on Linux still triggers the signal-and-exit path correctly (the foreground hand-off works as before)
- Windows: behaviour unchanged — same exception string, now matched by the platform-agnostic branch instead of the \`Platform.isWindows\` one