### PR TITLE
fix: cancel isolate drain on resume/new work so foreground messages aren't dropped

### DIFF
--- a/lib/services/backend/lifecycle/lifecycle_service.dart
+++ b/lib/services/backend/lifecycle/lifecycle_service.dart
@@ -73,6 +73,12 @@ class LifecycleService with WidgetsBindingObserver {
     statesSinceLastResume.add(state);
 
     if (state == AppLifecycleState.resumed) {
+      // If we resumed before the pause-initiated isolate drain finished, cancel
+      // it so foreground sends/receives aren't rejected (Android-only drain).
+      if (Platform.isAndroid && GetIt.I.isRegistered<GlobalIsolate>()) {
+        GetIt.I<GlobalIsolate>().cancelDrain();
+      }
+
       // Restore active-chat liveness immediately to avoid a race where
       // incoming messages are processed while lifecycle is already resumed
       // but chat state is still marked dead from the previous close().

--- a/lib/services/isolates/global_isolate.dart
+++ b/lib/services/isolates/global_isolate.dart
@@ -253,7 +253,8 @@ class GlobalIsolate {
   }
 
   /// Requests graceful shutdown:
-  /// - continues to accept new [send]/[broadcast] calls during drain
+  /// - [broadcast] calls are still accepted during the drain; a new [send]
+  ///   cancels the drain instead (a pending message means the app is active again)
   /// - stops the isolate once all pending requests complete (or immediately if none)
   ///
   /// Returns a Future that completes when the isolate has fully stopped.
@@ -278,6 +279,21 @@ class GlobalIsolate {
       'Will stop when all pending requests complete.',
     );
     return _drainCompleter!.future;
+  }
+
+  /// Cancels an in-progress drain because the app is active again (resumed, or a
+  /// new [send] arrived — e.g. a background notification quick-reply). Keeps the
+  /// isolate running and clears the reject flag so outgoing sends and incoming
+  /// message writes are not dropped. No-op if nothing is draining.
+  void cancelDrain() {
+    if (_drainCompleter == null && !_shutdownPending) return;
+    Logger.info('$isolateDebugName drain cancelled — new activity, keeping isolate alive.');
+    _shutdownPending = false;
+    final completer = _drainCompleter;
+    _drainCompleter = null;
+    if (completer != null && !completer.isCompleted) completer.complete();
+    // Restore normal idle-based shutdown so the isolate still stops if it goes idle.
+    _scheduleIdleShutdown();
   }
 
   /// Closes the isolate and clears all listeners
@@ -321,6 +337,12 @@ class GlobalIsolate {
 
   /// Sends a request to the isolate and waits for a response
   Future<T> send<T>(IsolateRequestType type, {dynamic input, Duration? customTimeout}) async {
+    // A new request means the app is active again. Cancel any in-progress drain
+    // rather than rejecting — dropping a message (outgoing send or incoming DB
+    // write) is far worse than delaying a graceful idle shutdown.
+    if (_shutdownPending) {
+      cancelDrain();
+    }
     await _ensureStarted();
 
     final requestId = const Uuid().v4();


### PR DESCRIPTION
## Context — complements d63131e52

d63131e52 ("reverted rejection of new requests during drain of global isolate") fixed the hard failure: sends during a drain are no longer rejected. This PR addresses what's left.

## Problem

On Android, backgrounding the app arms `drainAndStop()`. Nothing ever **disarms** it when the app returns to the foreground: `_maybeStopAfterDrain()` stops the isolate at the first moment `_pendingRequests` is empty — and under active use, that's the gap between any two operations (they're short-lived DB calls).

So the sequence *pause briefly → resume → keep using the app* guarantees the isolate is killed mid-use at the first quiet instant, and the next operation pays a cold isolate start. Besides the latency, every restart transition is a window where in-flight work can fail — on our fork this combined with the unguarded outgoing prep phase (companion PR) to silently lose user messages after backgrounding/resuming, worst in group chats.

The drain exists to tidy up *in the background*; genuine foreground idleness is already handled by the 5-minute `idleTimeout`. Stopping a warm isolate between two keystrokes serves neither purpose.

## Fix

Add `cancelDrain()`: clears `_shutdownPending`, completes and clears `_drainCompleter`, and re-schedules the normal idle shutdown. Called from two places:

- **`send()`** — a new request means the app is active again; cancel the drain instead of racing it.
- **Lifecycle resume (Android)** — returning to foreground disarms a pending drain outright.

A drain still runs to completion when the app genuinely stays backgrounded, and the idle timer still reclaims the isolate after real inactivity. `broadcast()` behavior is unchanged from d63131e52 (accepted during drain, doesn't cancel it — fire-and-forget bookkeeping like log-level updates shouldn't keep the isolate alive).

Note on semantics: `drainAndStop()`'s future completes when the drain is *cancelled* as well as when the isolate stops. Its only caller (the Android pause path) invokes it with `unawaited(...)`, so nothing depends on distinguishing the two.

## Testing

Validated on-device (Android, daily use for several days on a fork carrying this patch): no more post-resume isolate churn, and the message-loss scenario it enabled hasn't recurred. `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
