### PR TITLE
fix: attachment downloads crash with NoSuchMethodError on server 500 + heic decoding

### DIFF
--- a/lib/services/network/api/attachment_api.dart
+++ b/lib/services/network/api/attachment_api.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:bluebubbles/services/network/api/base_api.dart';
 import 'package:dio/dio.dart';
 import 'package:universal_io/io.dart';
@@ -42,17 +44,27 @@ class AttachmentApi {
         onReceiveProgress: onReceiveProgress,
       );
 
-      // dio doesn't throw on non-2xx when ResponseType.stream is set, so the
-      // error body comes back as a parsed Map. Bail out before we try to
-      // iterate `response.data.stream` and crash with NoSuchMethodError.
+      // dio doesn't throw on non-2xx when ResponseType.stream is set. Read the
+      // error body (it's a ResponseBody stream of bytes, not the parsed JSON)
+      // so callers can see what the server actually said.
       if (savePath != null && response.statusCode != 200) {
+        dynamic body = response.data;
+        try {
+          if (body is ResponseBody) {
+            final chunks = <int>[];
+            await for (final c in body.stream) {
+              chunks.addAll(c);
+            }
+            body = utf8.decode(chunks, allowMalformed: true);
+          }
+        } catch (_) {}
         return Response(
           requestOptions: response.requestOptions,
           statusCode: response.statusCode,
           statusMessage: response.statusMessage,
           headers: response.headers,
           extra: response.extra,
-          data: response.data,
+          data: body,
         );
       }
 

--- a/lib/services/network/api/attachment_api.dart
+++ b/lib/services/network/api/attachment_api.dart
@@ -42,6 +42,20 @@ class AttachmentApi {
         onReceiveProgress: onReceiveProgress,
       );
 
