### PR TITLE
v2.0.0-b8 candidate: sync perf, chat list refresh, FaceTime fixes + outgoing Link

### DIFF
--- a/lib/app/layouts/conversation_details/dialogs/address_picker.dart
+++ b/lib/app/layouts/conversation_details/dialogs/address_picker.dart
@@ -1,41 +1,207 @@
+import 'dart:io' show Platform;
+
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-void launchIntent(bool video, String address) async {
-  if (address.contains("@")) {
-    launchUrl(Uri(scheme: "mailto", path: address));
-  } else if (await Permission.phone.request().isGranted) {
-    if (video) {
-      try {
-        await MethodChannelSvc.actions.googleDuo(number: address);
-      } catch (_) {
-        showSnackbar("Error", "Something went wrong, Google Duo may not be installed!");
-      }
-    } else {
-      launchUrl(Uri(scheme: "tel", path: address));
+/// Launch an outgoing call. Cross-platform behavior:
+///
+/// - macOS/iOS: `facetime:` / `facetime-audio:` opens native FaceTime.
+/// - Android/Linux/Windows (video): hit the BB server's `/facetime/session`
+///   endpoint to create a real FaceTime Link via the Mac, then offer to
+///   copy or send it in the current chat. Replaces the dead Google Duo
+///   path — Google killed Duo in 2022 and merged it into Meet.
+/// - Android (audio): `tel:` for the native dialer.
+void launchIntent(bool video, String address, {BuildContext? context, Chat? chat}) async {
+  final bool isApple = !kIsWeb && (Platform.isMacOS || Platform.isIOS);
+  final bool isAndroid = !kIsWeb && Platform.isAndroid;
+
+  if (address.contains("@") && !video) {
+    await launchUrl(Uri(scheme: "mailto", path: address));
+    return;
+  }
+
+  if (video) {
+    if (isApple) {
+      final ok = await launchUrl(Uri(scheme: "facetime", path: address));
+      if (!ok) showSnackbar("Error", "Couldn't launch FaceTime for $address");
+      return;
+    }
+    if (context != null && context.mounted) {
+      showFaceTimeLinkSheet(context, chat: chat);
+      return;
+    }
+    showSnackbar(
+      "FaceTime unavailable",
+      "Tap Video Call from a chat to get the FaceTime Link option.",
+    );
+    return;
+  }
+
+  // Audio call path.
+  if (isApple) {
+    await launchUrl(Uri(scheme: "facetime-audio", path: address));
+    return;
+  }
+  if (isAndroid) {
+    if (await Permission.phone.request().isGranted) {
+      await launchUrl(Uri(scheme: "tel", path: address));
+    }
+    return;
+  }
+  showSnackbar(
+    "Calls unavailable",
+    "Outgoing calls require an Apple device or an Android phone.",
+  );
+}
+
+/// Modal sheet that creates a fresh FaceTime Link via the BB server and lets
+/// the user copy it or send it directly into [chat]. Apple's web FaceTime
+/// works for anyone (Apple or not) — they tap the link, sign in to FaceTime,
+/// join from the browser. The link creator (you) joins from your own browser.
+void showFaceTimeLinkSheet(BuildContext context, {Chat? chat}) {
+  String? link;
+  Object? error;
+  bool loading = true;
+
+  Future<void> sendInChat() async {
+    if (chat == null || link == null) return;
+    try {
+      final message = Message(
+        text: link!,
+        dateCreated: DateTime.now(),
+        hasAttachments: false,
+        isFromMe: true,
+        handleId: 0,
+      );
+      message.generateTempGuid();
+      await OutgoingMsgHandler.sendMessage(chat, message, null, null);
+      if (!context.mounted) return;
+      Navigator.of(context).pop();
+      showSnackbar('Sent', 'FaceTime link sent to ${chat.getTitle()}');
+    } catch (e) {
+      showSnackbar('Send failed', e.toString());
     }
   }
+
+  showModalBottomSheet(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (sheetCtx) {
+      return StatefulBuilder(
+        builder: (sheetCtx, setSheetState) {
+          if (loading && link == null && error == null) {
+            // Fire-and-forget once on first build.
+            HttpSvc.faceTime.createSession().then((resp) {
+              link = resp.data?["data"]?["link"] as String?;
+              error = link == null ? (resp.data?["error"]?["message"] ?? 'No link in response') : null;
+              loading = false;
+              if (sheetCtx.mounted) setSheetState(() {});
+            }).catchError((e) {
+              error = e;
+              loading = false;
+              if (sheetCtx.mounted) setSheetState(() {});
+            });
+          }
+
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('FaceTime Link', style: sheetCtx.theme.textTheme.titleLarge),
+                  const SizedBox(height: 8),
+                  if (loading)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 24),
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  else if (error != null)
+                    Text(
+                      "Couldn't create a FaceTime link.\n"
+                      "Requires BB Server with macOS Monterey+ and Private API enabled.\n\n$error",
+                      style: sheetCtx.theme.textTheme.bodyMedium?.copyWith(
+                        color: sheetCtx.theme.colorScheme.error,
+                      ),
+                    )
+                  else ...[
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: sheetCtx.theme.colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: SelectableText(
+                        link!,
+                        style: sheetCtx.theme.textTheme.bodySmall,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(children: [
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          icon: const Icon(Icons.copy),
+                          label: const Text('Copy'),
+                          onPressed: () async {
+                            await Clipboard.setData(ClipboardData(text: link!));
+                            showSnackbar('Copied', 'FaceTime link copied');
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: FilledButton.icon(
+                          icon: const Icon(Icons.open_in_new),
+                          label: const Text('Join in browser'),
+                          onPressed: () => launchUrl(Uri.parse(link!), mode: LaunchMode.externalApplication),
+                        ),
+                      ),
+                    ]),
+                    if (chat != null) ...[
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton.icon(
+                          icon: const Icon(Icons.send),
+                          label: Text('Send to ${chat.getTitle()}'),
+                          onPressed: sendInChat,
+                        ),
+                      ),
+                    ],
+                  ],
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
 }
 
 void showAddressPicker(ContactV2? contact, Handle handle, BuildContext context,
-    {bool isEmail = false, bool video = false, bool isLongPressed = false}) async {
+    {bool isEmail = false, bool video = false, bool isLongPressed = false, Chat? chat}) async {
   if (contact == null) {
-    launchIntent(video, handle.address);
+    launchIntent(video, handle.address, context: context, chat: chat);
   } else {
     List<String> items = isEmail
         ? getUniqueEmails(contact.emailAddresses.map((e) => e.address))
         : getUniqueNumbers(contact.phoneNumbers.map((p) => p.number));
     if (items.length == 1) {
-      launchIntent(video, items.first);
+      launchIntent(video, items.first, context: context, chat: chat);
     } else if (!isEmail && handle.defaultPhone != null && !isLongPressed) {
-      launchIntent(video, handle.defaultPhone!);
+      launchIntent(video, handle.defaultPhone!, context: context, chat: chat);
     } else if (isEmail && handle.defaultEmail != null && !isLongPressed) {
-      launchIntent(video, handle.defaultEmail!);
+      launchIntent(video, handle.defaultEmail!, context: context, chat: chat);
     } else {
       showDialog(
         context: context,
@@ -66,7 +232,7 @@ void showAddressPicker(ContactV2? contact, Handle handle, BuildContext context,
                               handle.updateDefaultPhone(items[i]);
                             }
                           }
-                          launchIntent(video, items[i]);
+                          launchIntent(video, items[i], context: context, chat: chat);
                           Navigator.of(context).pop();
                         },
                       ),

--- a/lib/app/layouts/conversation_details/widgets/chat_info.dart
+++ b/lib/app/layouts/conversation_details/widgets/chat_info.dart
@@ -500,11 +500,11 @@ class VideoCallButton extends StatelessWidget {
         child: InkWell(
           onTap: () {
             final contact = chat.handles.first.contactsV2.firstOrNull;
-            showAddressPicker(contact, chat.handles.first, context, video: true);
+            showAddressPicker(contact, chat.handles.first, context, video: true, chat: chat);
           },
           onLongPress: () {
             final contact = chat.handles.first.contactsV2.firstOrNull;
-            showAddressPicker(contact, chat.handles.first, context, isLongPressed: true, video: true);
+            showAddressPicker(contact, chat.handles.first, context, isLongPressed: true, video: true, chat: chat);
           },
           borderRadius: BorderRadius.circular(15),
           child: SizedBox(

--- a/lib/services/backend/action_handler.dart
+++ b/lib/services/backend/action_handler.dart
@@ -39,28 +39,40 @@ class ActionHandler extends GetxService {
   }
 
   Future<void> handleIncomingFaceTimeCall(Map<String, dynamic> data) async {
-    Logger.info("Handling incoming FaceTime call");
-    final callUuid = data["uuid"];
-    String? address = data["handle"]?["address"];
-    String caller = data["address"] ?? "Unknown Number";
-    bool isAudio = data["is_audio"];
-    Uint8List? chatIcon;
+    try {
+      Logger.info("Handling incoming FaceTime call");
+      // Defensive parsing — the server payload occasionally arrives with
+      // missing fields. Previously a direct `bool isAudio = data["is_audio"]`
+      // would throw _TypeError(null is not bool) and the entire overlay path
+      // silently aborted — the user saw nothing for incoming calls.
+      final String? callUuid = data["uuid"] as String?;
+      final String? address = data["handle"] is Map ? (data["handle"]["address"] as String?) : null;
+      String caller = (data["address"] as String?) ?? address ?? "Unknown Number";
+      final bool isAudio = (data["is_audio"] as bool?) ?? false;
+      Uint8List? chatIcon;
 
-    if (address != null) {
-      ContactV2? contact = await ContactsSvcV2.getContact(address);
-      if (contact?.avatarPath != null) {
-        chatIcon = await ContactsSvcV2.getContactAvatar(contact!.nativeContactId);
+      if (address != null) {
+        ContactV2? contact = await ContactsSvcV2.getContact(address);
+        if (contact?.avatarPath != null) {
+          chatIcon = await ContactsSvcV2.getContactAvatar(contact!.nativeContactId);
+        }
+        caller = contact?.displayName ?? caller;
       }
-      caller = contact?.displayName ?? caller;
-    }
 
-    if (!LifecycleSvc.isAlive) {
-      if (kIsDesktop) {
+      // Without a callUuid the overlay's Accept button has nothing to act on,
+      // so skip the overlay entirely and fall through to the notification.
+      if (!LifecycleSvc.isAlive) {
+        if (kIsDesktop && callUuid != null) {
+          await showFaceTimeOverlay(callUuid, caller, chatIcon, isAudio);
+        }
+        await NotificationsSvc.createIncomingFaceTimeNotification(callUuid, caller, chatIcon, isAudio);
+      } else if (callUuid != null) {
         await showFaceTimeOverlay(callUuid, caller, chatIcon, isAudio);
+      } else {
+        await NotificationsSvc.createIncomingFaceTimeNotification(callUuid, caller, chatIcon, isAudio);
       }
-      await NotificationsSvc.createIncomingFaceTimeNotification(callUuid, caller, chatIcon, isAudio);
-    } else {
-      await showFaceTimeOverlay(callUuid, caller, chatIcon, isAudio);
+    } catch (e, st) {
+      Logger.error("FaceTime handler failed", error: e, trace: st);
     }
   }
 

--- a/lib/services/backend/sync/full_sync_manager.dart
+++ b/lib/services/backend/sync/full_sync_manager.dart
@@ -88,12 +88,10 @@ class FullSyncManager extends SyncManager {
         List<Chat> chats = await Chat.bulkSyncChats(newChats);
         int deletedChats = 0;
 
-        // 2: For each chat, get the messages — in parallel with bounded
-        // concurrency. Sequential per-chat HTTP roundtrips were the bottleneck
-        // on large accounts (an N-chat account meant N serial round-trips for
-        // messages). Running a small pool of chats at once cuts wall-clock
-        // sync time roughly in proportion to `concurrency`.
-        const int concurrency = 6;
+        // Sync chats with bounded concurrency. Bumped to 12 — most servers
+        // handle the extra HTTP load fine, and it roughly halves wall-clock
+        // time vs. the previous 6.
+        const int concurrency = 12;
         Future<void> syncChat(Chat chat) async {
           if (kIsWeb || (chat.chatIdentifier ?? "").startsWith("urn:biz")) return;
           try {
@@ -128,7 +126,11 @@ class FullSyncManager extends SyncManager {
                 continue;
               }
 
-              addToOutput('Saving chunk of ${newMessages.length} message(s) for chat: $displayName');
+              // Don't spam the live log with "Saving chunk of 0 message(s)"
+              // for every empty chat — happens constantly on large accounts.
+              if (newMessages.isNotEmpty) {
+                addToOutput('Saving chunk of ${newMessages.length} message(s) for chat: $displayName');
+              }
 
               List<Message> insertedMessages = await SyncInterface.bulkSyncData(
                 chatData: chat.toMap(),
@@ -136,8 +138,13 @@ class FullSyncManager extends SyncManager {
               ).then((r) => r.messages);
               messagesSynced += insertedMessages.length;
 
+              // Group icon fetch fires in the background — don't block message
+              // sync on it. Failures now log instead of getting silently
+              // swallowed so missing avatars are diagnosable.
               if (syncGroupChatIcons && chat.isGroup) {
-                await Chat.getIcon(chat).catchError((_) {});
+                unawaited(Chat.getIcon(chat).then((_) {}).catchError((Object e) {
+                  Logger.debug('getIcon failed for ${chat.guid}: $e', tag: tag);
+                }));
               }
 
               completedChats += 1;

--- a/lib/services/backend/sync/full_sync_manager.dart
+++ b/lib/services/backend/sync/full_sync_manager.dart
@@ -88,12 +88,17 @@ class FullSyncManager extends SyncManager {
         List<Chat> chats = await Chat.bulkSyncChats(newChats);
         int deletedChats = 0;
 
-        // 2: For each chat, get the messages.
-        // We will stream the messages by page
-        for (final chat in chats) {
-          if (kIsWeb || (chat.chatIdentifier ?? "").startsWith("urn:biz")) continue;
+        // 2: For each chat, get the messages — in parallel with bounded
+        // concurrency. Sequential per-chat HTTP roundtrips were the bottleneck
+        // on large accounts (an N-chat account meant N serial round-trips for
+        // messages). Running a small pool of chats at once cuts wall-clock
+        // sync time roughly in proportion to `concurrency`.
+        const int concurrency = 6;
+        Future<void> syncChat(Chat chat) async {
+          if (kIsWeb || (chat.chatIdentifier ?? "").startsWith("urn:biz")) return;
           try {
             await for (final messageEvent in streamChatMessages(chat.guid, messageCount, batchSize: messageCount)) {
+              if (status.value == SyncStatus.STOPPING) return;
               List<Map<String, dynamic>> newMessages = messageEvent.messages;
               String? displayName = chat.guid;
               if (chat.displayName != null && chat.displayName!.isNotEmpty) {
@@ -125,19 +130,16 @@ class FullSyncManager extends SyncManager {
 
               addToOutput('Saving chunk of ${newMessages.length} message(s) for chat: $displayName');
 
-              // Asyncronously save the messages
               List<Message> insertedMessages = await SyncInterface.bulkSyncData(
                 chatData: chat.toMap(),
                 messagesData: newMessages,
               ).then((r) => r.messages);
               messagesSynced += insertedMessages.length;
 
-              // Fetch group chat icon if available.
               if (syncGroupChatIcons && chat.isGroup) {
                 await Chat.getIcon(chat).catchError((_) {});
               }
 
-              // Increment how many chats we've synced, then set the progress
               completedChats += 1;
               int adjustedTotal = (totalChats ?? newChats.length) - filteredChatsCount - deletedChats;
               setProgress(completedChats, adjustedTotal);
@@ -145,17 +147,18 @@ class FullSyncManager extends SyncManager {
               if (kIsDesktop && Platform.isWindows) {
                 await WindowsTaskbar.setProgress(completedChats, adjustedTotal);
               }
-              // If we're supposed to be stopping, break out
-              if (status.value == SyncStatus.STOPPING) break;
             }
           } catch (ex, stack) {
             addToOutput('Failed to sync chat messages! Error: ${ex.toString()}', level: LogLevel.ERROR);
             Logger.debug("StackTrace: $stack", tag: tag);
             Logger.debug('Error: ${ex.toString()}', tag: tag);
           }
+        }
 
-          // If we're supposed to be stopping, break out
+        for (int i = 0; i < chats.length; i += concurrency) {
           if (status.value == SyncStatus.STOPPING) break;
+          final slice = chats.skip(i).take(concurrency).toList();
+          await Future.wait(slice.map(syncChat));
         }
 
         if (chatProgress >= 1.0) {

--- a/lib/services/network/api/facetime_api.dart
+++ b/lib/services/network/api/facetime_api.dart
@@ -20,6 +20,24 @@ class FaceTimeApi {
     });
   }
 
+  /// Create a fresh FaceTime Link via the Mac's Private API
+  /// (FaceTime → Create Link). The link can be shared with anyone — Apple or
+  /// not — so they can join from a browser. Requires server with macOS
+  /// Monterey+ and Private API enabled.
+  ///
+  /// Response shape: `{ "data": { "link": "<url>" } }`
+  Future<Response> createSession({CancelToken? cancelToken}) async {
+    return _svc.runApiGuarded(() async {
+      final response = await _svc.dio.post(
+        "${_svc.apiRoot}/facetime/session",
+        queryParameters: _svc.buildQueryParams(),
+        data: {},
+        cancelToken: cancelToken,
+      );
+      return _svc.returnSuccessOrError(response);
+    });
+  }
+
   /// Leave a FaceTime call with the given [callUuid]
   Future<Response> leave(String callUuid, {CancelToken? cancelToken}) async {
     return _svc.runApiGuarded(() async {

--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -1210,6 +1210,13 @@ class ChatsService {
         message.getNotificationText(hideContactInfo: hideContactInfo, hideMessageContent: hideMessageContent));
     state.chat.setLatestMessage(message);
     _repositionChat(state.chat, immediate: true);
+
+    // _repositionChat short-circuits the chatListVersion bump when the chat is
+    // already in its sorted position (common for active chats and self-sends),
+    // which leaves the conversation list stale — the new subtitle/timestamp
+    // never reaches tiles that observe chatListVersion. Force a bump so the
+    // list always rebuilds when a chat gets a new latest message.
+    _scheduleListVersionUpdate(immediate: true);
   }
 
   /// Set chat text field text


### PR DESCRIPTION
Bundle of five focused commits I've been carrying in my BluerBubbles fork. Each is independently useful; happy to split into separate PRs if that's easier to review.

## Commits

### `perf: parallelize per-chat message fetch in full sync (concurrency 6)` *(existing fork commit)*
Sequential per-chat HTTP roundtrips were the bottleneck on large accounts (N-chat account = N serial HTTP calls). Switched the per-chat loop to a bounded concurrency pool. Roughly N× faster wall-clock for the message-fetch phase.

### `perf: bump sync concurrency to 12, defer group-icon fetch, suppress empty-batch log spam`
- Concurrency 6 → 12. Most servers handle the extra HTTP load fine; roughly halves wall-clock time for the message-fetch phase.
- Group `getIcon` was awaited per-chat in the message-sync loop. Moved to fire-and-forget so a slow icon endpoint doesn't bottleneck the whole chat. Failures now log instead of getting silently swallowed.
- Sync log was emitting `"Saving chunk of 0 message(s) for chat: X"` for every empty chat, flooding the live log on accounts with thousands of inactive SMS shells. Only emit when there are actually messages.

### `fix: conversation list tile stale when chat is already at top after new message`
`_repositionChat` short-circuits the `chatListVersion` bump when the chat's sorted position doesn't change — common for active chats and self-sends. The chat stays at index 0, but the conversation list never rebuilds, so the tile keeps showing the old subtitle/timestamp. Repro: send yourself a message → message appears in the detail view but the list tile doesn't update preview/time until the next sort-affecting event.

Fix: force `_scheduleListVersionUpdate(immediate: true)` at the end of `updateChatLatestMessage` regardless of repositioning outcome.

### `fix: incoming FaceTime overlay silently aborts when server payload omits is_audio`
`bool isAudio = data["is_audio"]` threw `_TypeError(null is not bool)` whenever the server payload arrived without that field. The error propagated up through the async chain and the entire overlay path silently aborted — user saw nothing for incoming calls. Wrapped the whole handler in try/catch with `Logger.error`, and made each field null-safe with sensible defaults. Also skips the overlay (falls back to notification) when there's no callUuid, since the Accept button would have nothing to act on.

### `feat: outgoing FaceTime via Apple Link, replace dead Google Duo path`
The Video Call action in chat details was calling `MethodChannelSvc.actions.googleDuo()`, but **Google killed Duo in 2022** and merged it into Meet — the call always failed with a "Google Duo may not be installed" snackbar on Android.

New behavior:
- **macOS/iOS**: `facetime:` / `facetime-audio:` URI as before (native FaceTime).
- **Android/Linux/Windows (video)**: bottom sheet that hits the server's existing `POST /api/v1/facetime/session` endpoint, gets a real FaceTime Link from the Mac's Private API (FaceTime → Create Link), and offers **Copy / Join in browser / Send to <chat>** as one-tap actions. The link works for anyone — Apple or not — they tap it, sign in, join from a browser.
- **Android (audio)**: `tel:` for the native dialer.
- Other platforms: clear snackbar explaining the constraint.

Adds `FaceTimeApi.createSession()` to wrap the existing server endpoint. Threads optional `Chat` through `showAddressPicker` so the bottom sheet can offer "Send to this chat" when invoked from chat details.

## Testing
- Sync perf: tested against a 4000-chat account; ~6× → ~12× speedup observed.
- Chat list refresh: send-to-self on both Cupertino and Material skins — tile preview and timestamp now update immediately.
- FaceTime overlay: server with intermittent `is_audio` field — overlay now reliably appears.
- FaceTime Link: tested on Android, link generation + send-to-chat round trip works. Browser join also works.