### PR TITLE
fix: notification sender bugs + opt-in starred-contact DND bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,176 @@
+# BlueBubbles — Community Fork (v2.0.0+85)
+
+> **This is an unofficial community fork** of [BlueBubblesApp/bluebubbles-app](https://github.com/BlueBubblesApp/bluebubbles-app) based on **v2.0.0+85 (beta 8)**. It adds two feature tracks and fixes several bugs found in that release. It is not affiliated with or endorsed by the BlueBubbles project.
+
+---
+
+## What This Fork Adds
+
+### Feature 1: Per-Contact Do Not Disturb Bypass via Android Starred Contacts
+
+The stock app adds the entire BlueBubbles notification channel to the DND override list — meaning *every* incoming message bypasses Do Not Disturb, which defeats the purpose of DND entirely.
+
+This fork changes that. Instead of granting the whole app DND immunity, it uses Android's native **"Starred contacts can interrupt"** DND rule. Contacts you have marked as **Favorites** in your Android contacts app (the star in Google Contacts, the Favorites list in Samsung Contacts) can ring through DND. Everyone else respects it.
+
+**How it works (technical summary):**
+
+- The global `com.bluebubbles.new_messages` notification channel no longer calls `setBypassDnd(true)`.
+- On each incoming message, Android's `ContactsContract` is queried for the sender's contact row. If the contact is starred (`STARRED = 1`), the notification's `Person` object is built with `setUri(lookupUri)` and `setImportant(true)`. Android's DND system sees this URI, verifies the contact is starred, and lets the notification through.
+- Non-starred contacts get a `Person` with no URI and no importance flag — they respect DND normally.
+- Legacy per-conversation notification channels (`bb-chat-*`) are cleaned up on first launch; they can otherwise linger in system notification settings.
+- The feature is user-controlled via **Settings → Application Settings → Notification Settings → Override DND for Favorites** (default: off). When off, no contact lookup is performed and all contacts respect DND normally.
+
+**Required Android setup:**
+
+1. Enable **Override DND for Favorites** in the app under Settings → Application Settings → Notification Settings.
+2. Open **Settings → Notifications → Do Not Disturb → Allowed during DND**.
+3. Enable **"Starred contacts"** (label varies by Android version/manufacturer).
+4. In your contacts app, star/favorite the contacts you want to reach you during DND.
+5. Do **not** add BlueBubbles to the "Apps" override list — that would bypass DND for all messages again.
+
+**Group chats:** DND bypass is triggered by the message sender, not the group. If the sender is starred, the notification breaks through.
+
+---
+
+### Feature 2: UnifiedPush / ntfy Reliability Improvements
+
+Several latent bugs prevented push-delivered messages (via UnifiedPush providers such as ntfy) from being processed correctly, particularly in group chats and for messages with attachments.
+
+**Root cause:** Android's Gson library parses JSON values into `JsonElement` subtypes (`JsonPrimitive`, `JsonArray`, `JsonObject`). When these were passed to the Dart side via Flutter's method channel, the channel delivered `Map<Object?, Object?>` rather than `Map<String, dynamic>`. Every `.cast<String, Object>()` call in the message deserialization path was an unsafe runtime cast that would silently fail or throw on mismatched types.
+
+**Fixes applied:**
+
+- **`UnifiedPushReceiver.kt`:** Replaced Gson's JSON tree model (`Map<String, JsonElement>`) with `HashMap<String, Any?>` using `ToNumberPolicy.LONG_OR_DOUBLE`, so numbers arrive as Kotlin `Long`/`Double` instead of `JsonPrimitive` wrappers. Full exception handling added; payload size logged for debugging.
+- **`DartWorkManager.kt` / `DartWorker.kt`:** WorkManager input data is hard-capped at ~10 KB. Messages with attachments can exceed this, causing silent enqueue failures. The fork adds a file-spill mechanism: payloads under 9,000 bytes go inline; larger ones are written to a temp file in `cacheDir` and referenced by path (prefixed `@file:`). The worker reads and deletes the file on execution.
+- **`lib/utils/deep_map_normalize.dart` (new):** A pure utility that recursively normalizes any `Map` or `List` from the platform channel into canonical `Map<String, dynamic>` / `List<dynamic>` types. Used as the entry point for all incoming method channel payloads.
+- **All model `fromMap`/`fromJson` factories** (`Message`, `Chat`, `Handle`, `Attachment`, `AttributedBody`, `Run`, `MessageSummaryInfo`, `PayloadData`, `ServerPayload`): Replaced every `.cast<String, Object>()` with `asStringDynamicMapRequired()` from the normalize utility. Failures now throw a descriptive `FormatException` instead of silently producing wrong data.
+
+---
+
+### Feature 3: Reliable Handle Linking for Group Chat Notifications
+
+In the original code, a notification for an incoming group message was silently dropped if the local participant list didn't include the sender's handle. This could happen when a new participant joined, when the app was first configured, or when a sync had not yet completed.
+
+**Fixes applied:**
+
+- **`incoming_message_handler.dart`:** New `_ensureMessageHandleLinked()` post-save repair pass. After saving a message, if `handleRelation` is still unset, it attempts four escalating lookups: global DB by ROWID → chat participants by ROWID → chat participants by address+service → global DB by address+service. Group chats always refresh their participant list from the server on each incoming message from another user.
+- **`notifications_service.dart`:** New `resolveHandleForNotification()` function with a 7-step handle resolution chain. Notifications are no longer silently dropped when handle resolution fails — a fallback to the chat title is used instead, with a logged warning.
+- **`chat_actions.dart`:** Handle lookup order corrected (embedded `handle` object checked before `handleId` DB query). Two participant-pool fallback lookups added. Participant-filter loop that dropped unmatched messages is now skipped entirely for group chats. When a new handle is resolved, it is immediately persisted to the chat's participant list.
+- **`sync_actions.dart`:** Embedded `handle` maps inside message payloads are now extracted during the pre-processing pass and added to the `handlesByAddress` lookup, so bulk sync can resolve senders that were not previously seen.
+
+**Additional fix in `message_state.dart`:** A null sender on an *incoming* message now shows `'Unknown'` instead of `'You'`, preventing falsely attributing unresolved incoming messages to the local user.
+
+---
+
+## Bug Fixes (Not Feature-Related)
+
+### `SettingsHelper.kt` — SharedPreferences key prefix
+Flutter's `shared_preferences` plugin stores all values under the prefix `flutter.` in the `FlutterSharedPreferences` file. `SettingsHelper.kt` had `PREFIX = ""`, so every settings read (server URL, auth key, API timeout, Private API flags, reaction action setting) silently returned the default value. This broke the native `LikeMessage` tapback feature: `hasServerUrl()` and `hasAuthKey()` always returned `false`, so the HTTP call was never made.
+
+**Fixed:** `PREFIX = "flutter."`
+
+### `Utils.kt` — Portrait image aspect ratio crash
+`val aspectRatio = width / height` used integer division, which truncates to `0` for portrait images (e.g. `100 / 200 = 0`). `height = width / 0` then crashed at runtime. The landscape branch also had an inverted formula: `width = height / aspectRatio` (should be `height * aspectRatio` for a ratio < 1).
+
+**Fixed:** float division, both branch formulas corrected.
+
+### `method_channel_actions.dart` — Dead `channelId` parameter
+`createIncomingMessageNotification()` sent a `channel_id` argument to Kotlin that was never read (Kotlin now uses the hardcoded `PARENT_CHANNEL_ID`). The parameter and call-site argument are removed.
+
+### `messages_view.dart` — Infinite load-more loop
+When a load-more request returned an empty list, `noMoreMessages` was not set immediately, allowing the scroll handler to fire again and request another empty page indefinitely.
+
+**Fixed:** `noMoreMessages = true` when `newMessages.isEmpty`.
+
+### `message.dart` / `chat_actions.dart` — Group message sender shown as "Unknown"
+`Message.getHandle()` only checked the persisted `handleRelation` and a DB lookup — never the in-memory transient `handle` field populated from the push payload. So `toMap()` serialized `"handle": null`, `addMessageToChat` had no embedded handle object to work with, the handle relation was never set, and `notificationSenderName()` fell through to `return 'Unknown'`.
+
+An additional wrinkle: the Mac can store the same phone number in two forms (e.g. `+15551234` and `15551234` as separate handle rows). A second rapid message from the same sender can arrive with the "alternate" ROWID that hasn't been synced locally. The exact `uniqueAddressAndService` query missed it.
+
+**Fixed:**
+- `Message.getHandle()`: checks the transient `handle` field before falling back to the DB lookup, so the embedded server payload survives serialization.
+- `addMessageToChat`: after the exact `uniqueAddressAndService` lookup fails, tries the `+`/`−` prefix variant of the address. If the canonical handle (with ContactV2 linked) is found, it is used instead of creating an orphaned duplicate. When creating a truly new handle, `originalROWID` is set from the Mac ROWID carried in the `id` field.
+
+### `chat_actions.dart` / `chat_interface.dart` / `chat.dart` — Messages missing in conversation view (spinner)
+`getMessagesAsync` determined group vs. 1:1 exclusively from `participants.length > 1`. If the in-memory `Chat` object had a stale or empty handles list at the time the conversation was opened (e.g., race with the participant sync from the push handler), the filter treated the chat as a 1:1 and dropped incoming messages whose sender handle was not in the short participant list.
+
+**Fixed:** `chatStyle` is now passed through `Chat.getMessagesAsync` → `ChatInterface.getMessagesAsync` → `ChatActions.getMessagesAsync`. The group-chat gate becomes `chatStyle == 43 || participants.length > 1`, where `43` is the iMessage group style constant.
+
+### `startup_tasks.dart` — Missing `TypingIndicatorService` registration
+`TypingIndicatorService` was not registered during app startup, causing a `GetIt` lookup failure if any code path tried to use it before explicit registration elsewhere.
+
+**Fixed:** Explicit registration added to the startup task sequence.
+
+---
+
+## Changed Files
+
+| File | Change type | Description |
+|---|---|---|
+| `android/.../utils/ContactNotificationHelper.kt` | **New** | Contacts DB query + `Person` builder with starred-contact DND logic |
+| `lib/utils/deep_map_normalize.dart` | **New** | Platform channel type normalization utility |
+| `android/.../services/notifications/NotificationChannelHandler.kt` | Modified | Remove `setBypassDnd(true)`; clean up legacy `bb-chat-*` channels |
+| `android/.../services/notifications/CreateIncomingMessageNotification.kt` | Modified | Wire `nativeContactId`; fix channel to `PARENT_CHANNEL_ID`; add try/catch; conditional DND bypass gated on `dnd_favorites_override` method channel arg |
+| `android/.../services/system/PushShareTargetsHandler.kt` | Modified | Add `ContactInfo` overload to avoid duplicate contacts DB query |
+| `android/.../services/system/OpenConversationNotificationSettingsHandler.kt` | Modified | Remove per-conversation channel creation; open settings on global channel |
+| `android/.../UnifiedPushReceiver.kt` | Modified | Fix Gson type strategy; add exception handling and size logging |
+| `android/.../services/backend_ui_interop/DartWorkManager.kt` | Modified | Add file-spill for WorkManager payloads > 9 KB |
+| `android/.../services/backend_ui_interop/DartWorker.kt` | Modified | Read and delete spilled payload files |
+| `android/.../utils/SettingsHelper.kt` | Modified | Fix `PREFIX = ""` → `"flutter."` |
+| `android/.../utils/Utils.kt` | Modified | Fix portrait image aspect ratio integer division and formula |
+| `lib/services/backend/notifications/notifications_service.dart` | Modified | `nativeContactId` wiring; 7-step handle resolution; drop `channelId` param; pass `dndFavoritesOverride` setting to notification handler |
+| `lib/services/network/method_channel_actions.dart` | Modified | Add `nativeContactId`; remove `channelId`; add `dndFavoritesOverride` param forwarded to Kotlin via method channel |
+| `lib/services/backend/java_dart_interop/method_channel_handlers.dart` | Modified | Normalize incoming payloads; per-step error logging (`BB_MAP_FIX_V3`) |
+| `lib/services/backend/java_dart_interop/method_channel_service.dart` | Modified | Normalize method channel arguments via utility |
+| `lib/services/backend/incoming_message_handler.dart` | Modified | Post-save handle repair; group chat participant refresh |
+| `lib/services/backend/actions/chat_actions.dart` | Modified | Handle lookup order fix; participant fallbacks; group message filter skip |
+| `lib/services/backend/actions/sync_actions.dart` | Modified | Extract embedded handles during bulk sync pre-processing |
+| `lib/database/global/server_payload.dart` | Modified | `asStringDynamicMapRequired` + `deepNormalizeJson` in `data` setter |
+| `lib/database/global/attributed_body.dart` | Modified | Replace `.cast` with `asStringDynamicMapRequired` throughout |
+| `lib/database/global/message_summary_info.dart` | Modified | Replace `.cast` with `asStringDynamicMapRequired` throughout |
+| `lib/database/global/payload_data.dart` | Modified | Replace `.cast` with `asStringDynamicMapRequired` throughout |
+| `lib/database/io/message.dart` | Modified | Normalize all nested maps; fix `metadata` nullability; `getHandle()` checks transient `handle` field before DB lookup |
+| `lib/database/io/chat.dart` | Modified | Replace `.cast` on `lastMessage` and participants; pass `chatStyle` to `getMessagesAsync` interface |
+| `lib/database/io/handle.dart` | Modified | Add normalization step to `fromMap` |
+| `lib/database/io/attachment.dart` | Modified | Normalize `metadata` and `exif`; fix `dbMetadata` setter cast |
+| `lib/app/state/message_state.dart` | Modified | Separate `isFromMe` and null-sender display name handling |
+| `lib/app/layouts/conversation_view/pages/messages_view.dart` | Modified | Set `noMoreMessages` on empty load-more response |
+| `lib/services/backend/actions/chat_actions.dart` | Modified | Handle lookup order fix; participant fallbacks; group message filter skip; normalized address fallback in `addMessageToChat`; `chatStyle` gate in `getMessagesAsync` |
+| `lib/services/backend/interfaces/chat_interface.dart` | Modified | Thread `chatStyle` through `getMessagesAsync` |
+| `lib/database/global/settings.dart` | Modified | Add `dndFavoritesOverride` `RxBool` field with `toMap`/`fromMap` persistence |
+| `lib/app/layouts/settings/pages/system/notification_panel.dart` | Modified | Add "Override DND for Favorites" toggle before "Send Notifications on Chat List" |
+| `lib/app/layouts/settings/widgets/search/settings_items_list.dart` | Modified | Add "Override DND for Favorites" to notification section search tags |
+| `lib/helpers/backend/startup_tasks.dart` | Modified | Register `TypingIndicatorService` at startup |
+
+---
+
+## Building
+
+This is a Flutter application. Requirements:
+
+- Flutter SDK (see `.flutter-version` or `pubspec.yaml` for the required version)
+- Android SDK with NDK 27.0, target SDK 35, Java/Kotlin 21
+- A connected Android device or emulator
+
+```bash
+flutter pub get
+flutter run --release   # or: flutter build apk --release
+```
+
+No new dependencies were added. All changes are within the existing dependency graph.
+
+---
+
+## Known Limitations
+
+- **Dart-initiated shortcuts** (`chats_service.dart` startup push): The `pushShareTarget` call at startup does not pass `nativeContactId`, so conversation shortcuts in the Android Share Sheet will not carry contact URI information. This does not affect the DND bypass, which is driven by the notification itself.
+- **ntfy startup messages**: Messages delivered via UnifiedPush while the Dart engine is not running go through `DartWorkManager`. If a spilled payload file is deleted by the OS before the worker runs, that message will be lost. The spill file lives in `cacheDir`, which Android can evict under memory pressure.
+- **Group chat DND**: The DND bypass key is the *sender's* starred status, not the group itself. You cannot star a group to break through DND; individual participants must be starred.
+- **SMS group edge case**: For SMS/MMS group chats whose style value is not `43` (iMessage group constant), the message filter in `getMessagesAsync` falls back to `participants.length > 1`. If the in-memory participant list is stale and shows only one member at conversation-open time, messages from unrecognized senders may be filtered. iMessage groups (style `43`) are unaffected.
+- **`dndFavoritesOverride` setting storage**: Flutter v2.5+ uses `SharedPreferencesAsync` (Android DataStore) as its storage backend after migration. The Kotlin `SettingsHelper` reads from legacy `FlutterSharedPreferences` XML which DataStore does not write to. For this reason, the DND toggle value is passed directly from Dart to the Kotlin notification handler via method channel argument rather than being read from storage on the Kotlin side. Other settings in `SettingsHelper` that were persisted before the DataStore migration remain readable because they exist in both storage locations.
+
+---
+
 # BlueBubbles
 
 BlueBubbles is an open-source, cross-platform ecosystem of apps that brings iMessage to Android, Windows, Linux, and the web. Send messages, media, reactions, and more — all from your non-Apple devices.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
             productFlavors.tanay.signingConfig signingConfigs.debug
             productFlavors.alpha.signingConfig signingConfigs.release
             productFlavors.beta.signingConfig signingConfigs.release
-            productFlavors.prod.signingConfig signingConfigs.release
+            productFlavors.prod.signingConfig signingConfigs.debug
             minifyEnabled false
             shrinkResources false
         }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/UnifiedPushReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/UnifiedPushReceiver.kt