+      // dio doesn't throw on non-2xx when ResponseType.stream is set, so the
+      // error body comes back as a parsed Map. Bail out before we try to
+      // iterate `response.data.stream` and crash with NoSuchMethodError.
+      if (savePath != null && response.statusCode != 200) {
+        return Response(
+          requestOptions: response.requestOptions,
+          statusCode: response.statusCode,
+          statusMessage: response.statusMessage,
+          headers: response.headers,
+          extra: response.extra,
+          data: response.data,
+        );
+      }
+
       // If savePath provided, write stream directly to file
       if (savePath != null && response.data != null) {
         final file = File(savePath);

--- a/lib/services/network/downloads_service.dart
+++ b/lib/services/network/downloads_service.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/services/network/heif_converter.dart';
 import 'package:bluebubbles/utils/file_utils.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -196,30 +197,54 @@ class AttachmentDownloadController extends GetxController {
     // For web, download to memory. For native platforms, write directly to disk
     final savePath = kIsWeb ? null : attachment.path;
 
-    var response = await HttpSvc.attachment
-        .download(
-      attachment.guid!,
-      savePath: savePath,
-      onReceiveProgress: (count, total) => setProgress(kIsWeb ? (count / total) : (count / attachment.totalBytes!)),
-    )
-        .catchError((err) async {
-      if (!kIsWeb && savePath != null) {
-        File file = File(savePath);
-        if (await file.exists()) {
-          await file.delete();
-        }
+    final bool isHeif = !kIsWeb && HeifConverter.isHeif(attachment.mimeType, filename: attachment.transferName);
+
+    Future<Response> attemptDownload({required bool original}) async {
+      try {
+        return await HttpSvc.attachment.download(
+          attachment.guid!,
+          savePath: savePath,
+          original: original,
+          onReceiveProgress: (count, total) => setProgress(kIsWeb ? (count / total) : (count / attachment.totalBytes!)),
+        );
+      } on DioException catch (e) {
+        if (e.response != null) return e.response!;
+        rethrow;
       }
-      for (Function f in errorFuncs) {
+    }
+
+    Response response;
+    try {
+      response = await attemptDownload(original: isHeif);
+      // sips on the server 500s on HEIC Live Photos / depth / HDR. Retry with the raw bytes.
+      if (response.statusCode == 500 && !isHeif && !kIsWeb && savePath != null) {
+        Logger.warn("Converted preview 500'd for ${attachment.guid}; retrying original=true");
+        response = await attemptDownload(original: true);
+      }
+    } catch (err) {
+      Logger.error("Attachment ${attachment.guid} download failed", error: err);
+      if (!kIsWeb && savePath != null) {
+        final f = File(savePath);
+        if (await f.exists()) await f.delete();
+      }
+      for (final f in errorFuncs) {
         f.call();
       }
-
       state.value = AttachmentDownloadState.error;
       AttachmentDownloader._removeFromQueue(this);
-      return Response(requestOptions: RequestOptions(path: ''));
-    });
+      return;
+    }
 
-    Logger.info("Finished downloading attachment");
-    if (response.statusCode != 200) return;
+    if (response.statusCode != 200) {
+      Logger.warn("Attachment ${attachment.guid} non-200: ${response.statusCode}");
+      for (final f in errorFuncs) {
+        f.call();
+      }
+      state.value = AttachmentDownloadState.error;
+      AttachmentDownloader._removeFromQueue(this);
+      return;
+    }
+    Logger.info("Finished downloading attachment ${attachment.guid}");
 
     attachment.webUrl = response.requestOptions.path;
     stopwatch.stop();
@@ -245,6 +270,15 @@ class AttachmentDownloadController extends GetxController {
         final fileBytes = await File(savePath).readAsBytes();
         final optimizedBytes = await fixSpeedyGifs(fileBytes);
         await File(savePath).writeAsBytes(optimizedBytes);
+      }
+      if (isHeif && savePath != null) {
+        final converted = await HeifConverter.convertInPlace(savePath);
+        if (converted != null) {
+          attachment.mimeType = "image/jpeg";
+          if (attachment.transferName != null) {
+            attachment.transferName = "${attachment.transferName!.split('.').first}.jpg";
+          }
+        }
       }
     }
 

--- a/lib/services/network/downloads_service.dart
+++ b/lib/services/network/downloads_service.dart
@@ -236,7 +236,7 @@ class AttachmentDownloadController extends GetxController {
     }
 
     if (response.statusCode != 200) {
-      Logger.warn("Attachment ${attachment.guid} non-200: ${response.statusCode}");
+      Logger.warn("Attachment ${attachment.guid} non-200: ${response.statusCode} body=${response.data}");
       for (final f in errorFuncs) {
         f.call();
       }

--- a/lib/services/network/heif_converter.dart
+++ b/lib/services/network/heif_converter.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:bluebubbles/utils/logger/logger.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart' as fic;
+import 'package:path/path.dart' as p;
+
+class HeifConverter {
+  static const _heifMimes = {'image/heic', 'image/heif', 'image/heic-sequence', 'image/heif-sequence'};
+  static const _heifExts = {'heic', 'heif', 'hif'};
+
+  static bool isHeif(String? mimeType, {String? filename}) {
+    if (mimeType != null && _heifMimes.contains(mimeType.toLowerCase())) return true;
+    if (filename != null && filename.contains('.')) {
+      return _heifExts.contains(filename.split('.').last.toLowerCase());
+    }
+    return false;
+  }
+
+  static Future<String?> convertInPlace(String sourcePath) async {
+    final src = File(sourcePath);
+    if (!await src.exists()) return null;
+
+    final dest = _swapExt(sourcePath, 'jpg');
+    bool ok = false;
+    try {
+      if (Platform.isAndroid || Platform.isIOS) {
+        ok = await _convertMobile(sourcePath, dest);
+      } else if (Platform.isLinux) {
+        ok = await _convertLinux(sourcePath, dest);
+      } else if (Platform.isMacOS) {
+        ok = await _convertMacOS(sourcePath, dest);
+      }
+    } catch (e, st) {
+      Logger.error('HEIF decode threw', error: e, trace: st);
+      return null;
+    }
+
+    if (!ok) return null;
+
+    try {
+      await src.delete();
+      await File(dest).rename(sourcePath);
+      return sourcePath;
+    } catch (_) {
+      return dest;
+    }
+  }
+
+  static Future<bool> _convertMobile(String src, String dest) async {
+    final bytes = await fic.FlutterImageCompress.compressWithFile(src, format: fic.CompressFormat.jpeg, quality: 92);
+    if (bytes == null || bytes.isEmpty) return false;
+    await File(dest).writeAsBytes(bytes);
+    return true;
+  }
+
+  static Future<bool> _convertLinux(String src, String dest) async {
+    for (final cmd in const [
+      ['heif-convert', '-q', '92'],
+      ['magick'],
+      ['convert'],
+    ]) {
+      if (!await _hasBinary(cmd.first)) continue;
+      final res = await Process.run(cmd.first, [...cmd.skip(1), src, dest]);
+      if (res.exitCode == 0 && await File(dest).exists() && await File(dest).length() > 0) return true;
+    }
+    Logger.warn('No HEIF decoder on PATH (install libheif-tools or imagemagick)');
+    return false;
+  }
+
+  static Future<bool> _convertMacOS(String src, String dest) async {
+    if (await _hasBinary('sips')) {
+      final res = await Process.run('sips', ['-s', 'format', 'jpeg', src, '--out', dest]);
+      if (res.exitCode == 0 && await File(dest).exists() && await File(dest).length() > 0) return true;
+    }
+    if (await _hasBinary('heif-convert')) {
+      final res = await Process.run('heif-convert', ['-q', '92', src, dest]);
+      if (res.exitCode == 0 && await File(dest).exists() && await File(dest).length() > 0) return true;
+    }
+    return false;
+  }
+
+  static final Map<String, bool> _binaryCache = {};
+  static Future<bool> _hasBinary(String name) async {
+    if (_binaryCache.containsKey(name)) return _binaryCache[name]!;
+    try {
+      final r = await Process.run('sh', ['-c', 'command -v $name']);
+      final ok = r.exitCode == 0 && (r.stdout as String).trim().isNotEmpty;
+      _binaryCache[name] = ok;
+      return ok;
+    } catch (_) {
+      _binaryCache[name] = false;
+      return false;
+    }
+  }
+
+  static String _swapExt(String path, String newExt) {
+    return p.join(p.dirname(path), '${p.basenameWithoutExtension(path)}.$newExt');
+  }
+}


### PR DESCRIPTION
three related attachment download fixes.

biggest one: when the server returns non 200 on /attachment/:guid/download, dio doesn't throw because we use ResponseType.stream. our code then does `response.data.stream` and the data is actually the parsed error map, so it blows up with `NoSuchMethodError: Class '_Map' has no instance getter 'stream'`. that crash bubbles out before any retry or error logging can run. now we check statusCode != 200 before consuming the stream and return the response cleanly. also read the error body so callers can see what the server actually said (was previously "Instance of 'ResponseBody'").

second: server's converted preview path (?original=false) returns 500 on some heic variants like live photos, depth maps, hdr, icloud placeholders. retry once with ?original=true to grab raw bytes.

third: heic decoded client side so we can actually show the image. flutter's Image widget can't decode heic on linux/android/windows (only ios via uikit). new HeifConverter wraps platform decoders: heif-convert or imagemagick on linux, sips or heif-convert on macos, flutter_image_compress on android/ios. detect heic by mime or filename extension since the server's mime guessing is inconsistent. after download we replace the cached file with jpeg and update the attachment record.