### PR TITLE
fix: persist ToMany relations on bulk sync (contacts, attachments) and surface attachment-only message previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .buildlog/
 .history
 .svn/
+.claude/
 
 # IntelliJ related
 *.iml

--- a/lib/app/layouts/conversation_view/widgets/text_field/text_field_icon_bar.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/text_field_icon_bar.dart
@@ -132,10 +132,27 @@ class TextFieldIconBar extends StatelessWidget {
           IconButton(
               icon: Icon(Icons.gif, color: context.theme.colorScheme.outline, size: 28),
               onPressed: () async {
+                // Resolve the Tenor API key. The web build embeds it as a
+                // const; native builds read it from .env. If the key is
+                // missing or empty, surface a helpful message instead of
+                // throwing / silently doing nothing.
+                String? apiKey;
+                try {
+                  apiKey = kIsWeb ? TENOR_API_KEY : dotenv.maybeGet('TENOR_API_KEY');
+                } catch (_) {
+                  apiKey = null;
+                }
+                if (apiKey == null || apiKey.isEmpty) {
+                  showSnackbar(
+                    'GIF picker unavailable',
+                    'No Tenor API key is configured. Add TENOR_API_KEY to .env to enable GIF search.',
+                  );
+                  return;
+                }
                 if (kIsDesktop || kIsWeb) {
                   controller.showingOverlays = true;
                 }
-                Tenor tenor = Tenor(apiKey: kIsWeb ? TENOR_API_KEY : dotenv.get('TENOR_API_KEY'));
+                Tenor tenor = Tenor(apiKey: apiKey);
                 TextEditingController tenorController = TextEditingController();
                 FocusNode focus = FocusNode();
                 Future<TenorResult?> resultFuture = tenor.showAsBottomSheet(

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -267,7 +267,12 @@ class Message {
       associatedMessageType: json["associatedMessageType"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
       handle: json['handle'] != null ? Handle.fromMap(json['handle']!.cast<String, Object>()) : null,
-      hasAttachments: json['hasAttachments'] == true,
+      // Server responses don't always include the boolean — derive it from the
+      // attachments array if present so the chat-list subtitle doesn't fall
+      // through the "no text, no attachments" branch and show "Empty message"
+      // for attachment-only messages (e.g. GIFs, photos).
+      hasAttachments: json['hasAttachments'] == true ||
+          (json['attachments'] is List && (json['attachments'] as List).isNotEmpty),
       hasReactions: json['hasReactions'] == true,
       dateDeleted: parseDate(json["dateDeleted"]),
       metadata: metadata is String ? null : metadata,

--- a/lib/helpers/types/extensions/extensions.dart
+++ b/lib/helpers/types/extensions/extensions.dart
@@ -318,7 +318,12 @@ extension MessageNotificationExtension on Message {
       if (isInteractive) {
         return "$sender$interactiveText";
       }
-      if (isNullOrEmpty(fullText) && !hasAttachments && isNullOrEmpty(associatedMessageGuid)) {
+      // The hasAttachments boolean is denormalized from the attachments array
+      // and isn't always set correctly (server omissions, older rows). Trust
+      // the actual relation as a fallback so attachment-only messages don't
+      // get labeled "Empty message" just because the flag wasn't populated.
+      final actuallyHasAttachments = hasAttachments || realAttachments.isNotEmpty;
+      if (isNullOrEmpty(fullText) && !actuallyHasAttachments && isNullOrEmpty(associatedMessageGuid)) {
         if (dateEdited != null) {
           return "${sender}Unsent message";
         }

--- a/lib/services/backend/actions/contact_v2_actions.dart
+++ b/lib/services/backend/actions/contact_v2_actions.dart
@@ -375,6 +375,11 @@ class ContactV2Actions {
           // written to the DB regardless of whether handle assignments changed.
           try {
             contactsBox.put(contact);
+            // ObjectBox Dart does not always flush ToMany changes implicitly,
+            // particularly for newly-inserted entities whose ID was assigned
+            // by the put above. Force the N:M relation to be written so the
+            // backlink on Handle.contactsV2 resolves correctly.
+            contact.handles.applyToDb();
           } on UniqueViolationException catch (e) {
             Logger.warn('[ContactV2] Unique violation for contact ${contact.nativeContactId}: $e');
           }

--- a/lib/services/backend/actions/message_actions.dart
+++ b/lib/services/backend/actions/message_actions.dart
@@ -121,14 +121,59 @@ class MessageActions {
         }
       }
 
-      // 6. Relate the attachments to the messages
+      // 6. Relate the attachments to the messages. Keep the per-message list
+      // around so we can re-apply the @Backlink ToMany after putMany — see step 7b.
+      final attachmentsPerMessage = <String, List<Attachment>>{};
       for (final msg in newMessages) {
         final relatedAttachments = messageAttachments[msg.guid]?.map((e) => attachmentMap[e]).nonNulls.toList() ?? [];
+        if (relatedAttachments.isEmpty) continue;
+        attachmentsPerMessage[msg.guid!] = relatedAttachments;
         msg.dbAttachments.addAll(relatedAttachments);
       }
 
       // 7. Save all messages (and handle/attachment relationships)
       messageBox.putMany(newMessages);
+
+      // 7b. ObjectBox Dart does not reliably persist @Backlink ToMany changes
+      // via putMany for newly-inserted entities — the link table on the inverse
+      // ToOne side won't be written. Without this, dbAttachments lazy-loads as
+      // empty on next read, so chats with attachment-only latest messages show
+      // "Empty message" in the conversation list. Mirror the pattern used in
+      // Message.save() and ChatActions.bulkSyncMessages.
+      for (final msg in newMessages) {
+        final atts = attachmentsPerMessage[msg.guid];
+        if (atts == null || atts.isEmpty) continue;
+        msg.dbAttachments
+          ..clear()
+          ..addAll(atts);
+        msg.dbAttachments.applyToDb();
+      }
+
+      // 7c. Repair pass for existing messages whose dbAttachments backlink was
+      // lost by the bug we just fixed in 7b. If the server reports attachments
+      // for an existing message but the local DB has none, link them now so
+      // resyncs heal historical "Empty message" chat-list entries instead of
+      // requiring a wipe.
+      for (final existing in existingMessages) {
+        final raw = messageAttachmentsData[existing.guid];
+        if (raw == null || raw.isEmpty) continue;
+        if (existing.dbAttachments.isNotEmpty) continue;
+        final linked = raw
+            .map((m) => m['guid'] as String?)
+            .whereType<String>()
+            .map((g) => attachmentMap[g])
+            .whereType<Attachment>()
+            .toList();
+        if (linked.isEmpty) continue;
+        existing.dbAttachments
+          ..clear()
+          ..addAll(linked);
+        existing.dbAttachments.applyToDb();
+        if (existing.hasAttachments != true) {
+          existing.hasAttachments = true;
+          messageBox.put(existing);
+        }
+      }
 
       // 8. Get the inserted messages
       final messageQuery2 = messageBox.query(Message_.guid.oneOf(inputMessageGuids)).build();


### PR DESCRIPTION
## Summary
Four related fixes for the 2.0 desktop branch that were causing chats to show phone numbers instead of contact names and "Empty message" subtitles for attachment-only messages on Windows. All four reproduce against a live BlueBubbles server (v1.9.9) syncing to the Windows client.

### `fix: persist contact handle relations after putMany`
`ContactV2Actions.syncContactsToHandles` adds matched handles to `contact.handles` (a `ToMany<Handle>`) and calls `contactsBox.put(contact)`. ObjectBox Dart does not reliably flush ToMany changes through `put` when the entity is newly inserted (the ID is assigned by that same `put`), so the link table on the inverse side stays empty. The next time `Handle.contactsV2` (the `@Backlink`) is read, it lazy-loads as an empty list and `Handle.displayName` falls through to the raw phone number.

Adds an explicit `contact.handles.applyToDb()` after the put — same pattern used elsewhere in the codebase.

### `fix: persist message attachment relations during bulk sync`
`MessageActions.bulkSaveNewMessages` was adding attachments to `msg.dbAttachments` (a `@Backlink ToMany<Attachment>`) before calling `messageBox.putMany`. Same root cause as the contact bug — the backlink ToMany never reaches the link table, so on next read `dbAttachments` is empty. Attachment-only messages (GIFs, photos) then render with no preview and the conversation tile shows "Empty message".

- Mirrors the pattern already used in `Message.save()` and `ChatActions.bulkSyncMessages`: explicit `applyToDb()` after the put.
- Adds a repair pass for existing messages so historical bad data heals on resync instead of needing a DB wipe.

### `fix: derive hasAttachments from JSON array, trust relation as fallback`
The server response sometimes omits the `hasAttachments` boolean even when `attachments: [...]` is populated. `Message.fromMap` was leaving the flag `false`, and the conversation-list subtitle code at `extensions.dart` short-circuits on `!hasAttachments` before checking the actual relation. So attachment-only messages showed "Empty message" even when the relation was persisted correctly via the incoming-message path.

- `Message.fromMap` now treats a non-empty `attachments` array as truthy.
- The subtitle code falls back to `realAttachments.isNotEmpty` so historical rows with the flag mis-set still render correctly without a full resync.

### `fix: surface missing TENOR_API_KEY instead of silent failure`
`dotenv.get('TENOR_API_KEY')` throws when the key is absent; the throw was swallowed upstream and the GIF picker button silently did nothing. Use `dotenv.maybeGet` and show a snackbar explaining how to add the key when missing.

## Test plan
- [x] Cold-start the Windows client with no contact relations populated → handle names resolve after first sync
- [x] Send/receive a GIF or photo attachment → conversation tile shows "1 Photo" / "1 GIF" instead of "Empty message"
- [x] Trigger full sync on a DB with the historical attachment-relation bug → repair pass links orphaned attachments back, subtitles update on next restart
- [x] Open GIF picker without `TENOR_API_KEY` in `.env` → snackbar surfaces clear error instead of unresponsive button

🤖 Generated with [Claude Code](https://claude.com/claude-code)