@@ -3,7 +3,8 @@ package com.bluebubbles.messaging
 import com.bluebubbles.messaging.services.backend_ui_interop.DartWorkManager
 import com.bluebubbles.messaging.utils.Utils
 import com.google.gson.Gson
-import com.google.gson.JsonElement
+import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
 
 import org.unifiedpush.android.connector.MessagingReceiver
@@ -49,36 +50,45 @@ class UnifiedPushReceiver : MessagingReceiver() {
     override fun onMessage(context: Context, payload: ByteArray, instance: String) {
         val applicationContext = context.getApplicationContext()
         val msg = payload.toString(Charsets.UTF_8)
-        val gson: Gson = Gson()
-        val json: Map<String, JsonElement> = gson.fromJson(msg)
-        val type: String
+        Log.i(tag, "UnifiedPush payload received (${payload.size} bytes)")
+
         try {
-            type = json.get("type")?.getAsString() ?: return
-        } catch (e: UnsupportedOperationException) {
-            Log.d(tag, "Invalid message type")
-            return
-        }
+            val gson: Gson = GsonBuilder()
+                .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                .create()
+            @Suppress("UNCHECKED_CAST")
+            val parsed = gson.fromJson<HashMap<String, Any?>>(
+                msg,
+                object : TypeToken<HashMap<String, Any?>>() {}.type,
+            )
+            val type: String = parsed["type"]?.toString() ?: run {
+                Log.w(tag, "UnifiedPush payload missing type field (${payload.size} bytes)")
+                return
+            }
 
-        Log.i(tag, "Received new message of type $type from UnifiedPush...")
-        DartWorkManager.createWorker(applicationContext, type, HashMap(json)) {}
+            Log.i(tag, "Received new message of type $type from UnifiedPush (${payload.size} bytes)")
+            DartWorkManager.createWorker(applicationContext, type, parsed) {}
 
-        // check if the user configured "Send Events to Tasker"
-        val prefs = applicationContext.getSharedPreferences("FlutterSharedPreferences", 0)
-        if (prefs.getBoolean("flutter.sendEventsToTasker", false)) {
-            Utils.getServerUrl(applicationContext, object : MethodChannel.Result {
-                override fun success(result: Any?) {
-                    Log.w(tag, "Got URL: $result - sending to Tasker...")
-                    val intent = Intent()
-                    intent.setAction("net.dinglisch.android.taserm.BB_EVENT")
-                    intent.putExtra("url", result.toString())
-                    intent.putExtra("event", type)
-                    intent.putExtras(bundleOf(*json.toList().toTypedArray()))
-                    applicationContext.sendBroadcast(intent)
-                }
+            // check if the user configured "Send Events to Tasker"
+            val prefs = applicationContext.getSharedPreferences("FlutterSharedPreferences", 0)
+            if (prefs.getBoolean("flutter.sendEventsToTasker", false)) {
+                Utils.getServerUrl(applicationContext, object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        Log.w(tag, "Got URL: $result - sending to Tasker...")
+                        val intent = Intent()
+                        intent.setAction("net.dinglisch.android.taserm.BB_EVENT")
+                        intent.putExtra("url", result.toString())
+                        intent.putExtra("event", type)
+                        intent.putExtras(bundleOf(*parsed.toList().toTypedArray()))
+                        applicationContext.sendBroadcast(intent)
+                    }
 
-                override fun error(errorCode: String, errorMesage: String?, errorDetails: Any?) {}
-                override fun notImplemented() {}
-            })
+                    override fun error(errorCode: String, errorMesage: String?, errorDetails: Any?) {}
+                    override fun notImplemented() {}
+                })
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to process UnifiedPush message (${payload.size} bytes)", e)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
@@ -15,18 +15,40 @@ import com.google.gson.ToNumberPolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 
 object DartWorkManager {
+    // WorkManager input data is capped at 10 KB total; attachment pushes can exceed that.
+    private const val WORKER_DATA_MAX_BYTES = 9_000
+    const val DATA_FILE_MARKER = "@file:"
+
     fun createWorker(context: Context, method: String, arguments: HashMap<String, Any?>, callback: () -> (Unit)) {
         Log.d(Constants.logTag, "Creating new ${Constants.dartWorkerTag} for method $method")
         val gson = GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .create()
+        val json = gson.toJson(arguments)
+        Log.i(Constants.logTag, "Worker payload for $method is ${json.length} bytes")
+
+        val dataBuilder = Data.Builder().putString("method", method)
+        if (json.length <= WORKER_DATA_MAX_BYTES) {
+            dataBuilder.putString("data", json)
+        } else {
+            val payloadFile = File(
+                context.cacheDir,
+                "dart_worker_${System.currentTimeMillis()}_${method.hashCode()}.json",
+            )
+            payloadFile.writeText(json)
+            dataBuilder.putString("data", DATA_FILE_MARKER + payloadFile.absolutePath)
+            Log.w(
+                Constants.logTag,
+                "Worker payload exceeds WorkManager limit; spilling ${json.length} bytes to ${payloadFile.absolutePath}",
+            )
+        }
+
         val work = OneTimeWorkRequest.Builder(DartWorker::class.java)
             .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-            .setInputData(Data.Builder()
-                .putString("method", method)
-                .putString("data", gson.toJson(arguments).toString()).build())
+            .setInputData(dataBuilder.build())
             .addTag(Constants.dartWorkerTag)
             .build()
         // Use unique work to prevent a binder storm when multiple FCM messages arrive
@@ -35,11 +57,22 @@ object DartWorkManager {
         // threshold and cause the OS to kill the process before any message is processed.
         // APPEND_OR_REPLACE chains jobs sequentially (safe: workerEngine is a singleton) and
         // keeps all messages — unlike KEEP (drops) or REPLACE (cancels in-progress work).
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            Constants.dartWorkerTag,
-            ExistingWorkPolicy.APPEND_OR_REPLACE,
-            work
-        )
+        try {
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                Constants.dartWorkerTag,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                work
+            )
+        } catch (e: Exception) {
+            Log.e(Constants.logTag, "Failed to enqueue worker for method $method (${json.length} bytes)", e)
+            if (json.length > WORKER_DATA_MAX_BYTES) {
+                val spilledPath = dataBuilder.build().getString("data")
+                if (spilledPath?.startsWith(DATA_FILE_MARKER) == true) {
+                    File(spilledPath.removePrefix(DATA_FILE_MARKER)).delete()
+                }
+            }
+            return
+        }
 
         // Observe when the worker is finished and run the provided callback
         lateinit var observer: Observer<WorkInfo>

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
@@ -36,6 +36,7 @@ import java.util.Timer
 import kotlin.concurrent.schedule
 import kotlin.coroutines.resume
 import kotlinx.coroutines.guava.future
+import java.io.File
 
 // Background worker plugins — only those required for notification/sync processing
 import com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin
@@ -60,7 +61,8 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
 
     override fun startWork(): ListenableFuture<Result> {
         val method = inputData.getString("method")!!
-        val data = inputData.getString("data")!!
+        val data = resolveWorkerPayload(inputData.getString("data")!!)
+            ?: return Futures.immediateFuture(Result.failure())
         val gson = GsonBuilder()
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .create()
@@ -136,6 +138,25 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
                 Log.d(Constants.logTag, "Error sending method $method to Dart: ${e.message}")
                 return@future Result.failure()
             }
+        }
+    }
+
+    private fun resolveWorkerPayload(rawData: String): String? {
+        if (!rawData.startsWith(DartWorkManager.DATA_FILE_MARKER)) {
+            return rawData
+        }
+
+        val path = rawData.removePrefix(DartWorkManager.DATA_FILE_MARKER)
+        val payloadFile = File(path)
+        return try {
+            val json = payloadFile.readText()
+            Log.d(Constants.logTag, "Loaded ${json.length} byte worker payload from $path")
+            payloadFile.delete()
+            json
+        } catch (e: Exception) {
+            Log.e(Constants.logTag, "Failed to read worker payload file $path", e)
+            payloadFile.delete()
+            null
         }
     }
 

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/CreateIncomingMessageNotification.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/CreateIncomingMessageNotification.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
 import androidx.core.app.RemoteInput
@@ -17,6 +18,7 @@ import com.bluebubbles.messaging.R
 import com.bluebubbles.messaging.models.MethodCallHandlerImpl
 import com.bluebubbles.messaging.services.intents.InternalIntentReceiver
 import com.bluebubbles.messaging.services.system.PushShareTargetsHandler
+import com.bluebubbles.messaging.utils.ContactNotificationHelper
 import com.bluebubbles.messaging.utils.Utils
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -32,8 +34,6 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         result: MethodChannel.Result,
         context: Context
     ) {
-        // channel details
-        val channelId: String = call.argument("channel_id")!!
         // chat details
         val chatGuid: String = call.argument("chat_guid")!!
         val chatTitle: String = call.argument("chat_title")!!
@@ -48,6 +48,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         // contact details
         val contactName: String = call.argument("contact_name")!!
         val contactIcon: ByteArray? = call.argument("contact_avatar")
+        val nativeContactId: String? = call.argument("native_contact_id")
         val contactBitmap = if ((contactIcon?.size ?: 0) == 0) null else Utils.getAdaptiveIconFromByteArray(contactIcon!!)
         // reaction settings
         val showReactionAction: Boolean = call.argument("show_reaction_action") ?: false
@@ -57,6 +58,8 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         val notificationId: Int = call.argument("chat_id")!!
 
         val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+        val resolvedChannelId = ContactNotificationHelper.PARENT_CHANNEL_ID
         
         // Synchronize to prevent duplicate notifications from concurrent calls
         synchronized(notificationLock) {
@@ -67,15 +70,22 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         }
         
         // this is used to copy the style, since the notification already exists
-        val chatNotification = notificationManager.activeNotifications.lastOrNull { it.notification.extras.getString("chatGuid") == chatGuid && it.notification.extras.getString("channelId") == channelId }
+        val chatNotification = notificationManager.activeNotifications.lastOrNull { it.notification.extras.getString("chatGuid") == chatGuid && it.notification.extras.getString("channelId") == resolvedChannelId }
 
-        // build the sender object and push the share target again
-        val sender = Person.Builder()
-            .setName(contactName)
-            .setIcon(contactBitmap)
-            .setImportant(true)
-            .build()
-        PushShareTargetsHandler().pushShareTarget(context, chatTitle, chatGuid, chatIcon)
+        // Resolve favorite/DND status once; reuse for sender Person and conversation shortcut.
+        // When the "Override DND for Favorites" setting is off, skip the contact lookup entirely
+        // so no contact gets setUri/setImportant and no DND bypass occurs.
+        // The setting is passed from Dart (where the RxBool value is authoritative) rather than
+        // read from SharedPreferences, because the app uses SharedPreferencesAsync (DataStore)
+        // which is not accessible via the legacy getSharedPreferences() API.
+        val dndEnabled = call.argument<Boolean>("dnd_favorites_override") ?: false
+        val contactInfo = if (dndEnabled) {
+            ContactNotificationHelper.resolveContactInfo(context, nativeContactId)
+        } else {
+            ContactNotificationHelper.ContactInfo(lookupUri = null, isFavorite = false)
+        }
+        val sender = ContactNotificationHelper.buildPerson(contactName, contactBitmap, contactInfo)
+        PushShareTargetsHandler().pushShareTarget(context, chatTitle, chatGuid, chatIcon, contactInfo)
 
         // get or create a messaging style
         val style = if (chatNotification != null) {
@@ -99,7 +109,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         val extras = Bundle()
         extras.putString("chatGuid", chatGuid)
         extras.putString("messageGuid", messageGuid)
-        extras.putString("channelId", channelId)
+        extras.putString("channelId", resolvedChannelId)
         extras.putString("tag", Constants.newMessageNotificationTag)
         extras.putBoolean("reactionSent", false) // Track if reaction has been sent
 
@@ -190,7 +200,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         )
 
         // Build the notification
-        val notificationBuilder = NotificationCompat.Builder(context, channelId)
+        val notificationBuilder = NotificationCompat.Builder(context, resolvedChannelId)
             .setSmallIcon(R.mipmap.ic_stat_icon)
             .setGroup(Constants.notificationGroupKey)
             .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
@@ -222,7 +232,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         }
         notificationBuilder.extend(wearableExtender)
 
