### PR TITLE
fix: linux desktop dies on isolate startup (SettingsSvc race + objectbox attach)

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -144,16 +144,20 @@ class Database {
       }
 
       Logger.info("Opening ObjectBox store from path: ${objectBoxDirectory.path}");
-      store = await openStore(directory: objectBoxDirectory.path);
+      if (Store.isOpen(objectBoxDirectory.path)) {
+        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
+      } else {
+        store = await openStore(directory: objectBoxDirectory.path);
+      }
     } catch (e) {
-      if (Platform.isLinux) {
+      if (e.toString().contains("another store is still open using the same path")) {
+        Logger.debug("Intra-process double-open; attaching to existing store");
+        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
+      } else if (Platform.isLinux) {
         Logger.debug("Another instance is probably running. Sending foreground signal");
         final instanceFile = File(join(FilesystemSvc.appDocDir.path, '.instance'));
         instanceFile.openSync(mode: FileMode.write).closeSync();
         exit(0);
-      } else if (Platform.isWindows && e.toString().contains("another store is still open using the same path")) {
-        Logger.debug("Retrying to attach to an existing ObjectBox store");
-        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
       }
     }
   }

--- a/lib/services/backend/settings/settings_service.dart
+++ b/lib/services/backend/settings/settings_service.dart
@@ -80,13 +80,17 @@ class SettingsService {
     // launch at startup - defer this so it doesn't block startup
     if (kIsDesktop) {
       Future.microtask(() async {
-        if (Platform.isWindows) {
-          try {
-            _canAuthenticate = await LocalAuthentication().isDeviceSupported();
-          } catch (_) {}
+        try {
+          if (Platform.isWindows) {
+            try {
+              _canAuthenticate = await LocalAuthentication().isDeviceSupported();
+            } catch (_) {}
+          }
+          SettingsSvc.settings.launchAtStartup.value = await setupLaunchAtStartup(
+              SettingsSvc.settings.launchAtStartup.value, SettingsSvc.settings.launchAtStartupMinimized.value);
+        } catch (_) {
+          // Best-effort: spawned isolates may have SettingsSvc unregistered.
         }
-        SettingsSvc.settings.launchAtStartup.value = await setupLaunchAtStartup(
-            SettingsSvc.settings.launchAtStartup.value, SettingsSvc.settings.launchAtStartupMinimized.value);
       });
     }
 


### PR DESCRIPTION
two things together kill the linux desktop on startup.

settings_service kicks off a fire and forget microtask that touches SettingsSvc again. on spawned isolates that races teardown and throws "Bad state: SettingsService not ready yet". unhandled so the GlobalIsolate dies in a tight loop and you see hundreds of "Failed to fetch message chunk" lines. wrapped the microtask in try/catch since setupLaunchAtStartup is best effort anyway.

_initDatabaseDesktop catches openStore failures and calls exit(0) on linux assuming a second process owns the lmdb lock. but a spawned isolate inside the same process can hit "another store is still open using the same path" which is intra process. should attach not die. mobile already handles this. now desktop checks the error string first and uses Store.attach for intra process, only exits on the actual second instance case.