### PR TITLE
fix: incoming FaceTime overlay was un-dismissable

### DIFF
--- a/lib/helpers/ui/facetime_helpers.dart
+++ b/lib/helpers/ui/facetime_helpers.dart
@@ -12,16 +12,21 @@ import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:bluebubbles/services/backend/notifications/notifications_service.dart';
 
-Map<String, Route> faceTimeOverlays = {}; // Map from call uuid to overlay route
+/// Map from call uuid to a closure that pops the dialog using the dialog's
+/// OWN Navigator (captured inside the builder). Previously this stored a
+/// `Route` and called `Get.removeRoute`, but `Get.removeRoute` searches via
+/// the global navigator delegate, which can miss dialogs pushed against
+/// `Get.context` — so the overlay stayed un-dismissable even after the user
+/// tapped Accept/Ignore. Storing a direct pop-closure is unambiguous: it
+/// always targets the right Navigator.
+Map<String, VoidCallback> faceTimeOverlays = {};
 
 /// Hides the FaceTime overlay with the given [callUuid]
 /// Also calls [NotificationsService.clearFaceTimeNotification] to clear the notification
 void hideFaceTimeOverlay(String callUuid) {
   notif.clearFaceTimeNotification(callUuid);
-  if (faceTimeOverlays.containsKey(callUuid)) {
-    Get.removeRoute(faceTimeOverlays[callUuid]!);
-    faceTimeOverlays.remove(callUuid);
-  }
+  final dismiss = faceTimeOverlays.remove(callUuid);
+  if (dismiss != null) dismiss();
 }
 
 /// Shows a FaceTime overlay with the given [callUuid], [caller], [chatIcon], and [isAudio]
@@ -40,7 +45,19 @@ Future<void> showFaceTimeOverlay(String callUuid, String caller, Uint8List? chat
   showDialog(
     context: Get.context!,
     barrierDismissible: false,
-    builder: (_) {
+    builder: (dialogContext) {
+      // Capture the dialog's OWN Navigator via its context. Using a
+      // pop-closure (instead of a Route + Get.removeRoute) is unambiguous:
+      // Navigator.of(dialogContext).pop() always targets the dialog itself,
+      // regardless of which navigator delegate Get currently considers
+      // active. The previous code stored a Route and called
+      // Get.removeRoute, which can silently no-op when the navigator
+      // delegate doesn't match — leaving the overlay un-dismissable.
+      faceTimeOverlays[callUuid] = () {
+        if (Navigator.of(dialogContext).canPop()) {
+          Navigator.of(dialogContext).pop();
+        }
+      };
       return BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 2, sigmaY: 2),
         child: AlertDialog(
@@ -72,6 +89,10 @@ Future<void> showFaceTimeOverlay(String callUuid, String caller, Uint8List? chat
                 ],
               ),
               onPressed: () async {
+                // Dismiss the overlay first so the user is never stuck staring
+                // at an un-dismissable dialog while answerFaceTime runs its
+                // HTTP call.
+                hideFaceTimeOverlay(callUuid);
                 await intents.answerFaceTime(callUuid);
               },
             ),
@@ -102,9 +123,5 @@ Future<void> showFaceTimeOverlay(String callUuid, String caller, Uint8List? chat
           ],
         ),
       );
-    }).then((_) => faceTimeOverlays.remove(callUuid) /* Not explicitly necessary since all ways of closing the dialog do this, but just in case */
-  );
-
-  // Save dialog as overlay route
-  faceTimeOverlays[callUuid] = Get.rawRoute!;
+    }).then((_) => faceTimeOverlays.remove(callUuid));
 }


### PR DESCRIPTION
## Bug
When an incoming FaceTime call comes in, the overlay dialog gets stuck on screen — Accept opens a new dialog on top of the still-present overlay, Ignore does nothing visible. The user is trapped.

## Cause
Two compounding issues:

1. `showFaceTimeOverlay` captured `Get.rawRoute!` immediately after `showDialog(...)`. But `showDialog` pushes its route asynchronously, so at that moment `Get.rawRoute` is still the parent route, not the dialog. The wrong route gets stored in `faceTimeOverlays[callUuid]`.

2. `hideFaceTimeOverlay` calls `Get.removeRoute(...)`, which uses Get's `searchDelegate(null)` to find the navigator. When the dialog was pushed against `Get.context!` (the root nav), that delegate doesn't always match — `removeRoute` silently no-ops and the dialog stays.

## Fix
Switch the storage from `Map<String, Route>` to `Map<String, VoidCallback>`. The closure captures the dialog's own `BuildContext` from inside the `builder:` (where it's guaranteed to be the dialog's context) and calls `Navigator.of(dialogContext).pop()` directly. That always targets the dialog itself, regardless of which navigator delegate Get currently considers active.

Also call `hideFaceTimeOverlay(callUuid)` before `intents.answerFaceTime(...)` in the Accept handler so the overlay is gone before the next dialog appears.

## Verified
Tested locally — incoming FaceTime overlay now dismisses cleanly on both Accept and Ignore.