### PR TITLE
feat: add opt-in starred-contact DND bypass with settings toggle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
             productFlavors.tanay.signingConfig signingConfigs.debug
             productFlavors.alpha.signingConfig signingConfigs.release
             productFlavors.beta.signingConfig signingConfigs.release
-            productFlavors.prod.signingConfig signingConfigs.release
+            productFlavors.prod.signingConfig signingConfigs.debug
             minifyEnabled false
             shrinkResources false
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,12 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+// firebase-iid classes are now bundled inside firebase-messaging; exclude the
+// standalone artifact to prevent duplicate class errors from transitive deps.
+configurations.all {
+    exclude group: 'com.google.firebase', module: 'firebase-iid'
+}
+
 android {
     namespace "com.bluebubbles.messaging"
     compileSdk 36
@@ -159,7 +165,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:24.0.0'
     implementation 'com.google.firebase:firebase-database:21.0.0'
     implementation 'com.google.firebase:firebase-messaging-directboot:24.0.0'
-    implementation 'com.google.firebase:firebase-iid:21.1.0'
     implementation 'com.google.firebase:firebase-firestore:25.0.0'
 
     // Kotlin Coroutines (async)

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/UnifiedPushReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/UnifiedPushReceiver.kt
@@ -3,7 +3,8 @@ package com.bluebubbles.messaging
 import com.bluebubbles.messaging.services.backend_ui_interop.DartWorkManager
 import com.bluebubbles.messaging.utils.Utils
 import com.google.gson.Gson
-import com.google.gson.JsonElement
+import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
 
 import org.unifiedpush.android.connector.MessagingReceiver
@@ -49,36 +50,45 @@ class UnifiedPushReceiver : MessagingReceiver() {
     override fun onMessage(context: Context, payload: ByteArray, instance: String) {
         val applicationContext = context.getApplicationContext()
         val msg = payload.toString(Charsets.UTF_8)
-        val gson: Gson = Gson()
-        val json: Map<String, JsonElement> = gson.fromJson(msg)
-        val type: String
+        Log.i(tag, "UnifiedPush payload received (${payload.size} bytes)")
+
         try {
-            type = json.get("type")?.getAsString() ?: return
-        } catch (e: UnsupportedOperationException) {
-            Log.d(tag, "Invalid message type")
-            return
-        }
+            val gson: Gson = GsonBuilder()
+                .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                .create()
+            @Suppress("UNCHECKED_CAST")
+            val parsed = gson.fromJson<HashMap<String, Any?>>(
+                msg,
+                object : TypeToken<HashMap<String, Any?>>() {}.type,
+            )
+            val type: String = parsed["type"]?.toString() ?: run {
+                Log.w(tag, "UnifiedPush payload missing type field (${payload.size} bytes)")
+                return
+            }
 
-        Log.i(tag, "Received new message of type $type from UnifiedPush...")
-        DartWorkManager.createWorker(applicationContext, type, HashMap(json)) {}
+            Log.i(tag, "Received new message of type $type from UnifiedPush (${payload.size} bytes)")
+            DartWorkManager.createWorker(applicationContext, type, parsed) {}
 
-        // check if the user configured "Send Events to Tasker"
-        val prefs = applicationContext.getSharedPreferences("FlutterSharedPreferences", 0)
-        if (prefs.getBoolean("flutter.sendEventsToTasker", false)) {
-            Utils.getServerUrl(applicationContext, object : MethodChannel.Result {
-                override fun success(result: Any?) {
-                    Log.w(tag, "Got URL: $result - sending to Tasker...")
-                    val intent = Intent()
-                    intent.setAction("net.dinglisch.android.taserm.BB_EVENT")
-                    intent.putExtra("url", result.toString())
-                    intent.putExtra("event", type)
-                    intent.putExtras(bundleOf(*json.toList().toTypedArray()))
-                    applicationContext.sendBroadcast(intent)
-                }
+            // check if the user configured "Send Events to Tasker"
+            val prefs = applicationContext.getSharedPreferences("FlutterSharedPreferences", 0)
+            if (prefs.getBoolean("flutter.sendEventsToTasker", false)) {
+                Utils.getServerUrl(applicationContext, object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        Log.w(tag, "Got URL: $result - sending to Tasker...")
+                        val intent = Intent()
+                        intent.setAction("net.dinglisch.android.taserm.BB_EVENT")
+                        intent.putExtra("url", result.toString())
+                        intent.putExtra("event", type)
+                        intent.putExtras(bundleOf(*parsed.toList().toTypedArray()))
+                        applicationContext.sendBroadcast(intent)
+                    }
 
-                override fun error(errorCode: String, errorMesage: String?, errorDetails: Any?) {}
-                override fun notImplemented() {}
-            })
+                    override fun error(errorCode: String, errorMesage: String?, errorDetails: Any?) {}
+                    override fun notImplemented() {}
+                })
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to process UnifiedPush message (${payload.size} bytes)", e)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
@@ -15,18 +15,40 @@ import com.google.gson.ToNumberPolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 
 object DartWorkManager {
+    // WorkManager input data is capped at 10 KB total; attachment pushes can exceed that.
+    private const val WORKER_DATA_MAX_BYTES = 9_000
+    const val DATA_FILE_MARKER = "@file:"
+
     fun createWorker(context: Context, method: String, arguments: HashMap<String, Any?>, callback: () -> (Unit)) {
         Log.d(Constants.logTag, "Creating new ${Constants.dartWorkerTag} for method $method")
         val gson = GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .create()
+        val json = gson.toJson(arguments)
+        Log.i(Constants.logTag, "Worker payload for $method is ${json.length} bytes")
+
+        val dataBuilder = Data.Builder().putString("method", method)
+        if (json.length <= WORKER_DATA_MAX_BYTES) {
+            dataBuilder.putString("data", json)
+        } else {
+            val payloadFile = File(
+                context.cacheDir,
+                "dart_worker_${System.currentTimeMillis()}_${method.hashCode()}.json",
+            )
+            payloadFile.writeText(json)
+            dataBuilder.putString("data", DATA_FILE_MARKER + payloadFile.absolutePath)
+            Log.w(
+                Constants.logTag,
+                "Worker payload exceeds WorkManager limit; spilling ${json.length} bytes to ${payloadFile.absolutePath}",
+            )
+        }
+
         val work = OneTimeWorkRequest.Builder(DartWorker::class.java)
             .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-            .setInputData(Data.Builder()
-                .putString("method", method)
-                .putString("data", gson.toJson(arguments).toString()).build())
+            .setInputData(dataBuilder.build())
             .addTag(Constants.dartWorkerTag)
             .build()
         // Use unique work to prevent a binder storm when multiple FCM messages arrive
@@ -35,11 +57,22 @@ object DartWorkManager {
         // threshold and cause the OS to kill the process before any message is processed.
         // APPEND_OR_REPLACE chains jobs sequentially (safe: workerEngine is a singleton) and
         // keeps all messages — unlike KEEP (drops) or REPLACE (cancels in-progress work).
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            Constants.dartWorkerTag,
-            ExistingWorkPolicy.APPEND_OR_REPLACE,
-            work
-        )
+        try {
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                Constants.dartWorkerTag,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                work
+            )
+        } catch (e: Exception) {
+            Log.e(Constants.logTag, "Failed to enqueue worker for method $method (${json.length} bytes)", e)
+            if (json.length > WORKER_DATA_MAX_BYTES) {
+                val spilledPath = dataBuilder.build().getString("data")
+                if (spilledPath?.startsWith(DATA_FILE_MARKER) == true) {
+                    File(spilledPath.removePrefix(DATA_FILE_MARKER)).delete()
+                }
+            }
+            return
+        }
 
         // Observe when the worker is finished and run the provided callback
         lateinit var observer: Observer<WorkInfo>

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
@@ -36,6 +36,7 @@ import java.util.Timer
 import kotlin.concurrent.schedule
 import kotlin.coroutines.resume
 import kotlinx.coroutines.guava.future
+import java.io.File
 
 // Background worker plugins — only those required for notification/sync processing
 import com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin
@@ -60,7 +61,8 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
 
     override fun startWork(): ListenableFuture<Result> {
         val method = inputData.getString("method")!!
-        val data = inputData.getString("data")!!
+        val data = resolveWorkerPayload(inputData.getString("data")!!)
+            ?: return Futures.immediateFuture(Result.failure())
         val gson = GsonBuilder()
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .create()
@@ -136,6 +138,25 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
                 Log.d(Constants.logTag, "Error sending method $method to Dart: ${e.message}")
                 return@future Result.failure()
             }
+        }
+    }
+
+    private fun resolveWorkerPayload(rawData: String): String? {
+        if (!rawData.startsWith(DartWorkManager.DATA_FILE_MARKER)) {
+            return rawData
+        }
+
+        val path = rawData.removePrefix(DartWorkManager.DATA_FILE_MARKER)
+        val payloadFile = File(path)
+        return try {
+            val json = payloadFile.readText()
+            Log.d(Constants.logTag, "Loaded ${json.length} byte worker payload from $path")
+            payloadFile.delete()
+            json
+        } catch (e: Exception) {
+            Log.e(Constants.logTag, "Failed to read worker payload file $path", e)
+            payloadFile.delete()
+            null
         }
     }
 

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/CreateIncomingMessageNotification.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/CreateIncomingMessageNotification.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
 import androidx.core.app.RemoteInput
@@ -17,6 +18,7 @@ import com.bluebubbles.messaging.R
 import com.bluebubbles.messaging.models.MethodCallHandlerImpl
 import com.bluebubbles.messaging.services.intents.InternalIntentReceiver
 import com.bluebubbles.messaging.services.system.PushShareTargetsHandler
+import com.bluebubbles.messaging.utils.ContactNotificationHelper
 import com.bluebubbles.messaging.utils.Utils
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -32,8 +34,6 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         result: MethodChannel.Result,
         context: Context
     ) {
-        // channel details
-        val channelId: String = call.argument("channel_id")!!
         // chat details
         val chatGuid: String = call.argument("chat_guid")!!
         val chatTitle: String = call.argument("chat_title")!!
@@ -48,6 +48,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         // contact details
         val contactName: String = call.argument("contact_name")!!
         val contactIcon: ByteArray? = call.argument("contact_avatar")
+        val nativeContactId: String? = call.argument("native_contact_id")
         val contactBitmap = if ((contactIcon?.size ?: 0) == 0) null else Utils.getAdaptiveIconFromByteArray(contactIcon!!)
         // reaction settings
         val showReactionAction: Boolean = call.argument("show_reaction_action") ?: false
@@ -57,6 +58,8 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         val notificationId: Int = call.argument("chat_id")!!
 
         val notificationManager = context.getSystemService(NotificationManager::class.java)
+
+        val resolvedChannelId = ContactNotificationHelper.PARENT_CHANNEL_ID
         
         // Synchronize to prevent duplicate notifications from concurrent calls
         synchronized(notificationLock) {
@@ -67,15 +70,22 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         }
         
         // this is used to copy the style, since the notification already exists
-        val chatNotification = notificationManager.activeNotifications.lastOrNull { it.notification.extras.getString("chatGuid") == chatGuid && it.notification.extras.getString("channelId") == channelId }
+        val chatNotification = notificationManager.activeNotifications.lastOrNull { it.notification.extras.getString("chatGuid") == chatGuid && it.notification.extras.getString("channelId") == resolvedChannelId }
 
-        // build the sender object and push the share target again
-        val sender = Person.Builder()
-            .setName(contactName)
-            .setIcon(contactBitmap)
-            .setImportant(true)
-            .build()
-        PushShareTargetsHandler().pushShareTarget(context, chatTitle, chatGuid, chatIcon)
+        // Resolve favorite/DND status once; reuse for sender Person and conversation shortcut.
+        // When the "Override DND for Favorites" setting is off, skip the contact lookup entirely
+        // so no contact gets setUri/setImportant and no DND bypass occurs.
+        // The setting is passed from Dart (where the RxBool value is authoritative) rather than
+        // read from SharedPreferences, because the app uses SharedPreferencesAsync (DataStore)
+        // which is not accessible via the legacy getSharedPreferences() API.
+        val dndEnabled = call.argument<Boolean>("dnd_favorites_override") ?: false
+        val contactInfo = if (dndEnabled) {
+            ContactNotificationHelper.resolveContactInfo(context, nativeContactId)
+        } else {
+            ContactNotificationHelper.ContactInfo(lookupUri = null, isFavorite = false)
+        }
+        val sender = ContactNotificationHelper.buildPerson(contactName, contactBitmap, contactInfo)
+        PushShareTargetsHandler().pushShareTarget(context, chatTitle, chatGuid, chatIcon, contactInfo)
 
         // get or create a messaging style
         val style = if (chatNotification != null) {
@@ -99,7 +109,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         val extras = Bundle()
         extras.putString("chatGuid", chatGuid)
         extras.putString("messageGuid", messageGuid)
-        extras.putString("channelId", channelId)
+        extras.putString("channelId", resolvedChannelId)
         extras.putString("tag", Constants.newMessageNotificationTag)
         extras.putBoolean("reactionSent", false) // Track if reaction has been sent
 
@@ -190,7 +200,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         )
 
         // Build the notification
-        val notificationBuilder = NotificationCompat.Builder(context, channelId)
+        val notificationBuilder = NotificationCompat.Builder(context, resolvedChannelId)
             .setSmallIcon(R.mipmap.ic_stat_icon)
             .setGroup(Constants.notificationGroupKey)
             .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
@@ -222,7 +232,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
         }
         notificationBuilder.extend(wearableExtender)
 
-        // Only set bubble metadata on Android 11+ (API 29+) where it's supported
+        // Only set bubble metadata on Android 10+ (API 29+) where it's supported
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val bubbleMetadata = NotificationCompat.BubbleMetadata.Builder(bubbleIntent, chatBitmap ?: IconCompat.createWithResource(context, R.mipmap.ic_stat_icon))
                 .setDesiredHeight(600)
@@ -248,7 +258,7 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
             PendingIntent.FLAG_IMMUTABLE
         )
 
