### PR TITLE
fix: prevent Android startup crash from malformed server URL (#2845)

### DIFF
--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/foreground/SocketIOForegroundService.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/foreground/SocketIOForegroundService.kt
@@ -19,6 +19,7 @@ import com.bluebubbles.messaging.services.backend_ui_interop.DartWorkManager
 import com.bluebubbles.messaging.utils.PersistentLog
 import io.socket.client.IO
 import io.socket.client.Socket
+import java.net.URI
 import java.net.URISyntaxException
 import java.net.URLEncoder
 import org.json.JSONObject
@@ -119,7 +120,8 @@ class SocketIOForegroundService : Service() {
             }
 
             // Initialize socket.io connection
-            PersistentLog.d(applicationContext, Constants.logTag, "Foreground Service is connecting to: $serverUrl")
+            // Do not log serverUrl — it may contain credentials in query parameters.
+            PersistentLog.d(applicationContext, Constants.logTag, "Foreground Service is connecting to server")
 
             val opts = IO.Options()
 
@@ -136,9 +138,22 @@ class SocketIOForegroundService : Service() {
                 PersistentLog.e(applicationContext, Constants.logTag, "Failed to parse custom headers JSON string!", e)
             }
 
-            // Only log the headers if they are not null or empty
+            // Only log the header keys (not values) to avoid leaking auth tokens or API keys.
             if (opts.extraHeaders != null && opts.extraHeaders.isNotEmpty()) {
-                PersistentLog.d(applicationContext, Constants.logTag, "Socket.io Custom headers: ${opts.extraHeaders}")
+                PersistentLog.d(applicationContext, Constants.logTag, "Socket.io Custom header keys: ${opts.extraHeaders!!.keys.joinToString(", ")}")
+            }
+
+            // Validate the URL before passing it to socket.io.
+            // socket.io's Java URLDecoder throws IllegalArgumentException in a background
+            // thread if the URL contains bare % characters (e.g. %s%), which crashes the
+            // process and permanently prevents the app from launching (GitHub issue #2845).
+            try {
+                URI(serverUrl)
+            } catch (e: URISyntaxException) {
+                // Do not log serverUrl — it may contain credentials in query parameters.
+                PersistentLog.e(applicationContext, Constants.logTag, "Server URL stored in preferences is malformed", e)
+                updateNotification(MISSING_SERVER_URL)
+                return
             }
 
             val encodedPw = URLEncoder.encode(storedPassword, "UTF-8")
@@ -153,7 +168,7 @@ class SocketIOForegroundService : Service() {
 
             mSocket!!.on(Socket.EVENT_CONNECT_ERROR) { args ->
                 val error = args[0] as Exception
-                PersistentLog.d(applicationContext, Constants.logTag, "Socket.io failed to connect to $serverUrl! Error: ${error.message}")
+                PersistentLog.d(applicationContext, Constants.logTag, "Socket.io failed to connect to server! Error: ${error.message}")
                 updateNotification(CONNECT_FAILED + error.message)
             }
 


### PR DESCRIPTION
## Summary

Fixes a permanent startup crash on Android (issue #2845). If the stored server URL contains bare `%` characters (e.g. `%s%`), socket.io's Java `URLDecoder` throws `IllegalArgumentException` on a background thread outside any try/catch in `SocketIOForegroundService`, crashing the process. Because the foreground service starts on every launch when `keepAppAlive` is enabled, the app then crashes on *every* startup and can only be recovered by clearing app data.

**Fix:** validate `serverUrl` with `java.net.URI()` (synchronous, no I/O) before handing it to `IO.socket()`; a `URISyntaxException` updates the notification to "missing server URL" and returns gracefully.

**Logging hardening (same code path):** the server URL is no longer written to logcat (connect + connect-error lines), and only custom-header *keys* are logged, never their values — both could leak credentials.

## Scope note

This PR was originally bundled with an ObjectBox store-corruption recovery path. Per @zlshames' question below, I've **pulled that out** — I haven't personally reproduced a store corruption (it was inferred from issue reports), so guarding against it is speculative. I'll revisit it in a **separate PR** only if I can produce a concrete repro. Rebased onto `development` to clear the conflict.

## Test plan

- [ ] **Malformed URL (#2845):** set `serverAddress` to `http://192.168.1.1:1234/%s%test`, launch → foreground service logs "Server URL stored in preferences is malformed", notification updates, no crash.
- [ ] **Normal startup:** valid server URL → connects as before.
