### PR TITLE
fix: refresh conversation list when a new chat is added at runtime

### DIFF
--- a/lib/app/state/chat_state.dart
+++ b/lib/app/state/chat_state.dart
@@ -382,11 +382,17 @@ class ChatState {
     // Rebuild participants from the fresh DB handles on the incoming chat object so
     // we never read the stale cached ToMany on the original ChatState.chat.
     _updateParticipantsInternal(updatedChat.handles.toList());
-    updateLatestMessageInternal(updatedChat.dbLatestMessage.target);
-    // Refresh the title & subtitle so it reflects any updated handle display names
+    // Don't blank an existing preview when the incoming chat arrives without its
+    // dbLatestMessage relation loaded (e.g. a bare DB re-query). The latest
+    // message only moves forward; updateChatLatestMessage sets it authoritatively.
+    final incomingLatest = updatedChat.dbLatestMessage.target;
+    if (incomingLatest != null) {
+      updateLatestMessageInternal(incomingLatest);
+      updateSubtitleInternal(_computeSubtitle(incomingLatest));
+    }
+    // Refresh the title so it reflects any updated handle display names
     // (e.g. a group-event whose sender handle was just added to the DB).
     updateTitleInternal(_computeTitle());
-    updateSubtitleInternal(_computeSubtitle(updatedChat.dbLatestMessage.target));
 
     // NOTE: textFieldText and textFieldAttachments are intentionally NOT synced here.
     // They are purely client-side fields managed exclusively by setChatTextFieldText /

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -377,7 +377,9 @@ class Chat {
 
     // Handle post-save operations on main thread
     if (isNewer) {
-      setLatestMessage(message);
+      // Link the saved (DB-hydrated) message so a freshly-added chat's tile is
+      // built with its subtitle populated on first paint.
+      setLatestMessage(newMessage ?? message);
       if (dateDeleted != null) {
         dateDeleted = null;
         await saveAsync(updateDateDeleted: true);

--- a/lib/services/backend/incoming_message_handler.dart
+++ b/lib/services/backend/incoming_message_handler.dart
@@ -379,6 +379,10 @@ class IncomingMessageHandler {
         unawaited(ChatsSvc.setChatHasUnread(c, false, force: true));
       }
 
+      // Seed the latest message before the ChatState is built so a freshly-added
+      // chat's tile has its subtitle on first paint.
+      c.setLatestMessage(saved);
+
       if (!ChatsSvc.updateChat(c, override: true)) {
         await ChatsSvc.addChat(c, immediate: true);
       }

--- a/lib/services/backend/incoming_message_handler.dart
+++ b/lib/services/backend/incoming_message_handler.dart
@@ -379,7 +379,9 @@ class IncomingMessageHandler {
         unawaited(ChatsSvc.setChatHasUnread(c, false, force: true));
       }
 
-      ChatsSvc.updateChat(c, override: true);
+      if (!ChatsSvc.updateChat(c, override: true)) {
+        await ChatsSvc.addChat(c, immediate: true);
+      }
       ChatsSvc.updateChatLatestMessage(c.guid, saved);
     }
 

--- a/lib/services/backend/incoming_message_handler.dart
+++ b/lib/services/backend/incoming_message_handler.dart
@@ -382,7 +382,13 @@ class IncomingMessageHandler {
       // The latest message is linked on the guarded sync path (Chat.addMessage,
       // gated on isNewer), so a freshly-added chat's tile already has its subtitle
       // on first paint here.
-      if (!ChatsSvc.updateChat(c, override: true)) {
+      //
+      // Gate add-vs-update on the chat actually existing, not on updateChat's return:
+      // updateChat also returns false when headless or when the chat's state isn't
+      // loaded, which would otherwise call addChat for a chat that already exists.
+      if (ChatsSvc.findChatByGuid(c.guid) != null) {
+        ChatsSvc.updateChat(c, override: true);
+      } else {
         await ChatsSvc.addChat(c, immediate: true);
       }
       ChatsSvc.updateChatLatestMessage(c.guid, saved);

--- a/lib/services/backend/incoming_message_handler.dart
+++ b/lib/services/backend/incoming_message_handler.dart
@@ -379,10 +379,9 @@ class IncomingMessageHandler {
         unawaited(ChatsSvc.setChatHasUnread(c, false, force: true));
       }
 
-      // Seed the latest message before the ChatState is built so a freshly-added
-      // chat's tile has its subtitle on first paint.
-      c.setLatestMessage(saved);
-
+      // The latest message is linked on the guarded sync path (Chat.addMessage,
+      // gated on isNewer), so a freshly-added chat's tile already has its subtitle
+      // on first paint here.
       if (!ChatsSvc.updateChat(c, override: true)) {
         await ChatsSvc.addChat(c, immediate: true);
       }

--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -565,6 +565,9 @@ class ChatsService {
 
     // Insert into sorted list at correct position
     _insertChatSorted(toAdd);
+
+    // _sortedChats isn't reactive; bump the list version so the UI rebuilds.
+    _scheduleListVersionUpdate(immediate: immediate);
   }
 
   void removeChat(Chat toRemove) {


### PR DESCRIPTION
A chat from a new incoming number, or one made in the chat creator, gets inserted into _sortedChats but the list doesn't re-render until something else bumps chatListVersion, so it stays invisible until you tap another chat. addChat inserts via _insertChatSorted without scheduling a list-version update; the batch loader does that itself, so only single runtime adds were affected. Also added the updateChat -> addChat fallback in the incoming handler for a brand-new chat, matching what the chat creator already does.

Hit it on linux desktop, but the code is shared so it should be validated on android too.
