### PR TITLE
fix: SettingsSvc crash in spawned isolates during launch-at-startup setup

### DIFF
--- a/lib/services/backend/settings/settings_service.dart
+++ b/lib/services/backend/settings/settings_service.dart
@@ -80,13 +80,17 @@ class SettingsService {
     // launch at startup - defer this so it doesn't block startup
     if (kIsDesktop) {
       Future.microtask(() async {
-        if (Platform.isWindows) {
-          try {
-            _canAuthenticate = await LocalAuthentication().isDeviceSupported();
-          } catch (_) {}
+        try {
+          if (Platform.isWindows) {
+            try {
+              _canAuthenticate = await LocalAuthentication().isDeviceSupported();
+            } catch (_) {}
+          }
+          SettingsSvc.settings.launchAtStartup.value = await setupLaunchAtStartup(
+              SettingsSvc.settings.launchAtStartup.value, SettingsSvc.settings.launchAtStartupMinimized.value);
+        } catch (_) {
+          // Best-effort: ignore failures (e.g. SettingsSvc not registered yet in spawned isolates).
         }
-        SettingsSvc.settings.launchAtStartup.value = await setupLaunchAtStartup(
-            SettingsSvc.settings.launchAtStartup.value, SettingsSvc.settings.launchAtStartupMinimized.value);
       });
     }
 


### PR DESCRIPTION
## Problem

the desktop \"launch at startup\" setup runs as a deferred \`Future.microtask\` from \`SettingsService.init\`. on spawned isolates (background, sync) the microtask can race with isolate teardown — hitting \`SettingsSvc\` before it's registered or after it's been disposed — and throws an unhandled \`GetIt\` error that surfaces as an init failure on Linux desktop:

\`\`\`
Failure during app initialization: Bad state: GetIt: Object/factory with type SettingsService is not registered inside GetIt.
\`\`\`

## Solution

wrap the whole microtask body in a try/catch and swallow the failure with a comment. the only \`setupLaunchAtStartup\` call that should ever \"win\" is the one running on the main isolate, which is the place actually mutating user-visible autostart state. failures from short-lived isolates are noise.

## Testing

- linux desktop: cold-start init no longer trips the GetIt error from a spawned isolate's microtask
- main-isolate behaviour unchanged: \`setupLaunchAtStartup\` still runs, still updates \`launchAtStartup.value\`, still creates/removes the startup shortcut on Windows