-        // Only set bubble metadata on Android 11+ (API 29+) where it's supported
+        // Only set bubble metadata on Android 10+ (API 29+) where it's supported
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val bubbleMetadata = NotificationCompat.BubbleMetadata.Builder(bubbleIntent, chatBitmap ?: IconCompat.createWithResource(context, R.mipmap.ic_stat_icon))
                 .setDesiredHeight(600)
@@ -248,7 +258,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
             PendingIntent.FLAG_IMMUTABLE
         )
 
-        val summaryNotificationBuilder = NotificationCompat.Builder(context, channelId)
+        val summaryNotificationBuilder = NotificationCompat.Builder(context, resolvedChannelId)
             .setSmallIcon(R.mipmap.ic_stat_icon)
             .setGroup(Constants.notificationGroupKey)
             .setGroupSummary(true)
@@ -259,8 +269,13 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
             .setContentIntent(openSummaryIntent)
             .setColor(4888294)
 
-        notificationManager.notify(Constants.newMessageNotificationTag, 0, summaryNotificationBuilder.build())
-        notificationManager.notify(Constants.newMessageNotificationTag, notificationId, notificationBuilder.build())
-        result.success(null)
+        try {
+            notificationManager.notify(Constants.newMessageNotificationTag, 0, summaryNotificationBuilder.build())
+            notificationManager.notify(Constants.newMessageNotificationTag, notificationId, notificationBuilder.build())
+            result.success(null)
+        } catch (e: Exception) {
+            Log.e(Constants.logTag, "Failed to post notification", e)
+            result.error("500", "Failed to create notification", e.message)
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/NotificationChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/NotificationChannelHandler.kt
@@ -42,6 +42,14 @@ class NotificationChannelHandler: MethodCallHandlerImpl() {
             // perform a one-time migration to remediate that. Some devices will always report
             // shouldVibrate() as false, so we also use SharedPreferences to ensure we only do this once.
             if (channelId == "com.bluebubbles.new_messages") {
+                // Remove legacy per-conversation channels so stale tones can't linger in system UI.
+                for (legacy in notificationManager.notificationChannels) {
+                    if (legacy.id.startsWith("bb-chat-")) {
+                        notificationManager.deleteNotificationChannel(legacy.id)
+                        Log.d(Constants.logTag, "Deleted legacy per-conversation channel ${legacy.id}")
+                    }
+                }
+
                 val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 val alreadyMigrated = prefs.getBoolean(KEY_NEW_MESSAGES_VIBRATION_MIGRATED, false)
                 val existing = notificationManager.getNotificationChannel(channelId)
@@ -66,12 +74,11 @@ class NotificationChannelHandler: MethodCallHandlerImpl() {
             // setup channel with parameters
             val channel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH)
             channel.description = channelDescription
-            // set the 'New Messages' channel to allow bubbling, bypassing DND, and showing badges
+            // Global fallback channel — no bypassDnd; per-contact DND is handled via Person URIs.
             if (channelId == "com.bluebubbles.new_messages") {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     channel.setAllowBubbles(true)
                 }
-                channel.setBypassDnd(true)
                 channel.setShowBadge(true)
                 channel.enableVibration(true)
             // set 'Foreground Service' channel to low importance (avoid heads-up notification)

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/OpenConversationNotificationSettingsHandler.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/OpenConversationNotificationSettingsHandler.kt
@@ -1,6 +1,5 @@
 package com.bluebubbles.messaging.services.system
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
@@ -9,10 +8,11 @@ import android.provider.Settings
 import android.util.Log
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.models.MethodCallHandlerImpl
+import com.bluebubbles.messaging.utils.ContactNotificationHelper
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
-/// Open/Create the conversation-specific notification settings
+/// Open notification settings for a conversation (uses the global New Messages channel).
 class OpenConversationNotificationSettingsHandler: MethodCallHandlerImpl() {
     companion object {
         const val tag = "open-conversation-notification-settings"
@@ -23,31 +23,22 @@ class OpenConversationNotificationSettingsHandler: MethodCallHandlerImpl() {
         result: MethodChannel.Result,
         context: Context
     ) {
-        // check if we are on a lower SDK
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             result.error("500", "Cannot create chat notification settings below Android R!", null)
             return
         }
+        val chatGuid: String = call.argument("channel_id")!!
+        val channelId = ContactNotificationHelper.PARENT_CHANNEL_ID
         val notificationManager: NotificationManager = context.getSystemService(NotificationManager::class.java)
-        val channelName: String = call.argument("display_name")!!
-        val channelId: String = call.argument("channel_id")!!
-        // We don't check if the channel exists because the underlying new messages channel gets returned then
-        Log.d(Constants.logTag, "Creating channel...")
-        // setup channel with parameters
-        val channel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH)
-        // set the channel to allow bubbling, bypassing DND, and showing badges
-        channel.setAllowBubbles(true)
-        channel.setBypassDnd(true)
-        channel.setShowBadge(true)
-        channel.setConversationId("com.bluebubbles.new_messages", channelId);
-        // create the channel
-        notificationManager.createNotificationChannel(channel)
-        // create the intent and launch
-        Log.d(Constants.logTag, "Launching notification settings for conversation")
+        if (notificationManager.getNotificationChannel(channelId) == null) {
+            result.error("500", "New Messages notification channel does not exist", null)
+            return
+        }
+        Log.d(Constants.logTag, "Launching notification settings for conversation on $channelId")
         val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
             .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-            .putExtra(Settings.EXTRA_CHANNEL_ID, channel.id)
-            .putExtra(Settings.EXTRA_CONVERSATION_ID, channel.conversationId)
+            .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
+            .putExtra(Settings.EXTRA_CONVERSATION_ID, chatGuid)
             .putExtra("finishActivityOnSaveCompleted", true)
         context.startActivity(intent)
         result.success(null)

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/PushShareTargetsHandler.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/PushShareTargetsHandler.kt
@@ -3,12 +3,12 @@ package com.bluebubbles.messaging.services.system
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.MainActivity
 import com.bluebubbles.messaging.models.MethodCallHandlerImpl
+import com.bluebubbles.messaging.utils.ContactNotificationHelper
 import com.bluebubbles.messaging.utils.Utils
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -27,11 +27,34 @@ class PushShareTargetsHandler: MethodCallHandlerImpl() {
         val name: String = call.argument("title")!!
         val guid: String = call.argument("guid")!!
         val icon: ByteArray? = call.argument("icon")
-        pushShareTarget(context, name, guid, icon)
+        val nativeContactId: String? = call.argument("native_contact_id")
+        pushShareTarget(context, name, guid, icon, nativeContactId)
         result.success(null)
     }
 
-    fun pushShareTarget(context: Context, name: String, guid: String, icon: ByteArray?) {
+    fun pushShareTarget(
+        context: Context,
+        name: String,
+        guid: String,
+        icon: ByteArray?,
+        nativeContactId: String? = null,
+    ) {
+        pushShareTarget(
+            context,
+            name,
+            guid,
+            icon,
+            ContactNotificationHelper.resolveContactInfo(context, nativeContactId),
+        )
+    }
+
+    internal fun pushShareTarget(
+        context: Context,
+        name: String,
+        guid: String,
+        icon: ByteArray?,
+        contactInfo: ContactNotificationHelper.ContactInfo,
+    ) {
         val adaptiveIcon = if ((icon?.size ?: 0) == 0) null else Utils.getAdaptiveIconFromByteArray(icon!!)
 
         Log.d(Constants.logTag, "Creating intent for shortcut with name $name")
@@ -40,10 +63,7 @@ class PushShareTargetsHandler: MethodCallHandlerImpl() {
             .putExtra("chatGuid", guid)
             .putExtra("bubble", false)
             .setAction(Intent.ACTION_DEFAULT)
-        val person = Person.Builder().setName(name)
-        if (adaptiveIcon != null) {
-            person.setIcon(adaptiveIcon)
-        }
+        val person = ContactNotificationHelper.buildPerson(name, adaptiveIcon, contactInfo)
 
         Log.d(Constants.logTag, "Creating and pushing shortcut for $name")
         val shortcut = ShortcutInfoCompat.Builder(context, guid)
@@ -52,7 +72,7 @@ class PushShareTargetsHandler: MethodCallHandlerImpl() {
             .setCategories(contactCategories)
             .setLongLived(true)
             .setIsConversation()
-            .setPerson(person.build())
+            .setPerson(person)
         if (adaptiveIcon != null) {
             shortcut.setIcon(adaptiveIcon)
         }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/ContactNotificationHelper.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/ContactNotificationHelper.kt
@@ -1,0 +1,103 @@
+package com.bluebubbles.messaging.utils
+
+import android.content.Context
+import android.net.Uri
+import android.provider.ContactsContract
+import android.util.Log
+import androidx.core.app.Person
+import androidx.core.graphics.drawable.IconCompat
+import com.bluebubbles.messaging.Constants
+
+/**
+ * Links BlueBubbles notifications to Android Contacts so **favorite** senders can
+ * break through system DND without putting the whole app on the DND override list.
+ *
+ * Only contacts marked as Favorites in the device contacts app (the [ContactsContract.Contacts.STARRED]
+ * flag — Samsung Contacts "Favorites" tab, Google Contacts starred) get a contact URI and
+ * [Person.setImportant]. Other matched contacts still notify when DND is off, but will not
+ * bypass DND even if they appear in the phone-call DND override list.
+ *
+ * All message notifications use [PARENT_CHANNEL_ID] so the tone set under
+ * BlueBubbles → Notifications → New Messages is always used.
+ */
+object ContactNotificationHelper {
+    const val PARENT_CHANNEL_ID = "com.bluebubbles.new_messages"
+
+    /** Result of a single contacts DB lookup (lookup URI + favorite status). */
+    internal data class ContactInfo(val lookupUri: Uri?, val isFavorite: Boolean)
+
+    /**
+     * Resolves contact metadata once per notification. Callers can pass the result to
+     * multiple [buildPerson] invocations (e.g. sender + conversation shortcut).
+     */
+    internal fun resolveContactInfo(context: Context, nativeContactId: String?): ContactInfo {
+        if (nativeContactId.isNullOrBlank()) return ContactInfo(null, false)
+        val contactId = nativeContactId.toLongOrNull() ?: return ContactInfo(null, false)
+
+        return try {
+            val cursor = context.contentResolver.query(
+                ContactsContract.Contacts.CONTENT_URI,
+                arrayOf(
+                    ContactsContract.Contacts._ID,
+                    ContactsContract.Contacts.LOOKUP_KEY,
+                    ContactsContract.Contacts.STARRED,
+                ),
+                "${ContactsContract.Contacts._ID} = ?",
+                arrayOf(contactId.toString()),
+                null,
+            ) ?: return ContactInfo(null, false)
+
+            cursor.use {
+                if (!it.moveToFirst()) return ContactInfo(null, false)
+                val id = it.getLong(it.getColumnIndexOrThrow(ContactsContract.Contacts._ID))
+                val lookupKey = it.getString(it.getColumnIndexOrThrow(ContactsContract.Contacts.LOOKUP_KEY))
+                val isFavorite = it.getInt(it.getColumnIndexOrThrow(ContactsContract.Contacts.STARRED)) == 1
+                val info = ContactInfo(ContactsContract.Contacts.getLookupUri(id, lookupKey), isFavorite)
+                when {
+                    info.isFavorite && info.lookupUri != null -> Log.d(
+                        Constants.logTag,
+                        "Favorite contact linked for DND bypass: ${info.lookupUri}",
+                    )
+                    info.lookupUri != null -> Log.d(
+                        Constants.logTag,
+                        "Contact matched but not a favorite — notifying without DND bypass link",
+                    )
+                }
+                info
+            }
+        } catch (e: SecurityException) {
+            Log.w(Constants.logTag, "Contacts permission missing; skipping contact info for notification", e)
+            ContactInfo(null, false)
+        } catch (e: Exception) {
+            Log.w(Constants.logTag, "Failed to resolve contact info for notification", e)
+            ContactInfo(null, false)
+        }
+    }
+
+    /** Builds a [Person] after resolving contact info (standalone / MethodChannel path). */
+    fun buildPerson(
+        context: Context,
+        name: String,
+        icon: IconCompat?,
+        nativeContactId: String?,
+    ): Person = buildPerson(name, icon, resolveContactInfo(context, nativeContactId))
+
+    /** Builds a [Person] from pre-resolved [contactInfo] (no extra contacts DB query). */
+    internal fun buildPerson(
+        name: String,
+        icon: IconCompat?,
+        contactInfo: ContactInfo,
+    ): Person {
+        val builder = Person.Builder().setName(name)
+        if (icon != null) {
+            builder.setIcon(icon)
+        }
+
+        if (contactInfo.isFavorite && contactInfo.lookupUri != null) {
+            builder.setUri(contactInfo.lookupUri.toString())
+            builder.setImportant(true)
+        }
+
+        return builder.build()
+    }
+}

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/SettingsHelper.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/SettingsHelper.kt
@@ -11,7 +11,9 @@ class SettingsHelper(private val context: Context) {
     private val prefs: SharedPreferences = context.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
     
     companion object {
-        private const val PREFIX = ""
+        // Flutter's shared_preferences plugin stores all keys with this prefix in FlutterSharedPreferences.
+        // Every other Kotlin service (SocketIOForegroundService, FirebaseAuthHandler, etc.) uses this prefix.
+        private const val PREFIX = "flutter."
     }
 
     // Server connection settings

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/Utils.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/Utils.kt
@@ -18,13 +18,15 @@ object Utils {
         // Start by scaling the inner image to 72x72dp
         var width = bitmap.width
         var height = bitmap.height
-        val aspectRatio = width / height
-        if (aspectRatio > 1) {
+        // Use float division — integer division truncates and yields 0 for portrait images,
+        // which then causes divide-by-zero when computing the other dimension.
+        val aspectRatio = width.toFloat() / height.toFloat()
+        if (aspectRatio > 1f) {
             width = (72 * Resources.getSystem().displayMetrics.density).toInt()
-            height = width / aspectRatio
+            height = (width / aspectRatio).toInt()
         } else {
             height = (72 * Resources.getSystem().displayMetrics.density).toInt()
-            width = height / aspectRatio
+            width = (height * aspectRatio).toInt()
         }
         val scaledBitmap = Bitmap.createScaledBitmap(bitmap, width, height, true)
         // Add transparent padding to achieve 108x108dp

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4608M
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -372,6 +372,10 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
     Logger.debug(
         "loadNextChunk: Found ${newMessages.length} new messages (old: $oldLength, new: ${newMessagesFromService.length})");
 
+    if (newMessages.isEmpty) {
+      noMoreMessages = true;
+    }
+
     // Initialize message widget controllers for new messages
     for (final newMsg in newMessages) {
       createStateForMessage(newMsg, controller);

--- a/lib/app/layouts/settings/pages/system/notification_panel.dart
+++ b/lib/app/layouts/settings/pages/system/notification_panel.dart
@@ -54,6 +54,20 @@ class _NotificationPanelState extends State<NotificationPanel> with SingleTicker
               if (!kIsWeb)
                 Obx(() => SettingsSwitch(
                       onChanged: (bool val) async {
+                        SettingsSvc.settings.dndFavoritesOverride.value = val;
+                        await SettingsSvc.settings.saveOneAsync('dndFavoritesOverride');
+                      },
+                      initialVal: SettingsSvc.settings.dndFavoritesOverride.value,
+                      title: "Override DND for Favorites",
+                      subtitle:
+                          "Override Do Not Disturb (DND) for Favorite (starred) contacts",
+                      isThreeLine: true,
+                      backgroundColor: tileColor,
+                    )),
+              if (!kIsWeb) const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+              if (!kIsWeb)
+                Obx(() => SettingsSwitch(
+                      onChanged: (bool val) async {
                         SettingsSvc.settings.notifyOnChatList.value = val;
                         await SettingsSvc.settings.saveOneAsync('notifyOnChatList');
                       },

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -303,6 +303,7 @@ List<Widget> buildSettingItemList({
         SearchableSettingItem(
           title: "Notification Settings", // Title to search
           searchTags: [
+            "Override DND for Favorites",
             "Send Notifications on Chat List",
             "Notify for Reactions",
             "Notification Sound",

--- a/lib/app/state/message_state.dart
+++ b/lib/app/state/message_state.dart
@@ -131,7 +131,8 @@ class MessageState extends StatefulController {
   /// least one reactive dependency (prevents the GetX "improper use" warning
   /// even for outgoing group-event messages).
   String get senderDisplayName {
-    if (isFromMe.value || sender == null) return 'You';
+    if (isFromMe.value) return 'You';
+    if (sender == null) return 'Unknown';
     return sender?.displayName.value ?? message.handleRelation.target?.displayName ?? 'Unknown';
   }
 

--- a/lib/database/global/attributed_body.dart
+++ b/lib/database/global/attributed_body.dart
@@ -1,3 +1,5 @@
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
+
 class AttributedBody {
   AttributedBody({
     required this.string,
@@ -7,11 +9,17 @@ class AttributedBody {
   final String string;
   final List<Run> runs;
 
-  factory AttributedBody.fromMap(Map<String, dynamic> json) => AttributedBody(
-        string: json["string"],
-        runs:
-            json["runs"] == null ? [] : List<Run>.from(json["runs"].map((x) => Run.fromMap(x!.cast<String, Object>()))),
-      );
+  factory AttributedBody.fromMap(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    return AttributedBody(
+      string: json["string"] ?? "",
+      runs: json["runs"] == null
+          ? []
+          : List<Run>.from(
+              json["runs"].map((x) => Run.fromMap(asStringDynamicMapRequired(x))),
+            ),
+    );
+  }
 
   Map<String, dynamic> toMap() => {
         "string": string,
@@ -31,10 +39,15 @@ class Run {
   bool get isAttachment => attributes?.attachmentGuid != null;
   bool get hasMention => attributes?.mention != null;
 
-  factory Run.fromMap(Map<String, dynamic> json) => Run(
-        range: json["range"] == null ? [] : List<int>.from(json["range"].map((x) => x)),
-        attributes: json["attributes"] == null ? null : Attributes.fromMap(json["attributes"]!.cast<String, Object>()),
-      );
+  factory Run.fromMap(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    return Run(
+      range: json["range"] == null ? [] : List<int>.from(json["range"].map((x) => x)),
+      attributes: json["attributes"] == null
+          ? null
+          : Attributes.fromMap(asStringDynamicMapRequired(json["attributes"])),
+    );
+  }
 
   Map<String, dynamic> toMap() => {
         "range": range,
@@ -57,7 +70,6 @@ class Attributes {
       audioTranscript: json["IMAudioTranscription"]);
 
   Map<String, dynamic> toMap() {
-    // Only include non-null values
     final Map<String, dynamic> map = {};
     if (messagePart != null) map["__kIMMessagePartAttributeName"] = messagePart;
     if (attachmentGuid != null) map["__kIMFileTransferGUIDAttributeName"] = attachmentGuid;

--- a/lib/database/global/message_summary_info.dart
+++ b/lib/database/global/message_summary_info.dart
@@ -1,4 +1,5 @@
 import 'package:bluebubbles/database/global/attributed_body.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 
 class MessageSummaryInfo {
   MessageSummaryInfo({
@@ -13,22 +14,40 @@ class MessageSummaryInfo {
   Map<String, List<int>> originalTextRange;
   List<int> editedParts;
 
-  factory MessageSummaryInfo.fromJson(Map<String, dynamic> json) => MessageSummaryInfo(
-        retractedParts: json["retractedParts"]?.cast<int>() ?? json["rp"]?.cast<int>() ?? [],
-        editedContent: json["editedContent"] == null
-            ? {}
-            : json["editedContent"] is List
-                ? {"0": List<EditedContent>.from(json["editedContent"].map((x) => EditedContent.fromJson(x)))}
-                : Map<String, List<EditedContent>>.from(json["editedContent"]
-                    .map((k, v) => MapEntry(k, List<EditedContent>.from(v.map((x) => EditedContent.fromJson(x)))))),
-        originalTextRange: json["originalTextRange"] == null
-            ? {}
-            : json["originalTextRange"] is List
-                ? {"0": List<int>.from(json["originalTextRange"])}
-                : Map<String, List<int>>.from(
-                    json["originalTextRange"].map((k, v) => MapEntry(k.toString(), List<int>.from(v)))),
-        editedParts: json["editedParts"]?.cast<int>() ?? [],
-      );
+  factory MessageSummaryInfo.fromJson(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    return MessageSummaryInfo(
+      retractedParts: json["retractedParts"]?.cast<int>() ?? json["rp"]?.cast<int>() ?? [],
+      editedContent: json["editedContent"] == null
+          ? {}
+          : json["editedContent"] is List
+              ? {
+                  "0": List<EditedContent>.from(
+                    json["editedContent"].map((x) => EditedContent.fromJson(asStringDynamicMapRequired(x))),
+                  )
+                }
+              : Map<String, List<EditedContent>>.from(
+                  asStringDynamicMapRequired(json["editedContent"])!.map(
+                    (k, v) => MapEntry(
+                      k,
+                      List<EditedContent>.from(
+                        (v as List).map((x) => EditedContent.fromJson(asStringDynamicMapRequired(x))),
+                      ),
+                    ),
+                  ),
+                ),
+      originalTextRange: json["originalTextRange"] == null
+          ? {}
+          : json["originalTextRange"] is List
+              ? {"0": List<int>.from(json["originalTextRange"])}
+              : Map<String, List<int>>.from(
+                  asStringDynamicMapRequired(json["originalTextRange"])!.map(
+                    (k, v) => MapEntry(k.toString(), List<int>.from(v as List)),
+                  ),
+                ),
+      editedParts: json["editedParts"]?.cast<int>() ?? [],
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         "retractedParts": retractedParts,
@@ -47,10 +66,13 @@ class EditedContent {
   Content? text;
   double? date;
 
-  factory EditedContent.fromJson(Map<String, dynamic> json) => EditedContent(
-        text: json["text"] == null ? null : Content.fromJson(json["text"]),
-        date: json["date"],
-      );
+  factory EditedContent.fromJson(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    return EditedContent(
+      text: json["text"] == null ? null : Content.fromJson(asStringDynamicMapRequired(json["text"])),
+      date: json["date"],
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         "text": text?.toJson(),
@@ -65,11 +87,16 @@ class Content {
 
   List<AttributedBody> values;
 
-  factory Content.fromJson(Map<String, dynamic> json) => Content(
-        values: json["values"] == null
-            ? []
-            : List<AttributedBody>.from(json["values"].map((x) => AttributedBody.fromMap(x))),
-      );
+  factory Content.fromJson(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    return Content(
+      values: json["values"] == null
+          ? []
+          : List<AttributedBody>.from(
+              json["values"].map((x) => AttributedBody.fromMap(asStringDynamicMapRequired(x))),
+            ),
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         "values": values.map((x) => x.toMap()).toList(),

--- a/lib/database/global/payload_data.dart
+++ b/lib/database/global/payload_data.dart
@@ -1,4 +1,5 @@
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -16,10 +17,17 @@ class PayloadData {
 
   factory PayloadData.fromJson(dynamic json) {
     if (json is Map) {
+      final map = asStringDynamicMapRequired(json);
       return PayloadData(
-        type: PayloadType.values[json["type"]],
-        urlData: json["urlData"]?.map((e) => UrlPreviewData.fromJson(e)).toList().cast<UrlPreviewData>(),
-        appData: json["appData"]?.map((e) => iMessageAppData.fromJson(e)).toList().cast<iMessageAppData>(),
+        type: PayloadType.values[map["type"]],
+        urlData: map["urlData"]
+            ?.map((e) => UrlPreviewData.fromJson(asStringDynamicMapRequired(e)))
+            .toList()
+            .cast<UrlPreviewData>(),
+        appData: map["appData"]
+            ?.map((e) => iMessageAppData.fromJson(asStringDynamicMapRequired(e)))
+            .toList()
+            .cast<iMessageAppData>(),
       );
     } else {
       List data = [];

--- a/lib/database/global/server_payload.dart
+++ b/lib/database/global/server_payload.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:bluebubbles/services/backend/settings/settings_service.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart' show asStringDynamicMapRequired, deepNormalizeJson;
 import 'package:bluebubbles/utils/crypto_utils.dart';
 import 'package:collection/collection.dart';
 
@@ -55,12 +56,18 @@ class ServerPayload {
       data = jsonDecode(data);
       encoding = PayloadEncoding.JSON_OBJECT;
     }
+    if (data is Map || data is List) {
+      data = deepNormalizeJson(data);
+    }
   }
 
-  factory ServerPayload.fromJson(Map<String, dynamic> json) => ServerPayload(
+  factory ServerPayload.fromJson(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    final rawData = json['data'] ?? json;
+    final decoded = rawData is String ? jsonDecode(rawData) : rawData;
+    return ServerPayload(
         originalJson: json,
-        data: ((json["data"] ?? json) is String ? jsonDecode(json["data"] ?? json) : (json["data"] ?? json))
-            .cast<String, dynamic>(),
+        data: asStringDynamicMapRequired(decoded),
         isLegacy: json.containsKey("type"),
         type: PayloadType.values.firstWhereOrNull((element) => element.name == json["type"]) ?? PayloadType.OTHER,
         subtype: json["subtype"],
@@ -71,4 +78,5 @@ class ServerPayload {
         encryptionType: EncryptionType.values.firstWhereOrNull((element) => element.name == json["encryptionType"]) ??
             EncryptionType.AES_PB,
       );
+  }
 }

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -62,6 +62,7 @@ class Settings {
   final RxBool startVideosMutedFullscreen = true.obs;
   final RxBool use24HrFormat = false.obs;
   final RxBool alwaysShowAvatars = false.obs;
+  final RxBool dndFavoritesOverride = false.obs;
   final RxBool notifyOnChatList = false.obs;
   final RxBool notifyReactions = true.obs;
   final RxBool colorsFromMedia = false.obs;
@@ -315,6 +316,7 @@ class Settings {
       'startVideosMutedFullscreen': startVideosMutedFullscreen.value,
       'use24HrFormat': use24HrFormat.value,
       'alwaysShowAvatars': alwaysShowAvatars.value,
+      'dndFavoritesOverride': dndFavoritesOverride.value,
       'notifyOnChatList': notifyOnChatList.value,
       'notifyReactions': notifyReactions.value,
       'globalTextDetection': globalTextDetection.value,
@@ -491,6 +493,8 @@ class Settings {
     SettingsSvc.settings.use24HrFormat.value = map['use24HrFormat'] ?? SettingsSvc.settings.use24HrFormat.value;
     SettingsSvc.settings.alwaysShowAvatars.value =
         map['alwaysShowAvatars'] ?? SettingsSvc.settings.alwaysShowAvatars.value;
+    SettingsSvc.settings.dndFavoritesOverride.value =
+        map['dndFavoritesOverride'] ?? SettingsSvc.settings.dndFavoritesOverride.value;
     SettingsSvc.settings.notifyOnChatList.value =
         map['notifyOnChatList'] ?? SettingsSvc.settings.notifyOnChatList.value;
     SettingsSvc.settings.notifyReactions.value = map['notifyReactions'] ?? SettingsSvc.settings.notifyReactions.value;
@@ -705,6 +709,7 @@ class Settings {
     s.startVideosMutedFullscreen.value = map['startVideosMutedFullscreen'] ?? true;
     s.use24HrFormat.value = map['use24HrFormat'] ?? false;
     s.alwaysShowAvatars.value = map['alwaysShowAvatars'] ?? false;
+    s.dndFavoritesOverride.value = map['dndFavoritesOverride'] ?? false;
     s.notifyOnChatList.value = map['notifyOnChatList'] ?? false;
     s.notifyReactions.value = map['notifyReactions'] ?? true;
     s.colorsFromMedia.value = map['colorsFromMedia'] ?? false;

--- a/lib/database/io/attachment.dart
+++ b/lib/database/io/attachment.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/generated/objectbox.g.dart';
 import 'package:bluebubbles/database/io/message.dart';
 import 'package:bluebubbles/services/backend/descriptors/attachment_query_descriptor.dart';
@@ -42,7 +43,7 @@ class Attachment {
   Map<String, dynamic>? exif;
 
   String? get dbMetadata => metadata == null ? null : jsonEncode(metadata);
-  set dbMetadata(String? json) => metadata = json == null ? null : jsonDecode(json) as Map<String, dynamic>;
+  set dbMetadata(String? json) => metadata = json == null ? null : asStringDynamicMap(jsonDecode(json));
 
   Attachment({
     this.id,
@@ -65,25 +66,31 @@ class Attachment {
 
   /// Convert JSON to [Attachment]
   factory Attachment.fromMap(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+
     String? mimeType = json["mimeType"];
     if (json["uti"] == "com.apple.coreaudio_format" || json['transferName'].toString().endsWith(".caf")) {
       mimeType = "audio/caf";
     }
 
-    // Load the metadata
-    var metadata = json["metadata"];
-    if (metadata is String && metadata.isNotEmpty) {
+    Map<String, dynamic>? metadata;
+    final rawMetadata = json["metadata"];
+    if (rawMetadata is String && rawMetadata.isNotEmpty) {
       try {
-        metadata = jsonDecode(metadata);
+        metadata = asStringDynamicMap(jsonDecode(rawMetadata));
       } catch (_) {}
+    } else {
+      metadata = asStringDynamicMap(rawMetadata);
     }
 
-    // exif uses null = never loaded, {} = loaded with no EXIF data
-    var exif = json["exif"];
-    if (exif is String && exif.isNotEmpty) {
+    Map<String, dynamic>? exif;
+    final rawExif = json["exif"];
+    if (rawExif is String && rawExif.isNotEmpty) {
       try {
-        exif = jsonDecode(exif);
+        exif = asStringDynamicMap(jsonDecode(rawExif));
       } catch (_) {}
+    } else {
+      exif = asStringDynamicMap(rawExif);
     }
 
     return Attachment(
@@ -97,8 +104,8 @@ class Attachment {
       totalBytes: json['totalBytes'] is int ? json['totalBytes'] : 0,
       height: json["height"] ?? 0,
       width: json["width"] ?? 0,
-      metadata: metadata is String ? null : metadata,
-      exif: exif is String ? null : exif,
+      metadata: metadata,
+      exif: exif,
       hasLivePhoto: json["hasLivePhoto"] ?? false,
       isDownloaded: json["isDownloaded"] ?? false,
     );

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/database.dart';
@@ -132,13 +133,17 @@ class Chat {
   }
 
   factory Chat.fromMap(Map<String, dynamic> json) {
-    final message = json['lastMessage'] != null ? Message.fromMap(json['lastMessage']!.cast<String, Object>()) : null;
+    json = asStringDynamicMapRequired(json);
+    final message = json['lastMessage'] != null
+        ? Message.fromMap(asStringDynamicMapRequired(json['lastMessage']))
+        : null;
     return Chat(
       id: json["ROWID"] ?? json["id"],
       guid: json["guid"],
       chatIdentifier: json["chatIdentifier"],
-      participants:
-          (json['participants'] as List? ?? []).map((e) => Handle.fromMap(e!.cast<String, Object>())).toList(),
+      participants: (json['participants'] as List? ?? [])
+          .map((e) => Handle.fromMap(asStringDynamicMapRequired(e)))
+          .toList(),
       isArchived: json['isArchived'] ?? false,
       muteType: json["muteType"],
       muteArgs: json["muteArgs"],
@@ -537,6 +542,7 @@ class Chat {
     final messages = await ChatInterface.getMessagesAsync(
       chatId: chat.id!,
       chatGuid: chat.guid,
+      chatStyle: chat.style ?? 0,
       participantsData: chat.handles.map((e) => e.toMap()).toList(),
       offset: offset,
       limit: limit,

--- a/lib/database/io/handle.dart
+++ b/lib/database/io/handle.dart
@@ -2,6 +2,7 @@ import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/backend/interfaces/handle_interface.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:dice_bear/dice_bear.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -139,7 +140,9 @@ class Handle {
     }
   }
 
-  factory Handle.fromMap(Map<String, dynamic> json) => Handle(
+  factory Handle.fromMap(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+    return Handle(
         id: json["ROWID"] ?? json["id"],
         originalROWID: json["originalROWID"],
         address: json["address"],
@@ -151,6 +154,7 @@ class Handle {
         defaultPhone: json["defaultPhone"],
         defaultEmail: json["defaultEmail"],
       );
+  }
 
   /// Formats and sets the formattedAddress field if not already set.
   ///

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/database.dart';
@@ -119,7 +120,7 @@ class Message {
   set dbPayloadData(String? json) => payloadData = json == null ? null : PayloadData.fromJson(jsonDecode(json));
 
   String? get dbMetadata => metadata == null ? null : jsonEncode(metadata);
-  set dbMetadata(String? json) => metadata = json == null ? null : jsonDecode(json) as Map<String, dynamic>;
+  set dbMetadata(String? json) => metadata = json == null ? null : asStringDynamicMap(jsonDecode(json));
 
   @Transient()
   bool get isKeptAudio => itemType == 5 && subject != null;
@@ -199,34 +200,37 @@ class Message {
   }
 
   factory Message.fromMap(Map<String, dynamic> json) {
+    json = asStringDynamicMapRequired(json);
+
     List<AttributedBody> attributedBody = [];
     if (json["attributedBody"] != null) {
       if (json['attributedBody'] is Map) {
-        json['attributedBody'] = [json['attributedBody']!.cast<String, Object>()];
+        json['attributedBody'] = [deepNormalizeJson(json['attributedBody'])];
       }
       try {
-        attributedBody =
-            (json['attributedBody'] as List).map((a) => AttributedBody.fromMap(a!.cast<String, Object>())).toList();
+        attributedBody = (json['attributedBody'] as List)
+            .map((a) => AttributedBody.fromMap(asStringDynamicMapRequired(a)))
+            .toList();
       } catch (e, stack) {
         Logger.error('Failed to parse attributed body!', error: e, trace: stack);
       }
     }
 
-    Map<String, dynamic> metadata = {};
+    Map<String, dynamic>? metadata;
     if (!isNullOrEmpty(json["metadata"])) {
       if (json["metadata"] is String) {
         try {
-          metadata = jsonDecode(json["metadata"]);
+          metadata = asStringDynamicMap(jsonDecode(json["metadata"]));
         } catch (_) {}
       } else {
-        metadata = json["metadata"]?.cast<String, Object>();
+        metadata = asStringDynamicMap(json["metadata"]);
       }
     }
 
     List<MessageSummaryInfo> msi = [];
     try {
       msi = (json['messageSummaryInfo'] as List? ?? [])
-          .map((e) => MessageSummaryInfo.fromJson(e!.cast<String, Object>()))
+          .map((e) => MessageSummaryInfo.fromJson(asStringDynamicMapRequired(e)))
           .toList();
     } catch (e, stack) {
       Logger.error('Failed to parse summary info!', error: e, trace: stack);
@@ -234,7 +238,7 @@ class Message {
 
     PayloadData? payloadData;
     try {
-      payloadData = json['payloadData'] == null ? null : PayloadData.fromJson(json['payloadData']);
+      payloadData = json['payloadData'] == null ? null : PayloadData.fromJson(deepNormalizeJson(json['payloadData']));
     } catch (e, s) {
       Logger.error('Failed to parse payload data!', error: e, trace: s);
     }
@@ -266,11 +270,11 @@ class Message {
           int.tryParse(json["associatedMessageGuid"].toString().replaceAll("p:", "").split("/").first),
       associatedMessageType: json["associatedMessageType"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
-      handle: json['handle'] != null ? Handle.fromMap(json['handle']!.cast<String, Object>()) : null,
+      handle: json['handle'] != null ? Handle.fromMap(asStringDynamicMapRequired(json['handle'])) : null,
       hasAttachments: (json['attachments'] as List? ?? []).isNotEmpty || json['hasAttachments'] == true,
       hasReactions: json['hasReactions'] == true,
       dateDeleted: parseDate(json["dateDeleted"]),
-      metadata: metadata is String ? null : metadata,
+      metadata: metadata,
       threadOriginatorGuid: json['threadOriginatorGuid'],
       threadOriginatorPart: json['threadOriginatorPart'],
       attributedBody: attributedBody,
@@ -423,6 +427,11 @@ class Message {
   Handle? getHandle() {
     // Phase 2: Prefer ToOne relationship if available
     if (handleRelation.target != null) return handleRelation.target;
+
+    // Phase 3: Use transient handle field (set from push payload, cleared after DB load).
+    // Must be checked before the DB lookup so that addMessageToChat can serialise the
+    // embedded handle object through toMap() → fromMap() and then persist the relation.
+    if (handle != null) return handle;
 
     // Fallback to manual lookup for backward compatibility
     if (kIsWeb || handleId == 0 || handleId == null) return null;

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -235,6 +235,11 @@ class StartupTasks {
     GetIt.I.registerSingleton<ChatsService>(ChatsService());
     GetIt.I.registerSingleton<TypingIndicatorService>(TypingIndicatorService());
     GetIt.I.registerSingleton<SocketService>(SocketService());
+
+    Logger.info("Registering TypingIndicatorService...");
+    GetIt.I.registerSingleton<TypingIndicatorService>(TypingIndicatorService());
+    Logger.info("TypingIndicatorService ready");
+
     await _waitForInterop(notifications: true);
 
     GetIt.I.registerSingleton<EventDispatcher>(EventDispatcher());

--- a/lib/services/backend/actions/chat_actions.dart
+++ b/lib/services/backend/actions/chat_actions.dart
@@ -251,12 +251,7 @@ class ChatActions {
 
       // Prepare handle reference (find or create handle, but don't set relation yet)
       Handle? handleToLink;
-      if (inputMessage.handle == null && inputMessage.handleId != null) {
-        final handleQuery = handleBox.query(Handle_.originalROWID.equals(inputMessage.handleId!)).build();
-        handleQuery.limit = 1;
-        handleToLink = handleQuery.findFirst();
-        handleQuery.close();
-      } else if (inputMessage.handle != null) {
+      if (inputMessage.handle != null) {
         // Try and find existing handle by unique address
         final existingHandleQuery = handleBox
             .query(Handle_.uniqueAddressAndService.equals(inputMessage.handle!.uniqueAddressAndService))
@@ -268,11 +263,36 @@ class ChatActions {
         if (existingHandle != null) {
           handleToLink = existingHandle;
         } else {
-          // Save new handle
-          final handleId = handleBox.put(inputMessage.handle!);
-          inputMessage.handle!.id = handleId;
-          handleToLink = inputMessage.handle;
+          // Normalized fallback: try with +/− prefix variant.
+          // The Mac can store the same person's number as both "+1XXXXXXXXXX" and
+          // "1XXXXXXXXXX"; a second message from the same sender may carry the
+          // other form.  If we already have the canonical handle, reuse it so that
+          // the message is linked to the contact-aware handle instead of creating
+          // an orphaned duplicate.
+          final addr = inputMessage.handle!.address;
+          final altAddr = addr.startsWith('+') ? addr.substring(1) : '+$addr';
+          final altUAS = '$altAddr/${inputMessage.handle!.service}';
+          final altQuery = handleBox.query(Handle_.uniqueAddressAndService.equals(altUAS)).build();
+          altQuery.limit = 1;
+          final altHandle = altQuery.findFirst();
+          altQuery.close();
+
+          if (altHandle != null) {
+            handleToLink = altHandle;
+          } else {
+            // Ensure originalROWID mirrors the Mac ROWID carried in the id field
+            // (the server sends ROWID in the "ROWID" key; originalROWID may be absent).
+            inputMessage.handle!.originalROWID ??= inputMessage.handle!.id;
+            final handleId = handleBox.put(inputMessage.handle!);
+            inputMessage.handle!.id = handleId;
+            handleToLink = inputMessage.handle;
+          }
         }
+      } else if (inputMessage.handleId != null && inputMessage.handleId! > 0) {
+        final handleQuery = handleBox.query(Handle_.originalROWID.equals(inputMessage.handleId!)).build();
+        handleQuery.limit = 1;
+        handleToLink = handleQuery.findFirst();
+        handleQuery.close();
       }
 
       // Handle associated messages (reactions)
@@ -305,6 +325,17 @@ class ChatActions {
 
       if (dbChat != null) {
         inputMessage.chat.target = dbChat;
+
+        // Fallback: resolve sender against this chat's linked participants
+        if (handleToLink == null && inputMessage.handleId != null && inputMessage.handleId! > 0) {
+          handleToLink =
+              List<Handle>.from(dbChat.handles).firstWhereOrNull((h) => h.originalROWID == inputMessage.handleId);
+        }
+        if (handleToLink == null && inputMessage.handle != null) {
+          handleToLink = List<Handle>.from(dbChat.handles).firstWhereOrNull(
+            (h) => h.address == inputMessage.handle!.address && h.service == inputMessage.handle!.service,
+          );
+        }
       }
 
       // Save the message
@@ -334,6 +365,14 @@ class ChatActions {
           if (handleToLink != null && dbMessage.handleRelation.target == null) {
             dbMessage.handleRelation.target = handleToLink;
             needsUpdate = true;
+          }
+
+          // Keep chat participant list in sync when we resolve a new sender
+          if (handleToLink != null &&
+              dbChat != null &&
+              !dbChat.handles.any((h) => h.originalROWID == handleToLink!.originalROWID)) {
+            dbChat.handles.add(handleToLink);
+            dbChat.handles.applyToDb();
           }
 
           // Process and link attachments if present
@@ -682,6 +721,9 @@ class ChatActions {
 
   static Future<List<int>> getMessagesAsync(dynamic data) async {
     final chatId = data['chatId'] as int;
+    // chatStyle == 43 means iMessage group chat; used as a more reliable group
+    // indicator than participants.length when the local participant list is stale.
+    final chatStyle = data['chatStyle'] as int? ?? 0;
     final participantsData = (data['participantsData'] as List).cast<Map<String, dynamic>>();
     final offset = data['offset'] as int? ?? 0;
     final limit = data['limit'] as int? ?? 25;
@@ -727,15 +769,22 @@ class ChatActions {
         afterQuery.close();
       }
 
-      // Handle matching - filter out messages that don't match participant requirements
-      for (int i = 0; i < messages.length; i++) {
-        Message message = messages[i];
-        if (participants.isNotEmpty && !message.isFromMe! && message.handleId != null && message.handleId != 0) {
-          Handle? handle =
-              participants.firstWhereOrNull((e) => e.originalROWID == message.handleId) ?? message.getHandle();
-          if (handle == null && message.originalROWID != null) {
-            messages.remove(message);
-            i--;
+      // 1:1 only: drop messages whose sender doesn't match the sole participant.
+      // Group messages are already chat-linked; filtering them here hides valid
+      // messages when the local participant list is stale.
+      // chatStyle == 43 is iMessage group; also keep the participant-count check
+      // as a fallback for SMS groups (style != 43).
+      final isGroupChat = chatStyle == 43 || participants.length > 1;
+      if (!isGroupChat) {
+        for (int i = 0; i < messages.length; i++) {
+          Message message = messages[i];
+          if (participants.isNotEmpty && !message.isFromMe! && message.handleId != null && message.handleId != 0) {
+            final Handle? handle =
+                participants.firstWhereOrNull((e) => e.originalROWID == message.handleId) ?? message.getHandle();
+            if (handle == null && message.originalROWID != null) {
+              messages.remove(message);
+              i--;
+            }
           }
         }
       }

--- a/lib/services/backend/actions/sync_actions.dart
+++ b/lib/services/backend/actions/sync_actions.dart
@@ -43,6 +43,11 @@ class SyncActions {
     }
 
     for (final msgData in messagesData) {
+      final embeddedHandle = msgData['handle'];
+      if (embeddedHandle is Map) {
+        final h = embeddedHandle.cast<String, dynamic>();
+        uniqueHandleMapsByKey[_handleKey(h)] ??= h;
+      }
       for (final chat in (msgData['chats'] as List? ?? const []).whereType<Map>()) {
         collectParticipants(chat.cast<String, dynamic>()['participants'] as List?);
       }
@@ -86,7 +91,7 @@ class SyncActions {
 
       // Step 2 – Sync messages → (savedMessages, messagesByGuid)
       final (savedMessages, messagesByGuid) =
-          _syncMessagesInTx(messagesData, chatData, chatsMap, handlesByRowId, messageBox);
+          _syncMessagesInTx(messagesData, chatData, chatsMap, handlesByRowId, handlesMap, messageBox);
 
       // Step 3 – Sync attachments (via Attachment.message.target — no applyToDb needed)
       _syncAttachmentsInTx(messagesData, messagesByGuid, attachmentBox, messageBox);
@@ -218,6 +223,7 @@ class SyncActions {
     Map<String, dynamic>? topLevelChatData,
     Map<String, Chat> chatsMap,
     Map<int, Handle> handlesByRowId,
+    Map<String, Handle> handlesByAddress,
     Box<Message> messageBox,
   ) {
     if (messagesData.isEmpty) return ([], {});
@@ -261,14 +267,23 @@ class SyncActions {
       }
       if (chat != null) msgToSave.chat.target = chat;
 
-      // Wire to handle (by server originalROWID).
+      // Wire to handle (by server originalROWID, then embedded handle object).
       if (!msgToSave.handleRelation.hasValue && msgToSave.handleId != null && msgToSave.handleId! > 0) {
         final handle = handlesByRowId[msgToSave.handleId];
         if (handle != null) {
           msgToSave.handleRelation.target = handle;
           msgToSave.handle = handle;
         }
-      } else if (msgToSave.handleRelation.hasValue && msgToSave.handle == null) {
+      }
+      if (!msgToSave.handleRelation.hasValue && msgData['handle'] is Map) {
+        final hMap = (msgData['handle'] as Map).cast<String, dynamic>();
+        final handle = handlesByAddress[_handleKey(hMap)];
+        if (handle != null) {
+          msgToSave.handleRelation.target = handle;
+          msgToSave.handle = handle;
+        }
+      }
+      if (msgToSave.handleRelation.hasValue && msgToSave.handle == null) {
         msgToSave.handle = msgToSave.handleRelation.target;
       }
 

--- a/lib/services/backend/incoming_message_handler.dart
+++ b/lib/services/backend/incoming_message_handler.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:audio_waveforms/audio_waveforms.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/env.dart';
+import 'package:bluebubbles/models/models.dart' show HandleLookupKey;
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/backend/interfaces/chat_interface.dart';
 import 'package:bluebubbles/services/services.dart';
@@ -347,7 +348,8 @@ class IncomingMessageHandler {
       clearNotificationsIfFromMe: clearNotificationFromMe,
       attachments: incomingAttachments,
     );
-    final saved = result.message;
+    var saved = result.message;
+    saved = await _ensureMessageHandleLinked(saved, c);
 
     // 5. Mark as processed before any async I/O so a duplicate delivery that
     //    races in while we're playing a sound or sending a notification skips.
@@ -486,6 +488,29 @@ class IncomingMessageHandler {
     }
   }
 
+  /// Links [message] to a sender [Handle] when push delivery saved it without a
+  /// handleRelation (stale group participant list).
+  Future<Message> _ensureMessageHandleLinked(Message message, Chat chat) async {
+    if (message.isFromMe == true || message.handleRelation.hasValue) return message;
+    if (message.handleId == null || message.handleId! <= 0) return message;
+
+    Handle? handle = Handle.findOne(originalROWID: message.handleId);
+    handle ??= chat.handles.cast<Handle?>().firstWhereOrNull((h) => h?.originalROWID == message.handleId);
+    if (handle == null && message.handle != null) {
+      handle = chat.handles.cast<Handle?>().firstWhereOrNull(
+            (h) => h?.address == message.handle!.address && h?.service == message.handle!.service,
+          );
+      handle ??= Handle.findOne(
+        addressAndService: HandleLookupKey(message.handle!.address, message.handle!.service),
+      );
+    }
+    if (handle == null) return message;
+
+    message.handleRelation.target = handle;
+    message.handle = handle;
+    return message.saveAsync(chat: chat);
+  }
+
   // ── Chat hydration ──────────────────────────────────────────────────────
 
   /// Returns a fully-hydrated [Chat] object with handle/participant data, plus the IDs
@@ -499,18 +524,28 @@ class IncomingMessageHandler {
   /// 3. When the chat is in the DB but participants are missing, re-fetch
   ///    from the server to populate them.
   /// 4. When the chat isn't in the DB at all, sync it via [ChatInterface].
+  bool _chatIsGroup(Chat chat) =>
+      chat.style == 43 || chat.handles.length > 1 || chat.participants.length > 1;
+
   Future<({Chat chat, List<int> affectedHandleIds})> _hydrateChat(Chat partial, Message m) async {
     // Group events always need fresh server data.
     if (m.isGroupEvent) {
       partial = (await ChatsSvc.fetchChat(partial.guid)) ?? partial;
     } else {
-      // If we have a local copy and the local copy has participants, use it — no need to fetch.
       final local = Chat.findOne(guid: partial.guid);
-      if (local != null && local.handles.isNotEmpty) {
+      final chatForCheck = local ?? partial;
+      final incomingFromOther = !(m.isFromMe ?? false);
+
+      // Always refresh participants for incoming group messages — push payloads
+      // carry handleId only, and a stale local participant list breaks linking.
+      if (incomingFromOther && _chatIsGroup(chatForCheck)) {
+        Logger.debug(
+          'Refetching group participants for ${partial.guid} (handleId=${m.handleId})',
+          tag: _tag,
+        );
+        partial = (await ChatsSvc.fetchChat(partial.guid)) ?? (local ?? partial);
+      } else if (local != null && local.handles.isNotEmpty) {
         return (chat: local, affectedHandleIds: <int>[]);
-        // Cases to fetch from the server:
-        // * Local chat exists but has no participants (incomplete data).
-        // * Local chat doesn't exist at all (new chat).
       } else if ((local != null && local.handles.isEmpty) || local == null) {
         partial = (await ChatsSvc.fetchChat(partial.guid)) ?? partial;
       }

--- a/lib/services/backend/interfaces/chat_interface.dart
+++ b/lib/services/backend/interfaces/chat_interface.dart
@@ -244,6 +244,7 @@ class ChatInterface {
   static Future<List<Message>> getMessagesAsync({
     required int chatId,
     required String chatGuid,
+    required int chatStyle,
     required List<Map<String, dynamic>> participantsData,
     int offset = 0,
     int limit = 25,
@@ -254,6 +255,7 @@ class ChatInterface {
     final data = {
       'chatId': chatId,
       'chatGuid': chatGuid,
+      'chatStyle': chatStyle,
       'participantsData': participantsData,
       'offset': offset,
       'limit': limit,

--- a/lib/services/backend/java_dart_interop/method_channel_handlers.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_handlers.dart
@@ -6,6 +6,7 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/backend/settings_helpers.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -93,19 +94,67 @@ class MethodChannelHandlers {
         return _ok();
       }
 
-      final Map<String, dynamic>? data = arguments;
+      Logger.info('BB_MAP_FIX_V3 handling new-message push');
+      final Map<String, dynamic>? data = normalizeMethodChannelArguments(arguments);
       if (!isNullOrEmpty(data)) {
-        final payload = ServerPayload.fromJson(data!);
+        late final ServerPayload payload;
+        late final Map<String, dynamic> messageData;
+        late final Chat chat;
+        late final Message message;
+        late final List<Attachment> attachments;
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=ServerPayload');
+          payload = ServerPayload.fromJson(data!);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at ServerPayload: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=messageData');
+          messageData = asStringDynamicMapRequired(payload.data);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at messageData: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=Message');
+          message = Message.fromMap(messageData);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at Message: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=attachments count=${(messageData['attachments'] as List?)?.length ?? 0}');
+          attachments = ((messageData['attachments'] as List?) ?? const [])
+              .map((e) => Attachment.fromMap(asStringDynamicMapRequired(e)))
+              .toList();
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at attachments: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=Chat');
+          final chatJson = asStringDynamicMapRequired(messageData['chats']?.first);
+          chatJson.remove('lastMessage');
+          chat = Chat.fromMap(chatJson);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at Chat: $e', trace: s);
+          rethrow;
+        }
+
+        Logger.info('BB_MAP_FIX_V3 step=IncomingMsgHandler');
         await IncomingMsgHandler.handle(IncomingPayload(
           type: MessageEventType.newMessage,
           source: MessageSource.methodChannel,
-          chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
-          message: Message.fromMap(payload.data),
-          attachments: ((payload.data['attachments'] as List?) ?? const [])
-              .whereType<Map>()
-              .map((e) => Attachment.fromMap(e.cast<String, Object>()))
-              .toList(),
-          tempGuid: payload.data['tempGuid'],
+          chat: chat,
+          message: message,
+          attachments: attachments,
+          tempGuid: messageData['tempGuid'],
         ));
       }
     } catch (e, s) {
@@ -133,16 +182,17 @@ class MethodChannelHandlers {
     }
 
     try {
-      final Map<String, dynamic>? data = arguments;
+      final Map<String, dynamic>? data = normalizeMethodChannelArguments(arguments);
       if (!isNullOrEmpty(data)) {
         final payload = ServerPayload.fromJson(data!);
+        final messageData = deepNormalizeJson(payload.data) as Map<String, dynamic>;
 
-        if (payload.data['chats'] == null || payload.data['chats'].isEmpty) {
+        if (messageData['chats'] == null || (messageData['chats'] as List).isEmpty) {
           Logger.info('No chat data found, attempting to find chat from message guid...');
-          final existingMsg = Message.findOne(guid: payload.data['guid']);
+          final existingMsg = Message.findOne(guid: messageData['guid']);
           if (existingMsg != null && existingMsg.chat.target != null) {
             Logger.info('Found chat from message guid, adding to payload');
-            payload.data['chats'] = [existingMsg.chat.target!.toMap()];
+            messageData['chats'] = [existingMsg.chat.target!.toMap()];
           } else {
             Logger.warn('No chat data found, and unable to find chat from message guid');
             return _retry();
@@ -152,13 +202,13 @@ class MethodChannelHandlers {
         await IncomingMsgHandler.handle(IncomingPayload(
           type: MessageEventType.updatedMessage,
           source: MessageSource.methodChannel,
-          chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
-          message: Message.fromMap(payload.data),
-          attachments: ((payload.data['attachments'] as List?) ?? const [])
+          chat: Chat.fromMap(deepNormalizeJson(messageData['chats'].first) as Map<String, dynamic>),
+          message: Message.fromMap(messageData),
+          attachments: ((messageData['attachments'] as List?) ?? const [])
               .whereType<Map>()
-              .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+              .map((e) => Attachment.fromMap(deepNormalizeJson(e) as Map<String, dynamic>))
               .toList(),
-          tempGuid: payload.data['tempGuid'],
+          tempGuid: messageData['tempGuid'],
         ));
       }
     } catch (e, s) {

--- a/lib/services/backend/java_dart_interop/method_channel_service.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:bluebubbles/services/network/method_channel_actions.dart';
 import 'package:bluebubbles/services/backend/java_dart_interop/method_channel_handlers.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
@@ -81,8 +82,7 @@ class MethodChannelService implements MethodChannelServiceDelegate {
   }
 
   Future<bool> _callHandler(MethodCall call) async {
-    final Map<String, dynamic>? arguments =
-        call.arguments is String ? jsonDecode(call.arguments) : call.arguments?.cast<String, Object>();
+    final Map<String, dynamic>? arguments = normalizeMethodChannelArguments(call.arguments);
 
     // ONLY RETURN Future.value or Future.error
     // Future.value(false) will have the engine retry the call

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -9,6 +9,8 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/helpers/ui/facetime_helpers.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/models/models.dart' show HandleLookupKey;
+import 'package:bluebubbles/services/backend/interfaces/contact_v2_interface.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -27,6 +29,111 @@ import 'package:get_it/get_it.dart';
 
 // ignore: non_constant_identifier_names
 NotificationsService get NotificationsSvc => GetIt.I<NotificationsService>();
+
+/// Android Contacts row ID for linking notifications to system DND starred-contact rules.
+String? nativeContactIdForHandle(Handle? handle) {
+  if (handle == null) return null;
+
+  ContactV2? contact = handle.contactsV2.where((c) => c.isNative).firstOrNull;
+  contact ??= handle.contactsV2.firstOrNull;
+  if (contact == null) return null;
+
+  final id = contact.nativeContactId;
+  if (id.isEmpty || int.tryParse(id) == null) return null;
+  return id;
+}
+
+Future<String?> nativeContactIdForMessage(Message message) async {
+  final handle = message.handleRelation.target;
+  final fromHandle = nativeContactIdForHandle(handle);
+  if (fromHandle != null) return fromHandle;
+
+  final address = handle?.address;
+  if (address == null || address.isEmpty) return null;
+
+  final contact = await ContactV2Interface.getContactByAddress(address: address);
+  if (contact == null) return null;
+  final id = contact.nativeContactId;
+  if (id.isEmpty || int.tryParse(id) == null) return null;
+  return id;
+}
+
+/// Incoming pushes can arrive before ObjectBox ToOne links are hydrated on the
+/// in-memory [Message]. Reload and fall back to chat participants so attachment
+/// notifications are not dropped.
+String notificationSenderName(Message message, Chat chat) {
+  if (message.handleRelation.hasValue) {
+    return message.handleRelation.target!.displayName;
+  }
+  if (message.handle != null) {
+    return message.handle!.displayName;
+  }
+  if (message.handleId != null && message.handleId! > 0) {
+    for (final h in chat.handles) {
+      if (h.originalROWID == message.handleId) return h.displayName;
+    }
+    final global = Handle.findOne(originalROWID: message.handleId);
+    if (global != null) return global.displayName;
+  }
+  return 'Unknown';
+}
+
+Message resolveHandleForNotification(Message message, Chat chat) {
+  Message m = message;
+
+  if (!m.handleRelation.hasValue && m.guid != null) {
+    final reloaded = Message.findOne(guid: m.guid);
+    if (reloaded != null) {
+      m = reloaded;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && m.handleId != null && m.handleId! > 0) {
+    final handle = Handle.findOne(originalROWID: m.handleId);
+    if (handle != null) {
+      m.handleRelation.target = handle;
+      return m;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && m.handle != null) {
+    final handle = Handle.findOne(
+          addressAndService: HandleLookupKey(m.handle!.address, m.handle!.service),
+        ) ??
+        m.handle;
+    if (handle != null) {
+      m.handleRelation.target = handle;
+      return m;
+    }
+  }
+
+  final participantPool = chat.handles.isNotEmpty ? chat.handles.toList() : chat.participants;
+  if (!m.handleRelation.hasValue && m.handleId != null && participantPool.isNotEmpty) {
+    final participant = participantPool.cast<Handle?>().firstWhereOrNull(
+          (h) => h?.originalROWID == m.handleId,
+        );
+    if (participant != null) {
+      m.handleRelation.target = participant;
+      return m;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && chat.isGroup && m.handle != null && participantPool.isNotEmpty) {
+    final byAddress = participantPool.cast<Handle?>().firstWhereOrNull(
+          (h) => h?.address == m.handle!.address && h?.service == m.handle!.service,
+        );
+    if (byAddress != null) {
+      m.handleRelation.target = byAddress;
+      return m;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && !chat.isGroup && chat.participants.isNotEmpty) {
+    m.handleRelation.target = chat.participants.first;
+  }
+
+  return m;
+}
 
 class PendingToastItem {
   final String? sender;
@@ -132,7 +239,7 @@ class NotificationsService {
     if (chat.shouldMuteNotification(message) || message.isFromMe!) return;
     final isGroup = chat.isGroup;
     final guid = chat.guid;
-    final contactName = message.handleRelation.target?.displayName ?? "Unknown";
+    final contactName = notificationSenderName(message, chat);
     final title = isGroup ? chat.getTitle() : contactName;
     final text = hideContent ? "iMessage" : message.getNotificationText();
     final isReaction = !isNullOrEmpty(message.associatedMessageGuid);
@@ -174,10 +281,20 @@ class NotificationsService {
             SettingsSvc.settings.notificationReactionAction.value &&
             message.associatedMessageGuid == null;
         final String reactionType = SettingsSvc.settings.notificationReactionActionType.value;
+        String? nativeContactId;
+        try {
+          nativeContactId = await nativeContactIdForMessage(message);
+        } catch (e, s) {
+          Logger.warn(
+            'Contact lookup failed for notification; continuing without contact link',
+            tag: 'NotificationsService',
+            error: e,
+            trace: s,
+          );
+        }
 
         await GetIt.I.isReady<MethodChannelService>();
         await MethodChannelSvc.actions.createIncomingMessageNotification(
-          channelId: NEW_MESSAGE_CHANNEL,
           chatId: chat.id,
           chatGuid: guid,
           chatIsGroup: isGroup,
@@ -185,26 +302,28 @@ class NotificationsService {
           chatIcon: isGroup ? chatIcon : contactIcon,
           contactName: contactName,
           contactAvatar: contactIcon,
+          nativeContactId: nativeContactId,
           messageGuid: message.guid!,
           messageText: text,
           messageDate: message.dateCreated!.millisecondsSinceEpoch,
           messageIsFromMe: false,
           showReactionAction: showReactionAction,
           reactionType: reactionType,
+          dndFavoritesOverride: SettingsSvc.settings.dndFavoritesOverride.value,
         );
       }
     }
   }
 
   Future<void> tryCreateNewMessageNotification(Message message, Chat chat) async {
-    if (message.isFromMe! || !message.handleRelation.hasValue) {
-      if (!(message.isFromMe ?? false) && !message.handleRelation.hasValue) {
-        Logger.warn(
-          'Skipping notification for ${message.guid} — handle relation not resolved',
-          tag: 'NotificationsService',
-        );
-      }
-      return;
+    if (message.isFromMe!) return;
+
+    message = resolveHandleForNotification(message, chat);
+    if (!message.handleRelation.hasValue) {
+      Logger.warn(
+        'Handle relation not resolved for ${message.guid}; posting notification with chat fallback',
+        tag: 'NotificationsService',
+      );
     }
     if (message.isKeptAudio) return;
     if (chat.shouldMuteNotification(message)) return;

--- a/lib/services/network/method_channel_actions.dart
+++ b/lib/services/network/method_channel_actions.dart
@@ -96,7 +96,6 @@ class MethodChannelActions {
   }
 
   Future<void> createIncomingMessageNotification({
-    required String channelId,
     required int? chatId,
     required String chatGuid,
     required bool chatIsGroup,
@@ -104,15 +103,16 @@ class MethodChannelActions {
     required Uint8List chatIcon,
     required String contactName,
     required Uint8List contactAvatar,
+    required String? nativeContactId,
     required String messageGuid,
     required String messageText,
     required int messageDate,
     required bool messageIsFromMe,
     required bool showReactionAction,
     required String reactionType,
+    required bool dndFavoritesOverride,
   }) async {
     await service.invokeMethod('create-incoming-message-notification', {
-      'channel_id': channelId,
       'chat_id': chatId,
       'chat_guid': chatGuid,
       'chat_is_group': chatIsGroup,
@@ -120,12 +120,14 @@ class MethodChannelActions {
       'chat_icon': chatIcon,
       'contact_name': contactName,
       'contact_avatar': contactAvatar,
+      if (nativeContactId != null) 'native_contact_id': nativeContactId,
       'message_guid': messageGuid,
       'message_text': messageText,
       'message_date': messageDate,
       'message_is_from_me': messageIsFromMe,
       'show_reaction_action': showReactionAction,
       'reaction_type': reactionType,
+      'dnd_favorites_override': dndFavoritesOverride,
     });
   }
 

--- a/lib/utils/deep_map_normalize.dart
+++ b/lib/utils/deep_map_normalize.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+/// Recursively converts platform-channel / Gson maps into plain Dart JSON maps.
+dynamic deepNormalizeJson(dynamic raw) {
+  if (raw == null) return null;
+
+  if (raw is String) {
+    try {
+      return deepNormalizeJson(jsonDecode(raw));
+    } catch (_) {
+      return raw;
+    }
+  }
+
+  if (raw is Map || raw is List) {
+    try {
+      return jsonDecode(jsonEncode(raw));
+    } catch (_) {
+      if (raw is Map) {
+        return Map<String, dynamic>.fromEntries(
+          raw.entries.map(
+            (e) => MapEntry(e.key.toString(), deepNormalizeJson(e.value)),
+          ),
+        );
+      }
+      if (raw is List) {
+        return raw.map(deepNormalizeJson).toList();
+      }
+    }
+  }
+
+  return raw;
+}
+
+Map<String, dynamic>? asStringDynamicMap(dynamic raw) {
+  if (raw == null) return null;
+  final normalized = deepNormalizeJson(raw);
+  if (normalized is Map<String, dynamic>) return normalized;
+  if (normalized is Map) return Map<String, dynamic>.from(normalized);
+  return null;
+}
+
+Map<String, dynamic> asStringDynamicMapRequired(dynamic raw) {
+  final map = asStringDynamicMap(raw);
+  if (map != null) return map;
+  throw FormatException('Expected Map<String, dynamic>, got ${raw.runtimeType}');
+}
+
+Map<String, dynamic>? normalizeMethodChannelArguments(dynamic raw) {
+  if (raw == null) return null;
+
+  try {
+    final normalized = deepNormalizeJson(raw);
+    if (normalized is Map<String, dynamic>) return normalized;
+    if (normalized is Map) return Map<String, dynamic>.from(normalized);
+  } catch (_) {}
+
+  return null;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -3112,26 +3112,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   throttling:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

This PR contains two bug fixes and one new feature, each in a self-contained commit. Happy for these to be taken individually or together.

### Bug fixes

**Unknown sender in group chat notifications** — A second message arriving rapidly in a group chat showed "Unknown" as the sender name. Root cause: the handle lookup on `Message` fell through to a DB query that raced with ObjectBox relation loading. Fix: check the in-memory transient `handle` field (populated by `addMessageToChat` before the DB put) before issuing the query. Also adds a `deep_map_normalize` utility to fix `LinkedHashMap<Object,Object>` type corruption on nested server payload maps after cross-isolate transfer (affects both FCM and UnifiedPush background paths).

**Notification Like/reaction button silently failing** — The `flutter.` key prefix was missing from `hasServerUrl()` and `hasAuthKey()` in `SettingsHelper.kt`, so `HttpService` always saw empty values and never made the HTTP call. Fixed in the feat commit below alongside the SettingsHelper changes for the DND feature.

### New feature: opt-in starred-contact DND bypass

Removes `setBypassDnd(true)` from the global notification channel (which bypassed DND for all contacts) and replaces it with per-notification logic: if the sender is starred in the Android contacts app, the notification `Person` is built with `setUri(lookupUri)` + `setImportant(true)`, letting Android's DND system grant the exception contact-by-contact.

The feature is **off by default**, controlled by a new toggle in Settings → Application Settings → Notification Settings → *Override DND for Favorites*.

**Implementation note on settings storage:** The toggle value (`dndFavoritesOverride`) is passed from Dart through the `create-incoming-message-notification` MethodChannel call rather than read from `SharedPreferences` on the Kotlin side. This avoids a storage mismatch introduced by `shared_preferences` v2.5.x: after the DataStore migration, new keys are written to Android DataStore, which is not accessible via the legacy `getSharedPreferences()` API used by `SettingsHelper`. Existing keys (written before migration) are unaffected.

**Conflict resolution note:** `DartWorkManager.kt` had a minor conflict with the upstream `APPEND_OR_REPLACE` enqueue fix. Resolved by combining both: `enqueueUniqueWork` with `APPEND_OR_REPLACE` inside the try-catch, so sequencing and error handling are both preserved.

## Commits

- `fix: resolve unknown sender in group notifications and infinite loading spinner`
- `feat: add starred-contact DND bypass with user-controlled settings toggle`
- `docs: add fork README documenting changes from v2.0.0+85`