### PR TITLE
feat: cross-device clipboard sync via BB server

### DIFF
--- a/lib/app/layouts/settings/pages/advanced/clipboard_sync_panel.dart
+++ b/lib/app/layouts/settings/pages/advanced/clipboard_sync_panel.dart
@@ -1,0 +1,82 @@
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class ClipboardSyncPanel extends StatefulWidget {
+  const ClipboardSyncPanel({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _ClipboardSyncPanelState();
+}
+
+class _ClipboardSyncPanelState extends State<ClipboardSyncPanel> with ThemeHelpers {
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: "Clipboard Sync",
+      initialHeader: "Clipboard Sync",
+      iosSubtitle: iosSubtitle,
+      materialSubtitle: materialSubtitle,
+      tileColor: tileColor,
+      headerColor: headerColor,
+      bodySlivers: [
+        SliverList(
+          delegate: SliverChildListDelegate(
+            <Widget>[
+              SettingsSection(
+                backgroundColor: tileColor,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8.0, left: 15, top: 8.0, right: 15),
+                    child: RichText(
+                      text: TextSpan(
+                        style: context.theme.textTheme.bodyMedium,
+                        children: const [
+                          TextSpan(
+                            text: "Keeps your clipboard in sync across all connected devices via your "
+                                "BlueBubbles server.\n\n",
+                          ),
+                          TextSpan(
+                            text: "iPhone↔Mac sync is handled automatically by Apple Universal Clipboard. "
+                                "This setting enables Windows↔Mac sync over your existing server connection. "
+                                "iOS devices receive only — they do not send.",
+                            style: TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Obx(
+                    () => SettingsSwitch(
+                      onChanged: (bool val) async {
+                        ss.settings.enableClipboardSync.value = val;
+                        await ss.settings.saveOne('enableClipboardSync');
+                        if (val) {
+                          ClipboardSyncSvc.start();
+                        } else {
+                          ClipboardSyncSvc.stop();
+                        }
+                      },
+                      initialVal: ss.settings.enableClipboardSync.value,
+                      title: "Enable Clipboard Sync",
+                      subtitle: "Sync clipboard text between this device and your Mac server",
+                      backgroundColor: tileColor,
+                      leading: const SettingsLeadingIcon(
+                        iosIcon: CupertinoIcons.doc_on_clipboard,
+                        materialIcon: Icons.content_paste,
+                        containerColor: Colors.teal,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/settings/settings_page.dart
+++ b/lib/app/layouts/settings/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/advanced/clipboard_sync_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/advanced/notification_providers_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/advanced/tasker_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/profile/profile_panel.dart';
@@ -569,6 +570,24 @@ class _SettingsPageState extends OptimizedState<SettingsPage> {
                                           iosIcon: CupertinoIcons.bell,
                                           materialIcon: Icons.notifications,
                                           containerColor: Colors.green)),
+                                  const SettingsDivider(),
+                                  if (!kIsWeb && (Platform.isWindows || Platform.isMacOS))
+                                    SettingsTile(
+                                        backgroundColor: tileColor,
+                                        title: "Clipboard Sync",
+                                        trailing: const NextButton(),
+                                        onTap: () async {
+                                          ns.pushAndRemoveSettingsUntil(
+                                            context,
+                                            const ClipboardSyncPanel(),
+                                            (route) => route.isFirst,
+                                          );
+                                        },
+                                        leading: const SettingsLeadingIcon(
+                                          iosIcon: CupertinoIcons.doc_on_clipboard,
+                                          materialIcon: Icons.content_paste,
+                                          containerColor: Colors.teal,
+                                        )),
                                   const SettingsDivider(),
                                   SettingsTile(
                                       backgroundColor: tileColor,

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -178,6 +178,8 @@ class Settings {
   // Windows settings
   final RxBool useWindowsAccent = RxBool(false);
 
+  final RxBool enableClipboardSync = false.obs;
+
   Future<DisplayMode> getDisplayMode() async {
     List<DisplayMode> modes = await FlutterDisplayMode.supported;
     return modes.firstWhereOrNull((element) => element.refreshRate.round() == refreshRate.value) ?? DisplayMode.auto;
@@ -366,6 +368,7 @@ class Settings {
       'hideNamesForReactions': hideNamesForReactions.value,
       'replaceEmoticonsWithEmoji': replaceEmoticonsWithEmoji.value,
       'lastReviewRequestTimestamp': lastReviewRequestTimestamp.value,
+      'enableClipboardSync': enableClipboardSync.value,
     };
     if (includeAll) {
       map.addAll({
@@ -648,6 +651,7 @@ class Settings {
     s.hideNamesForReactions.value = map['hideNamesForReactions'] ?? false;
     s.replaceEmoticonsWithEmoji.value = map['replaceEmoticonsWithEmoji'] ?? false;
     s.lastReviewRequestTimestamp.value = map['lastReviewRequestTimestamp'] ?? 0;
+    s.enableClipboardSync.value = map['enableClipboardSync'] ?? false;
     return s;
   }
 

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -63,6 +63,7 @@ class StartupTasks {
 
     await notif.init();
     await intents.init();
+    ClipboardSyncSvc.start();
   }
 
   static Future<void> initIsolateServices() async {

--- a/lib/services/backend/action_handler.dart
+++ b/lib/services/backend/action_handler.dart
@@ -522,6 +522,9 @@ class ActionHandler extends GetxService {
         Logger.info("Alias(es) removed ${data["aliases"]}");
         await notif.createAliasesRemovedNotification((data["aliases"] as List).cast<String>());
         return;
+      case "clipboard-sync":
+        await ClipboardSyncSvc.handleIncoming(data);
+        return;
       default:
         return;
     }

--- a/lib/services/backend/clipboard_sync_service.dart
+++ b/lib/services/backend/clipboard_sync_service.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/utils/logger/logger.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+import 'package:universal_io/io.dart';
+
+// ignore: non_constant_identifier_names
+ClipboardSyncService get ClipboardSyncSvc => Get.isRegistered<ClipboardSyncService>()
+    ? Get.find<ClipboardSyncService>()
+    : Get.put(ClipboardSyncService());
+
+/// Syncs the system clipboard across all connected devices via the BB server.
+///
+/// The Mac server is the hub: it polls its own clipboard (which picks up iPhone
+/// changes via Apple Universal Clipboard) and broadcasts the clipboard-sync
+/// socket event to all clients. Clients write the incoming content locally and,
+/// on platforms where clipboard reading is unrestricted, also send their own
+/// changes back to the server.
+///
+/// iOS receives only — Universal Clipboard handles the iPhone→Mac direction.
+class ClipboardSyncService extends GetxService {
+  static const String _tag = "ClipboardSyncService";
+  static const Duration _pollInterval = Duration(milliseconds: 1000);
+
+  Timer? _pollTimer;
+  String _lastKnown = "";
+  // Tracks what we last wrote so we don't echo it back to the server.
+  String _lastWritten = "";
+
+  // iOS cannot silently poll the clipboard (shows a system banner), so we only
+  // receive on iOS. All other platforms send + receive.
+  bool get _canSend => !kIsWeb && !(Platform.isIOS);
+
+  void start() {
+    if (!ss.settings.enableClipboardSync.value) return;
+    if (_pollTimer != null) return;
+    if (!_canSend) return;
+
+    _pollTimer = Timer.periodic(_pollInterval, (_) => _poll());
+    Logger.info("Clipboard sync started", tag: _tag);
+  }
+
+  void stop() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  /// Called by the action handler when the server broadcasts a clipboard change.
+  Future<void> handleIncoming(Map<String, dynamic> data) async {
+    final content = data['content'];
+    if (content == null || content is! String || content.isEmpty) return;
+    if (content == _lastKnown) return;
+
+    _lastWritten = content;
+    _lastKnown = content;
+    await Clipboard.setData(ClipboardData(text: content));
+    Logger.info("Clipboard updated from remote", tag: _tag);
+  }
+
+  Future<void> _poll() async {
+    if (!ss.settings.enableClipboardSync.value) return;
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      final current = data?.text ?? "";
+      if (current.isEmpty || current == _lastKnown) return;
+      _lastKnown = current;
+      if (current == _lastWritten) return;
+
+      socket.socket.emit("clipboard-sync", {"content": current});
+      Logger.info("Clipboard sent to server", tag: _tag);
+    } catch (e) {
+      Logger.warn("Clipboard poll failed: $e", tag: _tag);
+    }
+  }
+}

--- a/lib/services/network/socket_service.dart
+++ b/lib/services/network/socket_service.dart
@@ -95,6 +95,7 @@ class SocketService extends GetxService {
     socket.on("typing-indicator", (data) => ah.handleEvent("typing-indicator", data, 'DartSocket'));
     socket.on("chat-read-status-changed", (data) => ah.handleEvent("chat-read-status-changed", data, 'DartSocket'));
     socket.on("imessage-aliases-removed", (data) => ah.handleEvent("imessage-aliases-removed", data, 'DartSocket'));
+    socket.on("clipboard-sync", (data) => ah.handleEvent("clipboard-sync", data, 'DartSocket'));
 
     socket.connect();
   }

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -6,6 +6,7 @@ export 'backend/lifecycle/lifecycle_service.dart';
 export 'backend/notifications/notifications_service.dart';
 export 'backend/queue/incoming_queue.dart';
 export 'backend/queue/outgoing_queue.dart';
+export 'backend/clipboard_sync_service.dart';
 export 'backend/settings/settings_service.dart';
 export 'backend/setup/setup_service.dart';
 export 'backend/sync/full_sync_manager.dart';


### PR DESCRIPTION
## Summary

- Adds a `ClipboardSyncService` that polls the local clipboard every second and sends changes to the BlueBubbles server via a `clipboard-sync` socket event
- Receives `clipboard-sync` events from the server and writes the content to the local clipboard (iOS receives only — Universal Clipboard handles iPhone↔Mac)
- Adds a **Clipboard Sync** settings panel (Advanced section, desktop-only) with an enable/disable toggle

## How it works

The Mac server is the hub. It polls its own clipboard (which picks up iPhone changes via Apple Universal Clipboard) and broadcasts `clipboard-sync` to all connected clients. Windows and Mac clients also send their local clipboard changes back to the server. iOS receives only.

## Test plan

- [ ] Enable Clipboard Sync in Settings → Advanced → Clipboard Sync on a connected desktop client
- [ ] Copy text on Mac server machine — confirm it appears on the client clipboard
- [ ] Copy text on Windows/Mac client — confirm it appears on the server clipboard
- [ ] Disable the toggle — confirm polling stops and no more sync events are sent
- [ ] iOS: confirm no system clipboard-access banner appears (receive-only, no polling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)