### PR TITLE
fix: Linux desktop killed on spawned-isolate ObjectBox open instead of attaching

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -132,6 +132,19 @@ class Database {
       Logger.info("Opening ObjectBox store from path: ${objectBoxDirectory.path}");
       store = await openStore(directory: objectBoxDirectory.path);
     } catch (e, s) {
+      // A spawned isolate (e.g. the global isolate, sync isolate) opening the
+      // store that the main isolate already holds throws "another store is
+      // still open using the same path". ObjectBox forbids two open() calls
+      // for the same path in one process — Store.attach is the supported way
+      // to share the store across isolates. Without this branch, Linux
+      // unconditionally exit(0)'d on that error, killing any new launch the
+      // moment a spawned isolate raced the main isolate's open.
+      if (e.toString().contains("another store is still open using the same path")) {
+        Logger.info("Retrying to attach to an existing ObjectBox store");
+        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
+        return;
+      }
+
       if (Platform.isLinux) {
         Logger.debug("Another instance is probably running. Sending foreground signal");
         final instanceFile = File(join(fs.appDocDir.path, '.instance'));


### PR DESCRIPTION
## Bug
On Linux desktop, the app sometimes silently exits during startup. Logs show the main isolate successfully opens ObjectBox, then the spawned global isolate also tries to open the same store, ObjectBox throws 'another store is still open using the same path', and `_initDatabaseDesktop`'s catch unconditionally treats ANY exception as 'another instance is probably running' → `exit(0)`. The app dies immediately, no window ever appears.

This is the same case `_initDatabaseMobile` already handles correctly via `Store.attach` (lines 110-113). Desktop just didn't have the same branch.

## Fix
In the catch block, check for the 'another store is still open using the same path' string FIRST. If matched, it's a same-process race between isolates — call `Store.attach` like the mobile path does. Only fall through to the Linux 'another instance is running' `exit(0)` for genuinely OS-level instance conflicts.

## Repro
Build any post-3.10 desktop Flutter version that spawns isolates during startup on a Linux session. Without this fix, the app exits at the GlobalIsolate's first ObjectBox open attempt.