### PR TITLE
fix: Ctrl+C/V/X/A/Z stopped working in TextFields because shortcuts: map wipes Flutter defaults

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -281,7 +281,24 @@ class Main extends StatelessWidget {
           multitouchDragStrategy: MultitouchDragStrategy.latestPointer,
         ),
         home: Home(),
+        // IMPORTANT: passing `shortcuts:` to GetMaterialApp REPLACES Flutter's
+        // default shortcut map, including the text-editing clipboard bindings
+        // (Ctrl+C/V/X/A, Ctrl+Z, Ctrl+Shift+Z). Re-declare them here so
+        // copy/paste/cut/select-all/undo/redo keep working in every TextField
+        // in the app. GetMaterialApp's `shortcuts` is typed as
+        // Map<LogicalKeySet, Intent>, so the keys are LogicalKeySets here.
         shortcuts: {
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyC): CopySelectionTextIntent.copy,
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyX):
+              const CopySelectionTextIntent.cut(SelectionChangedCause.keyboard),
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
+              const PasteTextIntent(SelectionChangedCause.keyboard),
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyA):
+              const SelectAllTextIntent(SelectionChangedCause.keyboard),
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyZ):
+              const UndoTextIntent(SelectionChangedCause.keyboard),
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.shift, LogicalKeyboardKey.keyZ):
+              const RedoTextIntent(SelectionChangedCause.keyboard),
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.comma): const OpenSettingsIntent(),
           LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.keyN): const OpenNewChatCreatorIntent(),
           if (kIsDesktop)


### PR DESCRIPTION
## Bug
Ctrl+C, Ctrl+V, Ctrl+X, Ctrl+A, Ctrl+Z, Ctrl+Shift+Z do nothing in any TextField in the app on desktop. The conversation text field, search box, settings inputs, etc. — none of them honor clipboard shortcuts.

## Cause
`GetMaterialApp`'s `shortcuts:` parameter REPLACES (does not merge with) Flutter's default shortcut map. The default map lives in `DefaultTextEditingShortcuts._linuxShortcuts` / `._macShortcuts` / `._windowsShortcuts` and is where `Ctrl+C → CopySelectionTextIntent.copy` etc. live. Once we passed a custom `shortcuts:` to bind BlueBubbles-specific intents (OpenSettings, OpenSearch, etc.), the editing defaults silently disappeared.

## Fix
Add explicit `LogicalKeySet → Intent` entries for the six standard editing shortcuts at the top of the `shortcuts:` map. Spreading `WidgetsApp.defaultShortcuts` directly would be cleaner but GetMaterialApp types its map as `Map<LogicalKeySet, Intent>` (not `Map<ShortcutActivator, Intent>`), so explicit declarations are required.

## Repro
Open any TextField on desktop, type something, select it, press Ctrl+C. Nothing happens. After this patch, copy/paste/cut/select-all/undo/redo work as expected.