### PR TITLE
fix: bypass secure_application on Linux so the window can close

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -164,7 +164,11 @@ Future<Null> initApp(bool bubble, List<String> arguments) async {
           } else {
             await windowManager.hide();
           }
-          bool shouldAuthenticate = SettingsSvc.canAuthenticate && SettingsSvc.settings.shouldSecure.value;
+          // secure_application / local auth has no working Linux implementation,
+          // so never gate startup behind it there (otherwise ChatsSvc/SocketSvc
+          // would never init, since the auth flow can't complete).
+          bool shouldAuthenticate =
+              !Platform.isLinux && SettingsSvc.canAuthenticate && SettingsSvc.settings.shouldSecure.value;
           if (!shouldAuthenticate) {
             ChatsSvc.init();
             SocketSvc.init();
@@ -334,7 +338,13 @@ class Main extends StatelessWidget {
         builder: (context, child) => SafeArea(
           top: false,
           bottom: false,
-          child: SecureApplication(
+          // secure_application has no Linux implementation; mounting it (and the
+          // SecureGate below) throws MissingPluginException on every lifecycle
+          // event, which breaks window close/hide once the app is past setup.
+          // Bypass the secure wrapper entirely on Linux.
+          child: Platform.isLinux
+              ? TitleBarWrapper(child: child ?? Container())
+              : SecureApplication(
             child: Builder(
               builder: (context) {
                 if (SettingsSvc.canAuthenticate && (!LifecycleSvc.isAlive || !StartupTasks.uiReady.isCompleted)) {


### PR DESCRIPTION
## Problem

On Linux, the app cannot be closed once the `secure_application` wrapper is active — the window close request gets swallowed and the only way out is `kill`. The package has no working Linux support (the pubspec comment already notes `# no linux support`), so on Linux the wrapper contributes the breakage without providing the app-lock feature it exists for.

## Fix

Bypass `secure_application` on Linux only:

- `shouldAuthenticate` is forced off on Linux, and
- the widget tree skips the `SecureApplication`/`SecureGate` wrapper there (renders `TitleBarWrapper` directly).

Windows, macOS, and mobile are unchanged — the guards are `Platform.isLinux` only.

## Testing

- Linux release build, in daily use: window close/quit works again; app lock continues to function on the platforms that support it.
- No behavior change possible on other platforms by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
