### PR TITLE
feat: add Giphy GIF provider with selectable provider and in-app API keys

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/text_field/text_field_icon_bar.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/text_field_icon_bar.dart
@@ -13,6 +13,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
+import 'package:giphy_get/giphy_get.dart' as giphy;
 import 'package:tenor_flutter/tenor_flutter.dart';
 import 'package:universal_io/io.dart';
 
@@ -134,94 +135,7 @@ class TextFieldIconBar extends StatelessWidget {
         if (!kIsWeb && !Platform.isAndroid)
           IconButton(
               icon: Icon(Icons.gif, color: context.theme.colorScheme.outline, size: 28),
-              onPressed: () async {
-                if (kIsDesktop || kIsWeb) {
-                  controller.showingOverlays = true;
-                }
-                Tenor tenor = Tenor(apiKey: kIsWeb ? TENOR_API_KEY : dotenv.get('TENOR_API_KEY'));
-                TextEditingController tenorController = TextEditingController();
-                FocusNode focus = FocusNode();
-                Future<TenorResult?> resultFuture = tenor.showAsBottomSheet(
-                  maxExtent: 0.8,
-                  minExtent: 0.5,
-                  debounce: const Duration(seconds: 1),
-                  context: context,
-                  searchFieldController: tenorController,
-                  // Copied and slightly modified from source, just so I can autofocus
-                  searchFieldWidget: Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        TextField(
-                          focusNode: focus,
-                          controller: tenorController,
-                          decoration: InputDecoration(
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(8),
-                              borderSide: const BorderSide(
-                                width: 0,
-                                style: BorderStyle.none,
-                              ),
-                            ),
-                            contentPadding: const EdgeInsets.fromLTRB(28, 5, 32, 7),
-                            filled: true,
-                            hintStyle: const TenorSearchFieldStyle().hintStyle,
-                            hintText: "Search Tenor",
-                            isCollapsed: true,
-                            isDense: true,
-                          ),
-                          style: context.theme.textTheme.bodyMedium!,
-                        ),
-                        const Positioned(
-                          left: 4,
-                          child: Icon(
-                            Icons.search,
-                            color: Color(0xFF8A8A86),
-                            size: 22,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  style: TenorStyle(
-                    color: context.theme.colorScheme.surfaceContainerHighest,
-                    attributionStyle: TenorAttributionStyle(brightnes: context.theme.brightness),
-                    tabBarStyle: TenorTabBarStyle(
-                      decoration: BoxDecoration(
-                          color: context.theme.colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(8)),
-                      indicator: BoxDecoration(
-                        color: context.theme.colorScheme.primary,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      labelColor: context.theme.colorScheme.onSurface,
-                      unselectedLabelColor: context.theme.colorScheme.onSurface.withValues(alpha: 0.5),
-                    ),
-                  ),
-                );
-                focus.requestFocus();
-                TenorResult? result = await resultFuture;
-                if (kIsDesktop || kIsWeb) {
-                  controller.showingOverlays = false;
-                }
-                final selectedGif = result?.media.tinyGif ?? result?.media.tinyGifTransparent;
-                if (result != null && selectedGif != null) {
-                  final response = await HttpSvc.downloadFromUrl(selectedGif.url);
-                  if (response.statusCode == 200) {
-                    try {
-                      final Uint8List data = response.data;
-                      controller.pickedAttachments.add(PlatformFile(
-                        path: null,
-                        name: "${result.id}.gif",
-                        size: data.length,
-                        bytes: data,
-                      ));
-                      return;
-                    } catch (_) {}
-                  }
-                }
-              }),
+              onPressed: () => _onGifTapped(context)),
         if (kIsDesktop || kIsWeb)
           IconButton(
             icon: Icon(_iOS ? CupertinoIcons.smiley_fill : Icons.emoji_emotions,
@@ -241,5 +155,159 @@ class TextFieldIconBar extends StatelessWidget {
           ),
       ],
     );
+  }
+
+  // ---------- GIF picker ----------
+
+  String _resolveTenorKey() {
+    final override = SettingsSvc.settings.tenorApiKeyOverride.value.trim();
+    if (override.isNotEmpty) return override;
+    try {
+      return kIsWeb ? TENOR_API_KEY : (dotenv.maybeGet('TENOR_API_KEY') ?? '');
+    } catch (_) {
+      return '';
+    }
+  }
+
+  String _resolveGiphyKey() {
+    final override = SettingsSvc.settings.giphyApiKeyOverride.value.trim();
+    if (override.isNotEmpty) return override;
+    try {
+      return kIsWeb ? '' : (dotenv.maybeGet('GIPHY_API_KEY') ?? '');
+    } catch (_) {
+      return '';
+    }
+  }
+
+  Future<void> _onGifTapped(BuildContext context) async {
+    const validProviders = ['tenor', 'giphy', 'none'];
+    final raw = SettingsSvc.settings.gifProvider.value;
+    final provider = validProviders.contains(raw) ? raw : 'tenor';
+    if (provider == 'none') {
+      showSnackbar('GIF picker disabled',
+          'The GIF picker is turned off in settings. Enable Tenor or Giphy under Settings → Conversations → GIF Picker.');
+      return;
+    }
+    final apiKey = provider == 'tenor' ? _resolveTenorKey() : _resolveGiphyKey();
+    if (apiKey.isEmpty) {
+      final providerName = provider == 'tenor' ? 'Tenor' : 'Giphy';
+      showSnackbar(
+        'GIF picker unavailable',
+        'No $providerName API key is configured. Add one under Settings → Conversations → GIF Picker.',
+      );
+      return;
+    }
+    if (kIsDesktop || kIsWeb) {
+      controller.showingOverlays = true;
+    }
+    try {
+      ({String id, Uint8List bytes})? picked;
+      if (provider == 'tenor') {
+        picked = await _pickTenorGif(context, apiKey);
+      } else {
+        picked = await _pickGiphyGif(context, apiKey);
+      }
+      if (picked != null) {
+        controller.pickedAttachments.add(PlatformFile(
+          path: null,
+          name: "${picked.id}.gif",
+          size: picked.bytes.length,
+          bytes: picked.bytes,
+        ));
+      }
+    } finally {
+      if (kIsDesktop || kIsWeb) {
+        controller.showingOverlays = false;
+      }
+    }
+  }
+
+  Future<({String id, Uint8List bytes})?> _pickTenorGif(BuildContext context, String apiKey) async {
+    final tenor = Tenor(apiKey: apiKey);
+    final searchController = TextEditingController();
+    final focus = FocusNode();
+    final resultFuture = tenor.showAsBottomSheet(
+      maxExtent: 0.8,
+      minExtent: 0.5,
+      debounce: const Duration(seconds: 1),
+      context: context,
+      searchFieldController: searchController,
+      searchFieldWidget: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            TextField(
+              focusNode: focus,
+              controller: searchController,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(width: 0, style: BorderStyle.none),
+                ),
+                contentPadding: const EdgeInsets.fromLTRB(28, 5, 32, 7),
+                filled: true,
+                hintStyle: const TenorSearchFieldStyle().hintStyle,
+                hintText: "Search Tenor",
+                isCollapsed: true,
+                isDense: true,
+              ),
+              style: context.theme.textTheme.bodyMedium!,
+            ),
+            const Positioned(
+              left: 4,
+              child: Icon(Icons.search, color: Color(0xFF8A8A86), size: 22),
+            ),
+          ],
+        ),
+      ),
+      style: TenorStyle(
+        color: context.theme.colorScheme.surfaceContainerHighest,
+        attributionStyle: TenorAttributionStyle(brightnes: context.theme.brightness),
+        tabBarStyle: TenorTabBarStyle(
+          decoration: BoxDecoration(
+              color: context.theme.colorScheme.surfaceContainerHighest, borderRadius: BorderRadius.circular(8)),
+          indicator: BoxDecoration(
+            color: context.theme.colorScheme.primary,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          labelColor: context.theme.colorScheme.onSurface,
+          unselectedLabelColor: context.theme.colorScheme.onSurface.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+    focus.requestFocus();
+    final result = await resultFuture;
+    final selectedGif = result?.media.tinyGif ?? result?.media.tinyGifTransparent;
+    if (result == null || selectedGif == null) return null;
+    final response = await HttpSvc.downloadFromUrl(selectedGif.url);
+    if (response.statusCode != 200) return null;
+    try {
+      return (id: result.id, bytes: response.data as Uint8List);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<({String id, Uint8List bytes})?> _pickGiphyGif(BuildContext context, String apiKey) async {
+    final result = await giphy.GiphyGet.getGif(
+      context: context,
+      apiKey: apiKey,
+      lang: giphy.GiphyLanguage.english,
+      tabColor: context.theme.colorScheme.primary,
+    );
+    if (result == null) return null;
+    final url = result.images?.downsized?.url ??
+        result.images?.fixedHeightSmall?.url ??
+        result.images?.fixedHeight?.url ??
+        result.images?.original?.url;
+    if (url == null || url.isEmpty) return null;
+    final response = await HttpSvc.downloadFromUrl(url);
+    if (response.statusCode != 200) return null;
+    try {
+      return (id: result.id ?? 'giphy', bytes: response.data as Uint8List);
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/lib/app/layouts/settings/dialogs/api_key_dialog.dart
+++ b/lib/app/layouts/settings/dialogs/api_key_dialog.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Prompts the user for an API key. Returns the trimmed string on save,
+/// an empty string on clear, or `null` if dismissed without saving.
+Future<String?> showApiKeyDialog(
+  BuildContext context, {
+  required String title,
+  required String currentValue,
+  String? helperText,
+  Uri? signupUrl,
+}) async {
+  final controller = TextEditingController(text: currentValue);
+  final obscure = true.obs;
+  return await showDialog<String?>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title, style: context.theme.textTheme.titleLarge),
+      backgroundColor: context.theme.colorScheme.surfaceContainerHighest,
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (helperText != null) ...[
+              Text(helperText, style: context.theme.textTheme.bodyMedium),
+              const SizedBox(height: 12),
+            ],
+            Obx(() => TextField(
+                  controller: controller,
+                  obscureText: obscure.value,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  inputFormatters: [
+                    FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                  ],
+                  decoration: InputDecoration(
+                    labelText: "API Key",
+                    border: const OutlineInputBorder(),
+                    suffixIcon: IconButton(
+                      icon: Icon(obscure.value ? Icons.visibility : Icons.visibility_off),
+                      onPressed: () => obscure.value = !obscure.value,
+                    ),
+                  ),
+                )),
+            if (signupUrl != null) ...[
+              const SizedBox(height: 8),
+              TextButton.icon(
+                icon: const Icon(Icons.open_in_new, size: 16),
+                label: const Text("Get a key"),
+                onPressed: () => launchUrl(signupUrl),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        if (currentValue.isNotEmpty)
+          TextButton(
+            child: Text("Clear", style: TextStyle(color: context.theme.colorScheme.error)),
+            onPressed: () => Navigator.of(context).pop(""),
+          ),
+        TextButton(
+          child: Text("Cancel", style: context.theme.textTheme.bodyLarge),
+          onPressed: () => Navigator.of(context).pop(null),
+        ),
+        TextButton(
+          child: Text("Save", style: context.theme.textTheme.bodyLarge),
+          onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/app/layouts/settings/pages/message_view/conversation_panel.dart
+++ b/lib/app/layouts/settings/pages/message_view/conversation_panel.dart
@@ -1,4 +1,5 @@
 import 'package:audio_waveforms/audio_waveforms.dart' as aw;
+import 'package:bluebubbles/app/layouts/settings/dialogs/api_key_dialog.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/message_view/message_options_order_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/content/next_button.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -29,6 +30,14 @@ class _ConversationPanelState extends State<ConversationPanel> with ThemeHelpers
 
   bool sendPrepared = false;
   bool receivePrepared = false;
+
+  String get _normalizedGifProvider {
+    const valid = ["tenor", "giphy", "none"];
+    final v = SettingsSvc.settings.gifProvider.value;
+    return valid.contains(v) ? v : "tenor";
+  }
+
+  String _tail(String s) => s.length <= 4 ? s : s.substring(s.length - 4);
 
   @override
   void initState() {
@@ -474,6 +483,76 @@ class _ConversationPanelState extends State<ConversationPanel> with ThemeHelpers
                         title: "Scroll To Bottom When Sending Messages",
                         subtitle: "Scroll to the most recent messages in the chat when sending a new text",
                         backgroundColor: tileColor,
+                      )),
+                ],
+              ),
+              SettingsHeader(
+                iosSubtitle: iosSubtitle,
+                materialSubtitle: materialSubtitle,
+                text: "GIF Picker",
+              ),
+              SettingsSection(
+                backgroundColor: tileColor,
+                children: [
+                  Obx(() => SettingsOptions<String>(
+                        title: "Provider",
+                        subtitle: "Choose which GIF service the composer uses, or disable the picker.",
+                        initial: _normalizedGifProvider,
+                        options: const ["tenor", "giphy", "none"],
+                        textProcessing: (v) => switch (v) {
+                          "tenor" => "Tenor",
+                          "giphy" => "Giphy",
+                          _ => "Off",
+                        },
+                        onChanged: (val) async {
+                          if (val == null) return;
+                          SettingsSvc.settings.gifProvider.value = val;
+                          await SettingsSvc.settings.saveOneAsync('gifProvider');
+                        },
+                      )),
+                  const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                  Obx(() => SettingsTile(
+                        title: "Tenor API Key",
+                        subtitle: SettingsSvc.settings.tenorApiKeyOverride.value.isEmpty
+                            ? "Not set — falls back to the build-time key, if any. Tap to add."
+                            : "Custom key set (••••${_tail(SettingsSvc.settings.tenorApiKeyOverride.value)})",
+                        leading: const SettingsLeadingIcon(iosIcon: CupertinoIcons.gift, materialIcon: Icons.gif_box),
+                        trailing: const NextButton(),
+                        onTap: () async {
+                          final result = await showApiKeyDialog(
+                            context,
+                            title: "Tenor API Key",
+                            currentValue: SettingsSvc.settings.tenorApiKeyOverride.value,
+                            helperText:
+                                "Used when the GIF provider is Tenor. Leave blank to use the build-time key bundled with the app.",
+                            signupUrl: Uri.parse("https://developers.google.com/tenor/guides/quickstart"),
+                          );
+                          if (result == null) return;
+                          SettingsSvc.settings.tenorApiKeyOverride.value = result;
+                          await SettingsSvc.settings.saveOneAsync('tenorApiKeyOverride');
+                        },
+                      )),
+                  const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                  Obx(() => SettingsTile(
+                        title: "Giphy API Key",
+                        subtitle: SettingsSvc.settings.giphyApiKeyOverride.value.isEmpty
+                            ? "Required for Giphy. Tap to add. Free at developers.giphy.com."
+                            : "Custom key set (••••${_tail(SettingsSvc.settings.giphyApiKeyOverride.value)})",
+                        leading: const SettingsLeadingIcon(iosIcon: CupertinoIcons.gift, materialIcon: Icons.gif),
+                        trailing: const NextButton(),
+                        onTap: () async {
+                          final result = await showApiKeyDialog(
+                            context,
+                            title: "Giphy API Key",
+                            currentValue: SettingsSvc.settings.giphyApiKeyOverride.value,
+                            helperText:
+                                "Required when the GIF provider is Giphy. Get a free key at developers.giphy.com.",
+                            signupUrl: Uri.parse("https://developers.giphy.com/dashboard/"),
+                          );
+                          if (result == null) return;
+                          SettingsSvc.settings.giphyApiKeyOverride.value = result;
+                          await SettingsSvc.settings.saveOneAsync('giphyApiKeyOverride');
+                        },
                       )),
                 ],
               ),

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -123,6 +123,12 @@ class Settings {
   final RxBool enableQuickTapback = false.obs;
   final RxString quickTapbackType = ReactionTypes.toList()[0].obs; // The 'love' reaction
 
+  // GIF picker settings
+  /// "tenor" | "giphy" | "none"
+  final RxString gifProvider = "tenor".obs;
+  final RxString tenorApiKeyOverride = "".obs;
+  final RxString giphyApiKeyOverride = "".obs;
+
   // Notification reaction settings
   final RxBool notificationReactionAction = true.obs;
   final RxString notificationReactionActionType = ReactionTypes.LIKE.obs; // Default to 'like'
@@ -369,6 +375,9 @@ class Settings {
       'generateFakeMessageContent': hideMessageContent.value,
       'enableQuickTapback': enableQuickTapback.value,
       'quickTapbackType': quickTapbackType.value,
+      'gifProvider': gifProvider.value,
+      'tenorApiKeyOverride': tenorApiKeyOverride.value,
+      'giphyApiKeyOverride': giphyApiKeyOverride.value,
       'notificationReactionAction': notificationReactionAction.value,
       'notificationReactionActionType': notificationReactionActionType.value,
       'materialRightAction': materialRightAction.value.index,
@@ -580,6 +589,12 @@ class Settings {
         map['enableQuickTapback'] ?? SettingsSvc.settings.enableQuickTapback.value;
     SettingsSvc.settings.quickTapbackType.value =
         map['quickTapbackType'] ?? SettingsSvc.settings.quickTapbackType.value;
+    SettingsSvc.settings.gifProvider.value =
+        map['gifProvider'] ?? SettingsSvc.settings.gifProvider.value;
+    SettingsSvc.settings.tenorApiKeyOverride.value =
+        map['tenorApiKeyOverride'] ?? SettingsSvc.settings.tenorApiKeyOverride.value;
+    SettingsSvc.settings.giphyApiKeyOverride.value =
+        map['giphyApiKeyOverride'] ?? SettingsSvc.settings.giphyApiKeyOverride.value;
     SettingsSvc.settings.notificationReactionAction.value =
         map['notificationReactionAction'] ?? SettingsSvc.settings.notificationReactionAction.value;
     SettingsSvc.settings.notificationReactionActionType.value =
@@ -764,6 +779,9 @@ class Settings {
     s.endpointUnifiedPush.value = map['endpointUnifiedPush'] ?? "";
     s.enableQuickTapback.value = map['enableQuickTapback'] ?? false;
     s.quickTapbackType.value = map['quickTapbackType'] ?? ReactionTypes.toList()[0];
+    s.gifProvider.value = map['gifProvider'] ?? "tenor";
+    s.tenorApiKeyOverride.value = map['tenorApiKeyOverride'] ?? "";
+    s.giphyApiKeyOverride.value = map['giphyApiKeyOverride'] ?? "";
     s.notificationReactionAction.value = map['notificationReactionAction'] ?? true;
     s.notificationReactionActionType.value = map['notificationReactionActionType'] ?? ReactionTypes.LIKE;
     s.materialRightAction.value = map['materialRightAction'] != null

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1026,6 +1026,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_map:
     dependency: "direct main"
     description:
@@ -1230,6 +1235,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.1"
+  giphy_get:
+    dependency: "direct main"
+    description:
+      name: giphy_get
+      sha256: "2762b2343b78da19248b6aa3302097a51eecd65584c495b5184a8e4ae0a1efc7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.1+1"
   git:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -95,6 +95,7 @@ dependencies:
       ref: d63342cb17976f60bd94e7c1a822398115d3f83c
   get: ^4.7.2
   github: ^9.25.0
+  giphy_get: ^3.6.1+1
   google_fonts: ^8.0.2
   google_ml_kit: ^0.21.0 # mobile only
   google_mlkit_smart_reply: ^0.13.0


### PR DESCRIPTION
## Problem
GIF search is hardcoded to Tenor and depends on a build-time `TENOR_API_KEY`. Users building from source — or who prefer Giphy — can't choose a provider or supply their own key without rebuilding.

## Solution
- New `gifProvider` setting (`"tenor" | "giphy" | "none"`, defaults to `"tenor"` — existing behavior unchanged)
- New `tenorApiKeyOverride` / `giphyApiKeyOverride` settings to paste your own keys at runtime (falls back to the compiled-in key when blank)
- New **GIF Picker** section in Settings → Message View to choose the provider and manage keys
- New `showApiKeyDialog()` with obscured input + provider sign-up link
- The text-field GIF button routes to Tenor or Giphy based on the selection
- Adds `giphy_get: ^3.6.1+1`

No changes to existing Tenor behavior when defaults are kept.

## Testing
Built and manually tested on Windows desktop:
- Switching the GIF provider between Tenor and Giphy
- Entering and clearing API keys via the new dialog
- Searching and inserting GIFs from both providers

## Screenshots
_N/A — happy to add on request._
