### PR TITLE
fix: conversation list tile stale when chat already at top after new message

### DIFF
--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -1210,6 +1210,7 @@ class ChatsService {
         message.getNotificationText(hideContactInfo: hideContactInfo, hideMessageContent: hideMessageContent));
     state.chat.setLatestMessage(message);
     _repositionChat(state.chat, immediate: true);
+    _scheduleListVersionUpdate(immediate: true);
   }
 
   /// Set chat text field text


### PR DESCRIPTION
send yourself a message and watch the detail view update while the chat list tile keeps the old subtitle and timestamp. happens because _repositionChat short circuits the chatListVersion bump when the chat is already in its sorted slot (which it is for the active chat, self sends, anything pinned at the top).

force a _scheduleListVersionUpdate(immediate: true) at the end of updateChatLatestMessage regardless of whether reposition moved anything. one line.