### PR TITLE
fix(socket): stop Windows reachability poller from tearing down healthy sockets

### DIFF
--- a/lib/services/network/socket_service.dart
+++ b/lib/services/network/socket_service.dart
@@ -159,7 +159,9 @@ class SocketService {
         customCheckOptions: [
           InternetCheckOption(
             uri: Uri.parse(serverAddress),
-            timeout: const Duration(seconds: 3),
+            // 3s is too aggressive for a busy LAN server — a single slow probe
+            // would falsely report "no internet". 5s tolerates normal jitter.
+            timeout: const Duration(seconds: 5),
             responseStatusFn: (_) => true,
           ),
         ],
@@ -170,8 +172,16 @@ class SocketService {
       internetConnectionListener = internetConnection!.onStatusChange.listen((InternetStatus status) {
         Logger.info("Internet status changed: $status");
         if (status == InternetStatus.disconnected) {
-          handleStatusUpdate(SocketState.error, null);
-        } else if (state.value == SocketState.error) {
+          // A single failed reachability probe must NOT tear down a live
+          // websocket. socket.io already detects real drops via
+          // onDisconnect/onConnectError; forcing SocketState.error here on every
+          // transient LAN/probe timeout manufactures a restart loop (the cause
+          // of repeated disconnects on the home network). Only escalate if the
+          // socket truly isn't connected.
+          if (socket?.connected != true && state.value != SocketState.connected) {
+            handleStatusUpdate(SocketState.error, null);
+          }
+        } else if (state.value == SocketState.error && socket?.connected != true) {
           Logger.info("Internet reconnected, restarting socket...");
           restartSocket();
         }


### PR DESCRIPTION
## Problem

On Windows desktop, the client repeatedly loses its connection — most noticeably on a local network. Logs from an affected install show `Internet reconnected, restarting socket...` firing **hundreds of times** on a steady ~33s interval, with the socket disconnecting far more often from the LAN address than from the remote URL. The network never actually drops.

## Root cause

In `lib/services/network/socket_service.dart`, the Windows-only `InternetConnection` (internet_connection_checker_plus) poller probes `serverAddress` every few seconds with a 3s timeout. On a `disconnected` result it called `handleStatusUpdate(SocketState.error, null)` — forcing the state to `error` **even when the websocket was still connected**. The next successful probe then saw `error` and ran a full `restartSocket()`.

So a single slow/timed-out probe (easy to hit on a LAN with a 3s timeout) manufactured its own disconnect→restart cycle, independent of the real socket health. socket.io already has its own reconnection plus the `_handleReconnectFailed`/`_reconnectTimer` backoff, so the poller was both redundant and actively destructive here.

## Fix

- Only escalate to `SocketState.error` when the socket isn't actually connected (`socket?.connected != true && state.value != connected`).
- Only `restartSocket()` on recovery when the socket is genuinely down.
- Bump the probe timeout 3s → 5s to tolerate normal LAN jitter.

The poller's original intent (detecting genuine Windows disconnects, where `onConnectivityChanged` is unreliable) is preserved — socket.io's `onDisconnect`/`onConnectError` still handle real drops.

## Testing

- Confirmed `Socket.connected` is a public property in the pinned `socket_io_client` 3.1.4.
- Minimal, logic-only change; no new imports.
- Easy to validate at runtime: on an affected Windows install, `Internet reconnected, restarting socket...` should drop from hundreds of occurrences to near zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)