### PR TITLE
fix: facetime overlay silent abort + outgoing call via apple link instead of dead duo

### DIFF
--- a/lib/app/layouts/conversation_details/dialogs/address_picker.dart
+++ b/lib/app/layouts/conversation_details/dialogs/address_picker.dart
@@ -1,41 +1,182 @@
+import 'dart:io' show Platform;
+
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-void launchIntent(bool video, String address) async {
-  if (address.contains("@")) {
-    launchUrl(Uri(scheme: "mailto", path: address));
-  } else if (await Permission.phone.request().isGranted) {
-    if (video) {
-      try {
-        await MethodChannelSvc.actions.googleDuo(number: address);
-      } catch (_) {
-        showSnackbar("Error", "Something went wrong, Google Duo may not be installed!");
-      }
-    } else {
-      launchUrl(Uri(scheme: "tel", path: address));
+void launchIntent(bool video, String address, {BuildContext? context, Chat? chat}) async {
+  final bool isApple = !kIsWeb && (Platform.isMacOS || Platform.isIOS);
+  final bool isAndroid = !kIsWeb && Platform.isAndroid;
+
+  if (address.contains("@") && !video) {
+    await launchUrl(Uri(scheme: "mailto", path: address));
+    return;
+  }
+
+  if (video) {
+    if (isApple) {
+      final ok = await launchUrl(Uri(scheme: "facetime", path: address));
+      if (!ok) showSnackbar("Error", "Couldn't launch FaceTime for $address");
+      return;
+    }
+    if (context != null && context.mounted) {
+      showFaceTimeLinkSheet(context, chat: chat);
+      return;
+    }
+    showSnackbar("FaceTime unavailable", "Tap Video Call from a chat to get the FaceTime Link option.");
+    return;
+  }
+
+  if (isApple) {
+    await launchUrl(Uri(scheme: "facetime-audio", path: address));
+    return;
+  }
+  if (isAndroid) {
+    if (await Permission.phone.request().isGranted) {
+      await launchUrl(Uri(scheme: "tel", path: address));
+    }
+    return;
+  }
+  showSnackbar("Calls unavailable", "Outgoing calls require an Apple device or an Android phone.");
+}
+
+void showFaceTimeLinkSheet(BuildContext context, {Chat? chat}) {
+  String? link;
+  Object? error;
+  bool loading = true;
+
+  Future<void> sendInChat() async {
+    if (chat == null || link == null) return;
+    try {
+      final message = Message(
+        text: link!,
+        dateCreated: DateTime.now(),
+        hasAttachments: false,
+        isFromMe: true,
+        handleId: 0,
+      );
+      message.generateTempGuid();
+      await OutgoingMsgHandler.sendMessage(chat, message, null, null);
+      if (!context.mounted) return;
+      Navigator.of(context).pop();
+      showSnackbar('Sent', 'FaceTime link sent to ${chat.getTitle()}');
+    } catch (e) {
+      showSnackbar('Send failed', e.toString());
     }
   }
+
+  showModalBottomSheet(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (sheetCtx) {
+      return StatefulBuilder(
+        builder: (sheetCtx, setSheetState) {
+          if (loading && link == null && error == null) {
+            HttpSvc.faceTime.createSession().then((resp) {
+              link = resp.data?["data"]?["link"] as String?;
+              error = link == null ? (resp.data?["error"]?["message"] ?? 'No link in response') : null;
+              loading = false;
+              if (sheetCtx.mounted) setSheetState(() {});
+            }).catchError((e) {
+              error = e;
+              loading = false;
+              if (sheetCtx.mounted) setSheetState(() {});
+            });
+          }
+
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('FaceTime Link', style: sheetCtx.theme.textTheme.titleLarge),
+                  const SizedBox(height: 8),
+                  if (loading)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 24),
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  else if (error != null)
+                    Text(
+                      "Couldn't create a FaceTime link.\n"
+                      "Requires BB Server with macOS Monterey+ and Private API enabled.\n\n$error",
+                      style: sheetCtx.theme.textTheme.bodyMedium?.copyWith(color: sheetCtx.theme.colorScheme.error),
+                    )
+                  else ...[
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: sheetCtx.theme.colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: SelectableText(link!, style: sheetCtx.theme.textTheme.bodySmall),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(children: [
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          icon: const Icon(Icons.copy),
+                          label: const Text('Copy'),
+                          onPressed: () async {
+                            await Clipboard.setData(ClipboardData(text: link!));
+                            showSnackbar('Copied', 'FaceTime link copied');
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: FilledButton.icon(
+                          icon: const Icon(Icons.open_in_new),
+                          label: const Text('Join in browser'),
+                          onPressed: () => launchUrl(Uri.parse(link!), mode: LaunchMode.externalApplication),
+                        ),
+                      ),
+                    ]),
+                    if (chat != null) ...[
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton.icon(
+                          icon: const Icon(Icons.send),
+                          label: Text('Send to ${chat.getTitle()}'),
+                          onPressed: sendInChat,
+                        ),
+                      ),
+                    ],
+                  ],
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
 }
 
 void showAddressPicker(ContactV2? contact, Handle handle, BuildContext context,
-    {bool isEmail = false, bool video = false, bool isLongPressed = false}) async {
+    {bool isEmail = false, bool video = false, bool isLongPressed = false, Chat? chat}) async {
   if (contact == null) {
-    launchIntent(video, handle.address);
+    launchIntent(video, handle.address, context: context, chat: chat);
   } else {
     List<String> items = isEmail
         ? getUniqueEmails(contact.emailAddresses.map((e) => e.address))
         : getUniqueNumbers(contact.phoneNumbers.map((p) => p.number));
     if (items.length == 1) {
-      launchIntent(video, items.first);
+      launchIntent(video, items.first, context: context, chat: chat);
     } else if (!isEmail && handle.defaultPhone != null && !isLongPressed) {
-      launchIntent(video, handle.defaultPhone!);
+      launchIntent(video, handle.defaultPhone!, context: context, chat: chat);
     } else if (isEmail && handle.defaultEmail != null && !isLongPressed) {
-      launchIntent(video, handle.defaultEmail!);
+      launchIntent(video, handle.defaultEmail!, context: context, chat: chat);
     } else {
       showDialog(
         context: context,
@@ -66,7 +207,7 @@ void showAddressPicker(ContactV2? contact, Handle handle, BuildContext context,
                               handle.updateDefaultPhone(items[i]);
                             }
                           }
-                          launchIntent(video, items[i]);
+                          launchIntent(video, items[i], context: context, chat: chat);
                           Navigator.of(context).pop();
                         },
                       ),

--- a/lib/app/layouts/conversation_details/widgets/chat_info.dart
+++ b/lib/app/layouts/conversation_details/widgets/chat_info.dart
@@ -500,11 +500,11 @@ class VideoCallButton extends StatelessWidget {
         child: InkWell(
           onTap: () {
             final contact = chat.handles.first.contactsV2.firstOrNull;
-            showAddressPicker(contact, chat.handles.first, context, video: true);
+            showAddressPicker(contact, chat.handles.first, context, video: true, chat: chat);
           },
           onLongPress: () {
             final contact = chat.handles.first.contactsV2.firstOrNull;
-            showAddressPicker(contact, chat.handles.first, context, isLongPressed: true, video: true);
+            showAddressPicker(contact, chat.handles.first, context, isLongPressed: true, video: true, chat: chat);
           },
           borderRadius: BorderRadius.circular(15),
           child: SizedBox(

--- a/lib/services/backend/action_handler.dart
+++ b/lib/services/backend/action_handler.dart
@@ -39,28 +39,34 @@ class ActionHandler extends GetxService {
   }
 
   Future<void> handleIncomingFaceTimeCall(Map<String, dynamic> data) async {
-    Logger.info("Handling incoming FaceTime call");
-    final callUuid = data["uuid"];
-    String? address = data["handle"]?["address"];
-    String caller = data["address"] ?? "Unknown Number";
-    bool isAudio = data["is_audio"];
-    Uint8List? chatIcon;
+    try {
+      Logger.info("Handling incoming FaceTime call");
+      final String? callUuid = data["uuid"] as String?;
+      final String? address = data["handle"] is Map ? (data["handle"]["address"] as String?) : null;
+      String caller = (data["address"] as String?) ?? address ?? "Unknown Number";
+      final bool isAudio = (data["is_audio"] as bool?) ?? false;
+      Uint8List? chatIcon;
 
-    if (address != null) {
-      ContactV2? contact = await ContactsSvcV2.getContact(address);
-      if (contact?.avatarPath != null) {
-        chatIcon = await ContactsSvcV2.getContactAvatar(contact!.nativeContactId);
+      if (address != null) {
+        ContactV2? contact = await ContactsSvcV2.getContact(address);
+        if (contact?.avatarPath != null) {
+          chatIcon = await ContactsSvcV2.getContactAvatar(contact!.nativeContactId);
+        }
+        caller = contact?.displayName ?? caller;
       }
-      caller = contact?.displayName ?? caller;
-    }
 
-    if (!LifecycleSvc.isAlive) {
-      if (kIsDesktop) {
+      if (!LifecycleSvc.isAlive) {
+        if (kIsDesktop && callUuid != null) {
+          await showFaceTimeOverlay(callUuid, caller, chatIcon, isAudio);
+        }
+        await NotificationsSvc.createIncomingFaceTimeNotification(callUuid, caller, chatIcon, isAudio);
+      } else if (callUuid != null) {
         await showFaceTimeOverlay(callUuid, caller, chatIcon, isAudio);
+      } else {
+        await NotificationsSvc.createIncomingFaceTimeNotification(callUuid, caller, chatIcon, isAudio);
       }
-      await NotificationsSvc.createIncomingFaceTimeNotification(callUuid, caller, chatIcon, isAudio);
-    } else {
-      await showFaceTimeOverlay(callUuid, caller, chatIcon, isAudio);
+    } catch (e, st) {
+      Logger.error("FaceTime handler failed", error: e, trace: st);
     }
   }
 

--- a/lib/services/network/api/facetime_api.dart
+++ b/lib/services/network/api/facetime_api.dart
@@ -20,6 +20,18 @@ class FaceTimeApi {
     });
   }
 
+  Future<Response> createSession({CancelToken? cancelToken}) async {
+    return _svc.runApiGuarded(() async {
+      final response = await _svc.dio.post(
+        "${_svc.apiRoot}/facetime/session",
+        queryParameters: _svc.buildQueryParams(),
+        data: {},
+        cancelToken: cancelToken,
+      );
+      return _svc.returnSuccessOrError(response);
+    });
+  }
+
   /// Leave a FaceTime call with the given [callUuid]
   Future<Response> leave(String callUuid, {CancelToken? cancelToken}) async {
     return _svc.runApiGuarded(() async {


### PR DESCRIPTION
two facetime issues.

incoming overlay never appears when the server payload omits is_audio. handleIncomingFaceTimeCall does `bool isAudio = data["is_audio"]` which throws _TypeError on null and silently aborts the whole flow, so user sees nothing for a real incoming call. wrapped the handler in try/catch with logging and made the fields null safe. also fall back to a notification if there's no callUuid since the overlay's accept button would have nothing to act on.

outgoing video call from android still tries MethodChannelSvc.actions.googleDuo. google killed duo in 2022 (merged into meet) so it just snackbars "google duo may not be installed". on apple platforms use the facetime: and facetime-audio: schemes which the os handles natively. on android/linux/windows show a bottom sheet that hits the existing /api/v1/facetime/session endpoint, gets a real facetime link from the mac, and gives copy / join in browser / send to chat. anyone can tap a facetime link to join, apple or not. wires up createSession() on FaceTimeApi (server endpoint is already there).