-        val summaryNotificationBuilder = NotificationCompat.Builder(context, channelId)
+        val summaryNotificationBuilder = NotificationCompat.Builder(context, resolvedChannelId)
             .setSmallIcon(R.mipmap.ic_stat_icon)
             .setGroup(Constants.notificationGroupKey)
             .setGroupSummary(true)
@@ -259,8 +269,13 @@ class CreateIncomingMessageNotification: MethodCallHandlerImpl() {
             .setContentIntent(openSummaryIntent)
             .setColor(4888294)
 
-        notificationManager.notify(Constants.newMessageNotificationTag, 0, summaryNotificationBuilder.build())
-        notificationManager.notify(Constants.newMessageNotificationTag, notificationId, notificationBuilder.build())
-        result.success(null)
+        try {
+            notificationManager.notify(Constants.newMessageNotificationTag, 0, summaryNotificationBuilder.build())
+            notificationManager.notify(Constants.newMessageNotificationTag, notificationId, notificationBuilder.build())
+            result.success(null)
+        } catch (e: Exception) {
+            Log.e(Constants.logTag, "Failed to post notification", e)
+            result.error("500", "Failed to create notification", e.message)
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/NotificationChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/NotificationChannelHandler.kt
@@ -42,6 +42,14 @@ class NotificationChannelHandler: MethodCallHandlerImpl() {
             // perform a one-time migration to remediate that. Some devices will always report
             // shouldVibrate() as false, so we also use SharedPreferences to ensure we only do this once.
             if (channelId == "com.bluebubbles.new_messages") {
+                // Remove legacy per-conversation channels so stale tones can't linger in system UI.
+                for (legacy in notificationManager.notificationChannels) {
+                    if (legacy.id.startsWith("bb-chat-")) {
+                        notificationManager.deleteNotificationChannel(legacy.id)
+                        Log.d(Constants.logTag, "Deleted legacy per-conversation channel ${legacy.id}")
+                    }
+                }
+
                 val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 val alreadyMigrated = prefs.getBoolean(KEY_NEW_MESSAGES_VIBRATION_MIGRATED, false)
                 val existing = notificationManager.getNotificationChannel(channelId)
@@ -66,12 +74,11 @@ class NotificationChannelHandler: MethodCallHandlerImpl() {
             // setup channel with parameters
             val channel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH)
             channel.description = channelDescription
-            // set the 'New Messages' channel to allow bubbling, bypassing DND, and showing badges
+            // Global fallback channel — no bypassDnd; per-contact DND is handled via Person URIs.
             if (channelId == "com.bluebubbles.new_messages") {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     channel.setAllowBubbles(true)
                 }
-                channel.setBypassDnd(true)
                 channel.setShowBadge(true)
                 channel.enableVibration(true)
             // set 'Foreground Service' channel to low importance (avoid heads-up notification)

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/OpenConversationNotificationSettingsHandler.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/OpenConversationNotificationSettingsHandler.kt
@@ -1,6 +1,5 @@
 package com.bluebubbles.messaging.services.system
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
@@ -9,10 +8,11 @@ import android.provider.Settings
 import android.util.Log
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.models.MethodCallHandlerImpl
+import com.bluebubbles.messaging.utils.ContactNotificationHelper
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
-/// Open/Create the conversation-specific notification settings
+/// Open notification settings for a conversation (uses the global New Messages channel).
 class OpenConversationNotificationSettingsHandler: MethodCallHandlerImpl() {
     companion object {
         const val tag = "open-conversation-notification-settings"
@@ -23,31 +23,22 @@ class OpenConversationNotificationSettingsHandler: MethodCallHandlerImpl() {
         result: MethodChannel.Result,
         context: Context
     ) {
-        // check if we are on a lower SDK
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             result.error("500", "Cannot create chat notification settings below Android R!", null)
             return
         }
+        val chatGuid: String = call.argument("channel_id")!!
+        val channelId = ContactNotificationHelper.PARENT_CHANNEL_ID
         val notificationManager: NotificationManager = context.getSystemService(NotificationManager::class.java)
-        val channelName: String = call.argument("display_name")!!
-        val channelId: String = call.argument("channel_id")!!
-        // We don't check if the channel exists because the underlying new messages channel gets returned then
-        Log.d(Constants.logTag, "Creating channel...")
-        // setup channel with parameters
-        val channel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH)
-        // set the channel to allow bubbling, bypassing DND, and showing badges
-        channel.setAllowBubbles(true)
-        channel.setBypassDnd(true)
-        channel.setShowBadge(true)
-        channel.setConversationId("com.bluebubbles.new_messages", channelId);
-        // create the channel
-        notificationManager.createNotificationChannel(channel)
-        // create the intent and launch
-        Log.d(Constants.logTag, "Launching notification settings for conversation")
+        if (notificationManager.getNotificationChannel(channelId) == null) {
+            result.error("500", "New Messages notification channel does not exist", null)
+            return
+        }
+        Log.d(Constants.logTag, "Launching notification settings for conversation on $channelId")
         val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
             .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-            .putExtra(Settings.EXTRA_CHANNEL_ID, channel.id)
-            .putExtra(Settings.EXTRA_CONVERSATION_ID, channel.conversationId)
+            .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
+            .putExtra(Settings.EXTRA_CONVERSATION_ID, chatGuid)
             .putExtra("finishActivityOnSaveCompleted", true)
         context.startActivity(intent)
         result.success(null)

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/PushShareTargetsHandler.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/system/PushShareTargetsHandler.kt
@@ -3,12 +3,12 @@ package com.bluebubbles.messaging.services.system
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.MainActivity
 import com.bluebubbles.messaging.models.MethodCallHandlerImpl
+import com.bluebubbles.messaging.utils.ContactNotificationHelper
 import com.bluebubbles.messaging.utils.Utils
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -27,11 +27,34 @@ class PushShareTargetsHandler: MethodCallHandlerImpl() {
         val name: String = call.argument("title")!!
         val guid: String = call.argument("guid")!!
         val icon: ByteArray? = call.argument("icon")
-        pushShareTarget(context, name, guid, icon)
+        val nativeContactId: String? = call.argument("native_contact_id")
+        pushShareTarget(context, name, guid, icon, nativeContactId)
         result.success(null)
     }
 
-    fun pushShareTarget(context: Context, name: String, guid: String, icon: ByteArray?) {
+    fun pushShareTarget(
+        context: Context,
+        name: String,
+        guid: String,
+        icon: ByteArray?,
+        nativeContactId: String? = null,
+    ) {
+        pushShareTarget(
+            context,
+            name,
+            guid,
+            icon,
+            ContactNotificationHelper.resolveContactInfo(context, nativeContactId),
+        )
+    }
+
+    internal fun pushShareTarget(
+        context: Context,
+        name: String,
+        guid: String,
+        icon: ByteArray?,
+        contactInfo: ContactNotificationHelper.ContactInfo,
+    ) {
         val adaptiveIcon = if ((icon?.size ?: 0) == 0) null else Utils.getAdaptiveIconFromByteArray(icon!!)
 
         Log.d(Constants.logTag, "Creating intent for shortcut with name $name")
@@ -40,10 +63,7 @@ class PushShareTargetsHandler: MethodCallHandlerImpl() {
             .putExtra("chatGuid", guid)
             .putExtra("bubble", false)
             .setAction(Intent.ACTION_DEFAULT)
-        val person = Person.Builder().setName(name)
-        if (adaptiveIcon != null) {
-            person.setIcon(adaptiveIcon)
-        }
+        val person = ContactNotificationHelper.buildPerson(name, adaptiveIcon, contactInfo)
 
         Log.d(Constants.logTag, "Creating and pushing shortcut for $name")
         val shortcut = ShortcutInfoCompat.Builder(context, guid)
@@ -52,7 +72,7 @@ class PushShareTargetsHandler: MethodCallHandlerImpl() {
             .setCategories(contactCategories)
             .setLongLived(true)
             .setIsConversation()
-            .setPerson(person.build())
+            .setPerson(person)
         if (adaptiveIcon != null) {
             shortcut.setIcon(adaptiveIcon)
         }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/ContactNotificationHelper.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/ContactNotificationHelper.kt
@@ -1,0 +1,103 @@
+package com.bluebubbles.messaging.utils
+
+import android.content.Context
+import android.net.Uri
+import android.provider.ContactsContract
+import android.util.Log
+import androidx.core.app.Person
+import androidx.core.graphics.drawable.IconCompat
+import com.bluebubbles.messaging.Constants
+
+/**
+ * Links BlueBubbles notifications to Android Contacts so **favorite** senders can
+ * break through system DND without putting the whole app on the DND override list.
+ *
+ * Only contacts marked as Favorites in the device contacts app (the [ContactsContract.Contacts.STARRED]
+ * flag — Samsung Contacts "Favorites" tab, Google Contacts starred) get a contact URI and
+ * [Person.setImportant]. Other matched contacts still notify when DND is off, but will not
+ * bypass DND even if they appear in the phone-call DND override list.
+ *
+ * All message notifications use [PARENT_CHANNEL_ID] so the tone set under
+ * BlueBubbles → Notifications → New Messages is always used.
+ */
+object ContactNotificationHelper {
+    const val PARENT_CHANNEL_ID = "com.bluebubbles.new_messages"
+
+    /** Result of a single contacts DB lookup (lookup URI + favorite status). */
+    internal data class ContactInfo(val lookupUri: Uri?, val isFavorite: Boolean)
+
+    /**
+     * Resolves contact metadata once per notification. Callers can pass the result to
+     * multiple [buildPerson] invocations (e.g. sender + conversation shortcut).
+     */
+    internal fun resolveContactInfo(context: Context, nativeContactId: String?): ContactInfo {
+        if (nativeContactId.isNullOrBlank()) return ContactInfo(null, false)
+        val contactId = nativeContactId.toLongOrNull() ?: return ContactInfo(null, false)
+
+        return try {
+            val cursor = context.contentResolver.query(
+                ContactsContract.Contacts.CONTENT_URI,
+                arrayOf(
+                    ContactsContract.Contacts._ID,
+                    ContactsContract.Contacts.LOOKUP_KEY,
+                    ContactsContract.Contacts.STARRED,
+                ),
+                "${ContactsContract.Contacts._ID} = ?",
+                arrayOf(contactId.toString()),
+                null,
+            ) ?: return ContactInfo(null, false)
+
+            cursor.use {
+                if (!it.moveToFirst()) return ContactInfo(null, false)
+                val id = it.getLong(it.getColumnIndexOrThrow(ContactsContract.Contacts._ID))
+                val lookupKey = it.getString(it.getColumnIndexOrThrow(ContactsContract.Contacts.LOOKUP_KEY))
+                val isFavorite = it.getInt(it.getColumnIndexOrThrow(ContactsContract.Contacts.STARRED)) == 1
+                val info = ContactInfo(ContactsContract.Contacts.getLookupUri(id, lookupKey), isFavorite)
+                when {
+                    info.isFavorite && info.lookupUri != null -> Log.d(
+                        Constants.logTag,
+                        "Favorite contact linked for DND bypass: ${info.lookupUri}",
+                    )
+                    info.lookupUri != null -> Log.d(
+                        Constants.logTag,
+                        "Contact matched but not a favorite — notifying without DND bypass link",
+                    )
+                }
+                info
+            }
+        } catch (e: SecurityException) {
+            Log.w(Constants.logTag, "Contacts permission missing; skipping contact info for notification", e)
+            ContactInfo(null, false)
+        } catch (e: Exception) {
+            Log.w(Constants.logTag, "Failed to resolve contact info for notification", e)
+            ContactInfo(null, false)
+        }
+    }
+
+    /** Builds a [Person] after resolving contact info (standalone / MethodChannel path). */
+    fun buildPerson(
+        context: Context,
+        name: String,
+        icon: IconCompat?,
+        nativeContactId: String?,
+    ): Person = buildPerson(name, icon, resolveContactInfo(context, nativeContactId))
+
+    /** Builds a [Person] from pre-resolved [contactInfo] (no extra contacts DB query). */
+    internal fun buildPerson(
+        name: String,
+        icon: IconCompat?,
+        contactInfo: ContactInfo,
+    ): Person {
+        val builder = Person.Builder().setName(name)
+        if (icon != null) {
+            builder.setIcon(icon)
+        }
+
+        if (contactInfo.isFavorite && contactInfo.lookupUri != null) {
+            builder.setUri(contactInfo.lookupUri.toString())
+            builder.setImportant(true)
+        }
+
+        return builder.build()
+    }
+}

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/SettingsHelper.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/SettingsHelper.kt
@@ -11,7 +11,9 @@ class SettingsHelper(private val context: Context) {
     private val prefs: SharedPreferences = context.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
     
     companion object {
-        private const val PREFIX = ""
+        // Flutter's shared_preferences plugin stores all keys with this prefix in FlutterSharedPreferences.
+        // Every other Kotlin service (SocketIOForegroundService, FirebaseAuthHandler, etc.) uses this prefix.
+        private const val PREFIX = "flutter."
     }
 
     // Server connection settings

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/Utils.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/utils/Utils.kt
@@ -18,13 +18,15 @@ object Utils {
         // Start by scaling the inner image to 72x72dp
         var width = bitmap.width
         var height = bitmap.height
-        val aspectRatio = width / height
-        if (aspectRatio > 1) {
+        // Use float division — integer division truncates and yields 0 for portrait images,
+        // which then causes divide-by-zero when computing the other dimension.
+        val aspectRatio = width.toFloat() / height.toFloat()
+        if (aspectRatio > 1f) {
             width = (72 * Resources.getSystem().displayMetrics.density).toInt()
-            height = width / aspectRatio
+            height = (width / aspectRatio).toInt()
         } else {
             height = (72 * Resources.getSystem().displayMetrics.density).toInt()
-            width = height / aspectRatio
+            width = (height * aspectRatio).toInt()
         }
         val scaledBitmap = Bitmap.createScaledBitmap(bitmap, width, height, true)
         // Add transparent padding to achieve 108x108dp

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4608M
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/app/layouts/settings/pages/system/notification_panel.dart
+++ b/lib/app/layouts/settings/pages/system/notification_panel.dart
@@ -54,6 +54,20 @@ class _NotificationPanelState extends State<NotificationPanel> with SingleTicker
               if (!kIsWeb)
                 Obx(() => SettingsSwitch(
                       onChanged: (bool val) async {
+                        SettingsSvc.settings.dndFavoritesOverride.value = val;
+                        await SettingsSvc.settings.saveOneAsync('dndFavoritesOverride');
+                      },
+                      initialVal: SettingsSvc.settings.dndFavoritesOverride.value,
+                      title: "Override DND for Favorites",
+                      subtitle:
+                          "Override Do Not Disturb (DND) for Favorite (starred) contacts",
+                      isThreeLine: true,
+                      backgroundColor: tileColor,
+                    )),
+              if (!kIsWeb) const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+              if (!kIsWeb)
+                Obx(() => SettingsSwitch(
+                      onChanged: (bool val) async {
                         SettingsSvc.settings.notifyOnChatList.value = val;
                         await SettingsSvc.settings.saveOneAsync('notifyOnChatList');
                       },

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -303,6 +303,7 @@ List<Widget> buildSettingItemList({
         SearchableSettingItem(
           title: "Notification Settings", // Title to search
           searchTags: [
+            "Override DND for Favorites",
             "Send Notifications on Chat List",
             "Notify for Reactions",
             "Notification Sound",

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -62,6 +62,7 @@ class Settings {
   final RxBool startVideosMutedFullscreen = true.obs;
   final RxBool use24HrFormat = false.obs;
   final RxBool alwaysShowAvatars = false.obs;
+  final RxBool dndFavoritesOverride = false.obs;
   final RxBool notifyOnChatList = false.obs;
   final RxBool notifyReactions = true.obs;
   final RxBool colorsFromMedia = false.obs;
@@ -315,6 +316,7 @@ class Settings {
       'startVideosMutedFullscreen': startVideosMutedFullscreen.value,
       'use24HrFormat': use24HrFormat.value,
       'alwaysShowAvatars': alwaysShowAvatars.value,
+      'dndFavoritesOverride': dndFavoritesOverride.value,
       'notifyOnChatList': notifyOnChatList.value,
       'notifyReactions': notifyReactions.value,
       'globalTextDetection': globalTextDetection.value,
@@ -491,6 +493,8 @@ class Settings {
     SettingsSvc.settings.use24HrFormat.value = map['use24HrFormat'] ?? SettingsSvc.settings.use24HrFormat.value;
     SettingsSvc.settings.alwaysShowAvatars.value =
         map['alwaysShowAvatars'] ?? SettingsSvc.settings.alwaysShowAvatars.value;
+    SettingsSvc.settings.dndFavoritesOverride.value =
+        map['dndFavoritesOverride'] ?? SettingsSvc.settings.dndFavoritesOverride.value;
     SettingsSvc.settings.notifyOnChatList.value =
         map['notifyOnChatList'] ?? SettingsSvc.settings.notifyOnChatList.value;
     SettingsSvc.settings.notifyReactions.value = map['notifyReactions'] ?? SettingsSvc.settings.notifyReactions.value;
@@ -705,6 +709,7 @@ class Settings {
     s.startVideosMutedFullscreen.value = map['startVideosMutedFullscreen'] ?? true;
     s.use24HrFormat.value = map['use24HrFormat'] ?? false;
     s.alwaysShowAvatars.value = map['alwaysShowAvatars'] ?? false;
+    s.dndFavoritesOverride.value = map['dndFavoritesOverride'] ?? false;
     s.notifyOnChatList.value = map['notifyOnChatList'] ?? false;
     s.notifyReactions.value = map['notifyReactions'] ?? true;
     s.colorsFromMedia.value = map['colorsFromMedia'] ?? false;

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -235,6 +235,11 @@ class StartupTasks {
     GetIt.I.registerSingleton<ChatsService>(ChatsService());
     GetIt.I.registerSingleton<TypingIndicatorService>(TypingIndicatorService());
     GetIt.I.registerSingleton<SocketService>(SocketService());
+
+    Logger.info("Registering TypingIndicatorService...");
+    GetIt.I.registerSingleton<TypingIndicatorService>(TypingIndicatorService());
+    Logger.info("TypingIndicatorService ready");
+
     await _waitForInterop(notifications: true);
 
     GetIt.I.registerSingleton<EventDispatcher>(EventDispatcher());

--- a/lib/services/backend/java_dart_interop/method_channel_handlers.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_handlers.dart
@@ -6,6 +6,7 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/backend/settings_helpers.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -93,19 +94,67 @@ class MethodChannelHandlers {
         return _ok();
       }
 
-      final Map<String, dynamic>? data = arguments;
+      Logger.info('BB_MAP_FIX_V3 handling new-message push');
+      final Map<String, dynamic>? data = normalizeMethodChannelArguments(arguments);
       if (!isNullOrEmpty(data)) {
-        final payload = ServerPayload.fromJson(data!);
+        late final ServerPayload payload;
+        late final Map<String, dynamic> messageData;
+        late final Chat chat;
+        late final Message message;
+        late final List<Attachment> attachments;
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=ServerPayload');
+          payload = ServerPayload.fromJson(data!);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at ServerPayload: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=messageData');
+          messageData = asStringDynamicMapRequired(payload.data);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at messageData: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=Message');
+          message = Message.fromMap(messageData);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at Message: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=attachments count=${(messageData['attachments'] as List?)?.length ?? 0}');
+          attachments = ((messageData['attachments'] as List?) ?? const [])
+              .map((e) => Attachment.fromMap(asStringDynamicMapRequired(e)))
+              .toList();
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at attachments: $e', trace: s);
+          rethrow;
+        }
+
+        try {
+          Logger.info('BB_MAP_FIX_V3 step=Chat');
+          final chatJson = asStringDynamicMapRequired(messageData['chats']?.first);
+          chatJson.remove('lastMessage');
+          chat = Chat.fromMap(chatJson);
+        } catch (e, s) {
+          Logger.error('BB_MAP_FIX_V3 failed at Chat: $e', trace: s);
+          rethrow;
+        }
+
+        Logger.info('BB_MAP_FIX_V3 step=IncomingMsgHandler');
         await IncomingMsgHandler.handle(IncomingPayload(
           type: MessageEventType.newMessage,
           source: MessageSource.methodChannel,
-          chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
-          message: Message.fromMap(payload.data),
-          attachments: ((payload.data['attachments'] as List?) ?? const [])
-              .whereType<Map>()
-              .map((e) => Attachment.fromMap(e.cast<String, Object>()))
-              .toList(),
-          tempGuid: payload.data['tempGuid'],
+          chat: chat,
+          message: message,
+          attachments: attachments,
+          tempGuid: messageData['tempGuid'],
         ));
       }
     } catch (e, s) {
@@ -133,16 +182,17 @@ class MethodChannelHandlers {
     }
 
     try {
-      final Map<String, dynamic>? data = arguments;
+      final Map<String, dynamic>? data = normalizeMethodChannelArguments(arguments);
       if (!isNullOrEmpty(data)) {
         final payload = ServerPayload.fromJson(data!);
+        final messageData = deepNormalizeJson(payload.data) as Map<String, dynamic>;
 
-        if (payload.data['chats'] == null || payload.data['chats'].isEmpty) {
+        if (messageData['chats'] == null || (messageData['chats'] as List).isEmpty) {
           Logger.info('No chat data found, attempting to find chat from message guid...');
-          final existingMsg = Message.findOne(guid: payload.data['guid']);
+          final existingMsg = Message.findOne(guid: messageData['guid']);
           if (existingMsg != null && existingMsg.chat.target != null) {
             Logger.info('Found chat from message guid, adding to payload');
-            payload.data['chats'] = [existingMsg.chat.target!.toMap()];
+            messageData['chats'] = [existingMsg.chat.target!.toMap()];
           } else {
             Logger.warn('No chat data found, and unable to find chat from message guid');
             return _retry();
@@ -152,13 +202,13 @@ class MethodChannelHandlers {
         await IncomingMsgHandler.handle(IncomingPayload(
           type: MessageEventType.updatedMessage,
           source: MessageSource.methodChannel,
-          chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
-          message: Message.fromMap(payload.data),
-          attachments: ((payload.data['attachments'] as List?) ?? const [])
+          chat: Chat.fromMap(deepNormalizeJson(messageData['chats'].first) as Map<String, dynamic>),
+          message: Message.fromMap(messageData),
+          attachments: ((messageData['attachments'] as List?) ?? const [])
               .whereType<Map>()
-              .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+              .map((e) => Attachment.fromMap(deepNormalizeJson(e) as Map<String, dynamic>))
               .toList(),
-          tempGuid: payload.data['tempGuid'],
+          tempGuid: messageData['tempGuid'],
         ));
       }
     } catch (e, s) {

--- a/lib/services/backend/java_dart_interop/method_channel_service.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:bluebubbles/services/network/method_channel_actions.dart';
 import 'package:bluebubbles/services/backend/java_dart_interop/method_channel_handlers.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/utils/deep_map_normalize.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
@@ -81,8 +82,7 @@ class MethodChannelService implements MethodChannelServiceDelegate {
   }
 
   Future<bool> _callHandler(MethodCall call) async {
-    final Map<String, dynamic>? arguments =
-        call.arguments is String ? jsonDecode(call.arguments) : call.arguments?.cast<String, Object>();
+    final Map<String, dynamic>? arguments = normalizeMethodChannelArguments(call.arguments);
 
     // ONLY RETURN Future.value or Future.error
     // Future.value(false) will have the engine retry the call

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -9,6 +9,8 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/helpers/ui/facetime_helpers.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/models/models.dart' show HandleLookupKey;
+import 'package:bluebubbles/services/backend/interfaces/contact_v2_interface.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -27,6 +29,111 @@ import 'package:get_it/get_it.dart';
 
 // ignore: non_constant_identifier_names
 NotificationsService get NotificationsSvc => GetIt.I<NotificationsService>();
+
+/// Android Contacts row ID for linking notifications to system DND starred-contact rules.
+String? nativeContactIdForHandle(Handle? handle) {
+  if (handle == null) return null;
+
+  ContactV2? contact = handle.contactsV2.where((c) => c.isNative).firstOrNull;
+  contact ??= handle.contactsV2.firstOrNull;
+  if (contact == null) return null;
+
+  final id = contact.nativeContactId;
+  if (id.isEmpty || int.tryParse(id) == null) return null;
+  return id;
+}
+
+Future<String?> nativeContactIdForMessage(Message message) async {
+  final handle = message.handleRelation.target;
+  final fromHandle = nativeContactIdForHandle(handle);
+  if (fromHandle != null) return fromHandle;
+
+  final address = handle?.address;
+  if (address == null || address.isEmpty) return null;
+
+  final contact = await ContactV2Interface.getContactByAddress(address: address);
+  if (contact == null) return null;
+  final id = contact.nativeContactId;
+  if (id.isEmpty || int.tryParse(id) == null) return null;
+  return id;
+}
+
+/// Incoming pushes can arrive before ObjectBox ToOne links are hydrated on the
+/// in-memory [Message]. Reload and fall back to chat participants so attachment
+/// notifications are not dropped.
+String notificationSenderName(Message message, Chat chat) {
+  if (message.handleRelation.hasValue) {
+    return message.handleRelation.target!.displayName;
+  }
+  if (message.handle != null) {
+    return message.handle!.displayName;
+  }
+  if (message.handleId != null && message.handleId! > 0) {
+    for (final h in chat.handles) {
+      if (h.originalROWID == message.handleId) return h.displayName;
+    }
+    final global = Handle.findOne(originalROWID: message.handleId);
+    if (global != null) return global.displayName;
+  }
+  return 'Unknown';
+}
+
+Message resolveHandleForNotification(Message message, Chat chat) {
+  Message m = message;
+
+  if (!m.handleRelation.hasValue && m.guid != null) {
+    final reloaded = Message.findOne(guid: m.guid);
+    if (reloaded != null) {
+      m = reloaded;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && m.handleId != null && m.handleId! > 0) {
+    final handle = Handle.findOne(originalROWID: m.handleId);
+    if (handle != null) {
+      m.handleRelation.target = handle;
+      return m;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && m.handle != null) {
+    final handle = Handle.findOne(
+          addressAndService: HandleLookupKey(m.handle!.address, m.handle!.service),
+        ) ??
+        m.handle;
+    if (handle != null) {
+      m.handleRelation.target = handle;
+      return m;
+    }
+  }
+
+  final participantPool = chat.handles.isNotEmpty ? chat.handles.toList() : chat.participants;
+  if (!m.handleRelation.hasValue && m.handleId != null && participantPool.isNotEmpty) {
+    final participant = participantPool.cast<Handle?>().firstWhereOrNull(
+          (h) => h?.originalROWID == m.handleId,
+        );
+    if (participant != null) {
+      m.handleRelation.target = participant;
+      return m;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && chat.isGroup && m.handle != null && participantPool.isNotEmpty) {
+    final byAddress = participantPool.cast<Handle?>().firstWhereOrNull(
+          (h) => h?.address == m.handle!.address && h?.service == m.handle!.service,
+        );
+    if (byAddress != null) {
+      m.handleRelation.target = byAddress;
+      return m;
+    }
+  }
+
+  if (!m.handleRelation.hasValue && !chat.isGroup && chat.participants.isNotEmpty) {
+    m.handleRelation.target = chat.participants.first;
+  }
+
+  return m;
+}
 
 class PendingToastItem {
   final String? sender;
@@ -132,7 +239,7 @@ class NotificationsService {
     if (chat.shouldMuteNotification(message) || message.isFromMe!) return;
     final isGroup = chat.isGroup;
     final guid = chat.guid;
-    final contactName = message.handleRelation.target?.displayName ?? "Unknown";
+    final contactName = notificationSenderName(message, chat);
     final title = isGroup ? chat.getTitle() : contactName;
     final text = hideContent ? "iMessage" : message.getNotificationText();
     final isReaction = !isNullOrEmpty(message.associatedMessageGuid);
@@ -174,10 +281,20 @@ class NotificationsService {
             SettingsSvc.settings.notificationReactionAction.value &&
             message.associatedMessageGuid == null;
         final String reactionType = SettingsSvc.settings.notificationReactionActionType.value;
+        String? nativeContactId;
+        try {
+          nativeContactId = await nativeContactIdForMessage(message);
+        } catch (e, s) {
+          Logger.warn(
+            'Contact lookup failed for notification; continuing without contact link',
+            tag: 'NotificationsService',
+            error: e,
+            trace: s,
+          );
+        }
 
         await GetIt.I.isReady<MethodChannelService>();
         await MethodChannelSvc.actions.createIncomingMessageNotification(
-          channelId: NEW_MESSAGE_CHANNEL,
           chatId: chat.id,
           chatGuid: guid,
           chatIsGroup: isGroup,
@@ -185,26 +302,28 @@ class NotificationsService {
           chatIcon: isGroup ? chatIcon : contactIcon,
           contactName: contactName,
           contactAvatar: contactIcon,
+          nativeContactId: nativeContactId,
           messageGuid: message.guid!,
           messageText: text,
           messageDate: message.dateCreated!.millisecondsSinceEpoch,
           messageIsFromMe: false,
           showReactionAction: showReactionAction,
           reactionType: reactionType,
+          dndFavoritesOverride: SettingsSvc.settings.dndFavoritesOverride.value,
         );
       }
     }
   }
 
   Future<void> tryCreateNewMessageNotification(Message message, Chat chat) async {
-    if (message.isFromMe! || !message.handleRelation.hasValue) {
-      if (!(message.isFromMe ?? false) && !message.handleRelation.hasValue) {
-        Logger.warn(
-          'Skipping notification for ${message.guid} — handle relation not resolved',
-          tag: 'NotificationsService',
-        );
-      }
-      return;
+    if (message.isFromMe!) return;
+
+    message = resolveHandleForNotification(message, chat);
+    if (!message.handleRelation.hasValue) {
+      Logger.warn(
+        'Handle relation not resolved for ${message.guid}; posting notification with chat fallback',
+        tag: 'NotificationsService',
+      );
     }
     if (message.isKeptAudio) return;
     if (chat.shouldMuteNotification(message)) return;

--- a/lib/services/network/method_channel_actions.dart
+++ b/lib/services/network/method_channel_actions.dart
@@ -96,7 +96,6 @@ class MethodChannelActions {
   }
 
   Future<void> createIncomingMessageNotification({
-    required String channelId,
     required int? chatId,
     required String chatGuid,
     required bool chatIsGroup,
@@ -104,15 +103,16 @@ class MethodChannelActions {
     required Uint8List chatIcon,
     required String contactName,
     required Uint8List contactAvatar,
+    required String? nativeContactId,
     required String messageGuid,
     required String messageText,
     required int messageDate,
     required bool messageIsFromMe,
     required bool showReactionAction,
     required String reactionType,
+    required bool dndFavoritesOverride,
   }) async {
     await service.invokeMethod('create-incoming-message-notification', {
-      'channel_id': channelId,
       'chat_id': chatId,
       'chat_guid': chatGuid,
       'chat_is_group': chatIsGroup,
@@ -120,12 +120,14 @@ class MethodChannelActions {
       'chat_icon': chatIcon,
       'contact_name': contactName,
       'contact_avatar': contactAvatar,
+      if (nativeContactId != null) 'native_contact_id': nativeContactId,
       'message_guid': messageGuid,
       'message_text': messageText,
       'message_date': messageDate,
       'message_is_from_me': messageIsFromMe,
       'show_reaction_action': showReactionAction,
       'reaction_type': reactionType,
+      'dnd_favorites_override': dndFavoritesOverride,
     });
   }
 

--- a/lib/utils/deep_map_normalize.dart
+++ b/lib/utils/deep_map_normalize.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+/// Recursively converts platform-channel / Gson maps into plain Dart JSON maps.
+dynamic deepNormalizeJson(dynamic raw) {
+  if (raw == null) return null;
+
+  if (raw is String) {
+    try {
+      return deepNormalizeJson(jsonDecode(raw));
+    } catch (_) {
+      return raw;
+    }
+  }
+
+  if (raw is Map || raw is List) {
+    try {
+      return jsonDecode(jsonEncode(raw));
+    } catch (_) {
+      if (raw is Map) {
+        return Map<String, dynamic>.fromEntries(
+          raw.entries.map(
+            (e) => MapEntry(e.key.toString(), deepNormalizeJson(e.value)),
+          ),
+        );
+      }
+      if (raw is List) {
+        return raw.map(deepNormalizeJson).toList();
+      }
+    }
+  }
+
+  return raw;
+}
+
+Map<String, dynamic>? asStringDynamicMap(dynamic raw) {
+  if (raw == null) return null;
+  final normalized = deepNormalizeJson(raw);
+  if (normalized is Map<String, dynamic>) return normalized;
+  if (normalized is Map) return Map<String, dynamic>.from(normalized);
+  return null;
+}
+
+Map<String, dynamic> asStringDynamicMapRequired(dynamic raw) {
+  final map = asStringDynamicMap(raw);
+  if (map != null) return map;
+  throw FormatException('Expected Map<String, dynamic>, got ${raw.runtimeType}');
+}
+
+Map<String, dynamic>? normalizeMethodChannelArguments(dynamic raw) {
+  if (raw == null) return null;
+
+  try {
+    final normalized = deepNormalizeJson(raw);
+    if (normalized is Map<String, dynamic>) return normalized;
+    if (normalized is Map) return Map<String, dynamic>.from(normalized);
+  } catch (_) {}
+
+  return null;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -3112,26 +3112,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   throttling:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Replaces the global `setBypassDnd(true)` on the notification channel (which bypassed DND for all contacts) with per-notification logic: if the message sender is starred in the Android contacts app, the notification `Person` is built with `setUri(lookupUri)` + `setImportant(true)`, letting Android's DND system grant the exception contact-by-contact.

The feature is **off by default**, controlled by a new toggle:
> Settings → Application Settings → Notification Settings → **Override DND for Favorites**

## How it works

1. `nativeContactId` is threaded from the Dart notification pipeline through `MethodChannelActions`, `DartWorker`, and `UnifiedPushReceiver` down to `CreateIncomingMessageNotification`
2. New `ContactNotificationHelper` resolves the contact lookup URI and starred status from `nativeContactId`
3. `PushShareTargetsHandler` reuses the same `ContactInfo` to avoid a second contacts DB query for conversation shortcuts
4. The `setBypassDnd(true)` call is removed from `NotificationChannelHandler` — the channel itself no longer forces through DND

## Implementation note: settings storage

The toggle value is passed from Dart through the `create-incoming-message-notification` MethodChannel call as `dnd_favorites_override` rather than read from `SharedPreferences` on the Kotlin side. This avoids a storage mismatch introduced by `shared_preferences` v2.5.x: after the DataStore migration, new keys are only in Android DataStore, which is not accessible via the legacy `getSharedPreferences()` API used by `SettingsHelper`. Existing keys written before migration are unaffected.

Also fixes the `flutter.` key prefix missing from `hasServerUrl()` and `hasAuthKey()` in `SettingsHelper.kt`, which was causing the notification Like/reaction button to silently fail to send.

## What changed

- `android/app/src/main/kotlin/.../utils/ContactNotificationHelper.kt` — new file
- `android/app/src/main/kotlin/.../utils/SettingsHelper.kt` — prefix fix + no new settings reads
- `android/app/src/main/kotlin/.../services/notifications/NotificationChannelHandler.kt` — remove bypassDnd
- `android/app/src/main/kotlin/.../services/notifications/CreateIncomingMessageNotification.kt` — conditional DND via method channel arg
- `android/app/src/main/kotlin/.../services/system/PushShareTargetsHandler.kt` — ContactInfo overload
- `android/app/src/main/kotlin/.../services/system/OpenConversationNotificationSettingsHandler.kt`
- `android/app/src/main/kotlin/.../services/backend_ui_interop/DartWorkManager.kt`, `DartWorker.kt`
- `android/app/src/main/kotlin/.../UnifiedPushReceiver.kt`
- `lib/database/global/settings.dart` — `dndFavoritesOverride` RxBool field
- `lib/services/backend/notifications/notifications_service.dart`
- `lib/services/network/method_channel_actions.dart`
- `lib/services/backend/java_dart_interop/method_channel_handlers.dart`, `method_channel_service.dart`
- `lib/helpers/backend/startup_tasks.dart`
- `lib/app/layouts/settings/pages/system/notification_panel.dart` — toggle UI
- `lib/app/layouts/settings/widgets/search/settings_items_list.dart` — search tag