### PR TITLE
fix: prevent desktop notification sound crash when player is replaced

### DIFF
--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -578,7 +578,7 @@ class NotificationsService {
       _desktopNotificationPlayer = player;
       await player.setVolume(SettingsSvc.settings.desktopNotificationSoundVolume.value.toDouble());
       await player.open(Media(SettingsSvc.settings.desktopNotificationSoundPath.value!));
-      player.stream.completed.firstWhere((completed) => completed).then((_) async {
+      player.stream.completed.firstWhere((completed) => completed, orElse: () => false).then((_) async {
         await Future.delayed(const Duration(milliseconds: 450));
         if (_desktopNotificationPlayer == player) {
           await player.dispose();


### PR DESCRIPTION
If a new desktop notification comes in before the previous one's sound finishes, the old `Player` gets disposed and its `stream.completed.firstWhere` throws `Bad state: No element` (uncaught, surfaces in the zone handler). Added an `orElse` so it resolves instead of throwing. Only affects desktop with a custom notification sound set.
