### PR TITLE
feat: FindMy map preview on conversation details

### DIFF
--- a/lib/app/layouts/conversation_details/CLAUDE.md
+++ b/lib/app/layouts/conversation_details/CLAUDE.md
@@ -12,6 +12,7 @@ Displayed as a right-side panel on tablet or pushed screen on mobile.
 - `timeframe_picker.dart` — date range selector (for media/docs filtering)
 - `add_participant.dart` — add a member to a group chat
 - `chat_sync_dialog.dart` — progress dialog for re-syncing chat history
+- `participants_findmy_sheet/` — interactive Find My map bottom sheet for chat participants
 
 ## Material 3 Expressive (`material/`)
 The Material/Samsung-only expressive tree — `conversation_details.dart` routes to these instead
@@ -30,6 +31,7 @@ of the iOS widgets below based on `SettingsSvc.settings.skin.value`. See
 - `chat_options.dart` — action buttons (mute, archive, FaceTime, custom avatar, etc.)
 - `participants_list.dart` — group member list
 - `contact_tile.dart` — individual participant row (tappable → contact details)
+- `participants_findmy_card/` — Find My map preview for participants sharing location
 
 **Shared Media**
 - `attachment_section_header.dart` — section label + "Show more" action

--- a/lib/app/layouts/conversation_details/conversation_details.dart
+++ b/lib/app/layouts/conversation_details/conversation_details.dart
@@ -6,11 +6,12 @@ import 'package:bluebubbles/app/layouts/conversation_details/widgets/attachments
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/chat_info.dart';
 import 'package:bluebubbles/app/state/chat_state_scope.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/chat_options.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/widgets/participants_findmy_card/participants_findmy_card.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/widgets/participants_list.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/sections/documents/documents_section.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/sections/links/links_section.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/sections/locations/locations_section.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart';
-import 'package:bluebubbles/app/layouts/conversation_details/widgets/participants_list.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
 import 'package:bluebubbles/database/models.dart';
@@ -125,6 +126,7 @@ class _ConversationDetailsState extends State<ConversationDetails> with WidgetsB
                     ? ChatInfo(chat: chat)
                     : ExpressiveChatHeader(chat: chat),
               ),
+              if (ParticipantsFindMyMapCard.isSupported) ParticipantsFindMyMapCard(chat: chat),
               SettingsSvc.settings.skin.value == Skins.iOS
                   ? ParticipantsList(chat: chat)
                   : ExpressiveParticipantsSection(chat: chat),

--- a/lib/app/layouts/conversation_details/dialogs/CLAUDE.md
+++ b/lib/app/layouts/conversation_details/dialogs/CLAUDE.md
@@ -7,6 +7,7 @@ Dialogs shown from within the conversation details / info panel.
 | File | Purpose |
 |------|---------|
 | `add_participant.dart` | Dialog for adding a new participant to a group chat |
+| `participants_findmy_sheet/` | Bottom sheet with interactive map for conversation participants |
 | `address_picker.dart` | Picker for choosing which address/handle to use when sending to a contact with multiple numbers |
 | `change_name.dart` | Dialog for renaming a group conversation |
 | `chat_sync_dialog.dart` | Progress dialog shown during a manual chat-level resync |

--- a/lib/app/layouts/conversation_details/dialogs/participants_findmy_sheet/participants_findmy_sheet.dart
+++ b/lib/app/layouts/conversation_details/dialogs/participants_findmy_sheet/participants_findmy_sheet.dart
@@ -71,10 +71,14 @@ class _ParticipantsFindMyMapSheetBodyState extends State<_ParticipantsFindMyMapS
   void initState() {
     super.initState();
     _mapController = MapController();
+    widget.controller.participantSheetMapController = _mapController;
   }
 
   @override
   void dispose() {
+    if (identical(widget.controller.participantSheetMapController, _mapController)) {
+      widget.controller.participantSheetMapController = null;
+    }
     _mapController.dispose();
     super.dispose();
   }

--- a/lib/app/layouts/conversation_details/dialogs/participants_findmy_sheet/participants_findmy_sheet.dart
+++ b/lib/app/layouts/conversation_details/dialogs/participants_findmy_sheet/participants_findmy_sheet.dart
@@ -1,0 +1,250 @@
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_controller.dart';
+import 'package:bluebubbles/app/layouts/findmy/widgets/findmy_map_widget.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:get/get.dart';
+
+Future<void> showParticipantsFindMyMap(
+  BuildContext context, {
+  required FindMyController controller,
+  required Chat chat,
+  VoidCallback? onSheetClosed,
+}) async {
+  try {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      enableDrag: true,
+      isDismissible: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => FractionallySizedBox(
+        heightFactor: sheetContext.iOS ? 0.92 : 0.9,
+        alignment: Alignment.bottomCenter,
+        child: _ParticipantsFindMyMapSheetBody(
+          controller: controller,
+          chat: chat,
+        ),
+      ),
+    );
+  } finally {
+    onSheetClosed?.call();
+  }
+}
+
+class _ParticipantsFindMyHeaderData {
+  final String title;
+  final bool isGroup;
+  final int participantCount;
+  final String? singleLocationDescription;
+  final String? singleLocationState;
+
+  const _ParticipantsFindMyHeaderData({
+    required this.title,
+    required this.isGroup,
+    required this.participantCount,
+    required this.singleLocationDescription,
+    required this.singleLocationState,
+  });
+}
+
+class _ParticipantsFindMyMapSheetBody extends StatefulWidget {
+  final FindMyController controller;
+  final Chat chat;
+
+  const _ParticipantsFindMyMapSheetBody({
+    required this.controller,
+    required this.chat,
+  });
+
+  @override
+  State<_ParticipantsFindMyMapSheetBody> createState() => _ParticipantsFindMyMapSheetBodyState();
+}
+
+class _ParticipantsFindMyMapSheetBodyState extends State<_ParticipantsFindMyMapSheetBody> {
+  late final MapController _mapController;
+
+  @override
+  void initState() {
+    super.initState();
+    _mapController = MapController();
+  }
+
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
+
+  String _chatTitle() {
+    final state = ChatsSvc.chatStates[widget.chat.guid];
+    return state?.title.value ?? widget.chat.getTitle();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final topRadius = context.iOS ? 16.0 : M3EShapes.xl;
+    final borderRadius = BorderRadius.vertical(top: Radius.circular(topRadius));
+
+    return Material(
+      color: context.iOS ? context.theme.colorScheme.surface : context.tileColor,
+      borderRadius: borderRadius,
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          Obx(() {
+            widget.controller.friendsWithLocation.length;
+            final visibleParticipants = widget.controller.participantFriendsWithLocation;
+            final firstFriend = visibleParticipants.isEmpty ? null : visibleParticipants.first;
+            final data = _ParticipantsFindMyHeaderData(
+              title: visibleParticipants.isEmpty ? 'Location' : _chatTitle(),
+              isGroup: widget.chat.isGroup,
+              participantCount: visibleParticipants.length,
+              singleLocationDescription: firstFriend == null ? null : _findMyLocationDescription(firstFriend),
+              singleLocationState: firstFriend == null ? null : _findMyLocationStateLabel(firstFriend),
+            );
+            return _buildHeader(context, data, () => Navigator.of(context).pop());
+          }),
+          Expanded(
+            child: FindMyMapWidget(
+              controller: widget.controller,
+              mapController: _mapController,
+              interactive: true,
+              initialZoom: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, _ParticipantsFindMyHeaderData data, VoidCallback closeSheet) {
+    if (context.iOS) return _buildIosHeader(context, data, closeSheet);
+    return _buildExpressiveHeader(context, data, closeSheet);
+  }
+
+  Widget _buildIosHeader(BuildContext context, _ParticipantsFindMyHeaderData data, VoidCallback closeSheet) {
+    final subtitleStyle = context.theme.textTheme.bodySmall;
+    return ColoredBox(
+      color: context.theme.colorScheme.surfaceContainerHighest,
+      child: SafeArea(
+        bottom: false,
+        child: SizedBox(
+          height: 56,
+          child: NavigationToolbar(
+            centerMiddle: true,
+            middle: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  data.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.theme.textTheme.titleMedium,
+                ),
+                if (data.isGroup)
+                  Text(
+                    _findMyGroupParticipantLabel(data.participantCount),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: subtitleStyle,
+                  )
+                else if (data.singleLocationDescription != null && data.singleLocationState != null)
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          data.singleLocationDescription!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: subtitleStyle,
+                        ),
+                      ),
+                      Text(' • ${data.singleLocationState!}', style: subtitleStyle),
+                    ],
+                  ),
+              ],
+            ),
+            trailing: Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: TextButton(
+                onPressed: closeSheet,
+                child: Text(
+                  'Done',
+                  style: context.theme.textTheme.bodyLarge!.copyWith(
+                    color: context.theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExpressiveHeader(BuildContext context, _ParticipantsFindMyHeaderData data, VoidCallback closeSheet) {
+    final subtitle = data.isGroup
+        ? _findMyGroupParticipantLabel(data.participantCount)
+        : (data.singleLocationState ?? 'Location');
+    final subtitleStyle = context.theme.textTheme.bodySmall?.copyWith(
+      color: context.theme.colorScheme.onSurfaceVariant,
+    );
+
+    return SafeArea(
+      bottom: false,
+      child: SizedBox(
+        height: 68,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: M3ESpacing.xs),
+          child: Row(
+            children: [
+              IconButton(onPressed: closeSheet, icon: const Icon(Icons.close)),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      data.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.theme.textTheme.titleMedium,
+                    ),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: subtitleStyle,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: M3ESpacing.sm),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _findMyGroupParticipantLabel(int count) => '$count ${count == 1 ? "Person" : "People"}';
+
+String _findMyLocationDescription(FindMyFriend friend) {
+  if (shouldRedactFindMyContactInfo()) return 'Location';
+  final description = (friend.longAddress ?? '').trim();
+  if (description.isEmpty) return 'Location';
+  return description;
+}
+
+String _findMyLocationStateLabel(FindMyFriend friend) {
+  final status = friend.status;
+  if (status == null) return 'Location';
+  return '${status.name.capitalize!} Location';
+}

--- a/lib/app/layouts/conversation_details/widgets/CLAUDE.md
+++ b/lib/app/layouts/conversation_details/widgets/CLAUDE.md
@@ -7,6 +7,7 @@ Reusable widgets composing the conversation details / info panel.
 | File | Purpose |
 |------|---------|
 | `chat_info.dart` | **iOS-only.** Top section: avatar, name, participant count, edit name button. Material/Samsung use `../material/material_chat_header.dart` instead — routed from `conversation_details.dart` by skin |
+| `participants_findmy_card/` | Find My map preview for chat participants; opens the map bottom sheet |
 | `chat_options.dart` | **iOS-only.** Action row: mute, pin, archive, block, delete. Material/Samsung use `../material/material_chat_options.dart` instead |
 | `contact_tile.dart` | Single participant row (avatar, name, address, remove button) — shared by both skins |
 | `participants_list.dart` | **iOS-only.** Scrollable list of `ContactTile`s for group chats. Material/Samsung use `../material/material_participants_section.dart` instead |

--- a/lib/app/layouts/conversation_details/widgets/participants_findmy_card/participants_findmy_card.dart
+++ b/lib/app/layouts/conversation_details/widgets/participants_findmy_card/participants_findmy_card.dart
@@ -1,0 +1,378 @@
+import 'dart:async';
+
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/dialogs/participants_findmy_sheet/participants_findmy_sheet.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_controller.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_participant_prefetch.dart';
+import 'package:bluebubbles/app/layouts/findmy/widgets/findmy_map_widget.dart';
+import 'package:bluebubbles/app/state/chat_state.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class ParticipantsFindMyMapCard extends StatefulWidget {
+  final Chat chat;
+
+  const ParticipantsFindMyMapCard({super.key, required this.chat});
+
+  /// Same capability gate as the Find My nav entry (plus web exclusion).
+  static bool get isSupported => FindMyParticipantPrefetch.isSupported;
+
+  @override
+  State<ParticipantsFindMyMapCard> createState() => _ParticipantsFindMyMapCardState();
+}
+
+class _ParticipantsFindMyMapCardState extends State<ParticipantsFindMyMapCard> {
+  /// Tag → owning card State's token. Prevents a stale sheet-close callback from
+  /// deleting a controller after a remount has claimed the same tag.
+  static final Map<String, Object> _owners = <String, Object>{};
+
+  /// Tags with an expanded sheet currently open (survives card remount).
+  static final Set<String> _sheetOpenTags = <String>{};
+
+  /// Sheet-close handler for the current owner of each tag.
+  static final Map<String, VoidCallback> _sheetCloseHandlers = <String, VoidCallback>{};
+
+  late final FindMyController _controller;
+  final Object _ownerToken = Object();
+  StreamSubscription? _participantsSub;
+  bool _sheetOpen = false;
+
+  ChatState? get _chatState => ChatsSvc.chatStates[widget.chat.guid];
+
+  String get _controllerTag => FindMyParticipantPrefetch.controllerTag(widget.chat.guid);
+
+  List<Handle> get _currentParticipants {
+    final state = _chatState;
+    if (state != null) return state.participants.map((hs) => hs.handle).toList();
+    return widget.chat.handles.toList();
+  }
+
+  bool _owns(String tag) => identical(_owners[tag], _ownerToken);
+
+  @override
+  void initState() {
+    super.initState();
+    _initController();
+    _participantsSub = _chatState?.participants.listen((_) {
+      if (!mounted) return;
+      _controller.updateParticipantFilter(_currentParticipants);
+      setState(() {});
+    });
+  }
+
+  void _initController() {
+    final tag = _controllerTag;
+    if (Get.isRegistered<FindMyController>(tag: tag)) {
+      _controller = Get.find<FindMyController>(tag: tag);
+      _controller.updateParticipantFilter(_currentParticipants);
+    } else {
+      _controller = Get.put(
+        FindMyController(participantFilter: _currentParticipants),
+        tag: tag,
+      );
+    }
+    _claimOwnership(tag);
+  }
+
+  void _claimOwnership(String tag) {
+    _owners[tag] = _ownerToken;
+    _sheetCloseHandlers[tag] = _handleSheetClosed;
+    // Remount while a sheet is still open: inherit the flag so dispose skips delete.
+    if (_sheetOpenTags.contains(tag)) {
+      _sheetOpen = true;
+    }
+  }
+
+  void _clearOwnership(String tag) {
+    if (!_owns(tag)) return;
+    _owners.remove(tag);
+    _sheetCloseHandlers.remove(tag);
+  }
+
+  void _deleteControllerIfRegistered(String tag) {
+    if (Get.isRegistered<FindMyController>(tag: tag)) {
+      Get.delete<FindMyController>(tag: tag);
+    }
+  }
+
+  /// Invoked via [_sheetCloseHandlers] so a remounted card receives the close.
+  void _handleSheetClosed() {
+    final tag = _controllerTag;
+    if (!_owns(tag)) return;
+
+    if (mounted) {
+      setState(() => _sheetOpen = false);
+    } else {
+      _deleteControllerIfRegistered(tag);
+      _clearOwnership(tag);
+    }
+  }
+
+  Future<void> _openExpandedMap() async {
+    if (_sheetOpen) return;
+
+    final tag = _controllerTag;
+    setState(() => _sheetOpen = true);
+    _sheetOpenTags.add(tag);
+    await showParticipantsFindMyMap(
+      context,
+      controller: _controller,
+      chat: widget.chat,
+      onSheetClosed: () {
+        _sheetOpenTags.remove(tag);
+        _sheetCloseHandlers[tag]?.call();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _participantsSub?.cancel();
+    final tag = _controllerTag;
+    // Skip delete while the sheet still holds the controller; sheet close will
+    // clean up if this card (or a remounted owner) is already gone.
+    if (_owns(tag) && !_sheetOpen) {
+      _deleteControllerIfRegistered(tag);
+      _clearOwnership(tag);
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      _controller.friendsWithLocation.length;
+      final visibleParticipants = _controller.participantFriendsWithLocation;
+      final loading = visibleParticipants.isEmpty;
+
+      // Show the card when we have real locations, or when prefetch already
+      // knows a participant is sharing (map area stays in a loading state).
+      // Otherwise render nothing so we never leave an empty gap.
+      if (loading && !FindMyParticipantPrefetch.hasParticipantSharing(widget.chat)) {
+        return const SliverToBoxAdapter(child: SizedBox.shrink());
+      }
+
+      return SliverToBoxAdapter(
+        child: _ParticipantsFindMyCardContent(
+          controller: _controller,
+          visibleParticipants: visibleParticipants,
+          isGroup: widget.chat.isGroup,
+          groupTitle: _chatState?.title.value ?? widget.chat.getTitle(),
+          locationTitle: widget.chat.isGroup
+              ? null
+              : (loading ? 'Location' : _singleChatLocationTitle(visibleParticipants.first)),
+          loading: loading,
+          sheetOpen: _sheetOpen,
+          openExpandedMap: _openExpandedMap,
+        ),
+      );
+    });
+  }
+}
+
+class _ParticipantsFindMyCardContent extends StatelessWidget {
+  final FindMyController controller;
+  final List<FindMyFriend> visibleParticipants;
+  final bool isGroup;
+  final String groupTitle;
+  final String? locationTitle;
+  final bool loading;
+  final bool sheetOpen;
+  final VoidCallback openExpandedMap;
+
+  const _ParticipantsFindMyCardContent({
+    required this.controller,
+    required this.visibleParticipants,
+    required this.isGroup,
+    required this.groupTitle,
+    required this.locationTitle,
+    required this.loading,
+    required this.sheetOpen,
+    required this.openExpandedMap,
+  });
+
+  static const double _mapAspectRatio = _kFindMyMapAspectRatio;
+  static const double _footerHeight = _kFindMyFooterHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final onTap = loading || sheetOpen ? null : openExpandedMap;
+    final card = Column(
+      children: [
+        _buildMapPreview(context),
+        _buildFooter(context),
+      ],
+    );
+
+    if (context.iOS) {
+      return Padding(
+        padding: EdgeInsets.fromLTRB(20, isGroup ? 4 : 12, 20, isGroup ? 12 : 4),
+        child: Material(
+          color: context.theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(16),
+          clipBehavior: Clip.antiAlias,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onTap,
+            child: card,
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const M3ESectionHeader(label: "Location"),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: M3ESpacing.lg, vertical: M3ESpacing.xs),
+          child: Material(
+            color: context.tileColor,
+            borderRadius: BorderRadius.circular(M3EShapes.xl),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: onTap,
+              child: card,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMapPreview(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: _mapAspectRatio,
+      child: loading
+          ? _buildMapSkeleton(context)
+          : IgnorePointer(
+              child: FindMyMapWidget(
+                controller: controller,
+                mapController: controller.mapController,
+                interactive: false,
+                onMapReady: controller.onParticipantMapReady,
+              ),
+            ),
+    );
+  }
+
+  Widget _buildMapSkeleton(BuildContext context) {
+    final color = context.iOS
+        ? context.theme.colorScheme.surfaceContainerHighest
+        : context.tileColor.themeLightenOrDarken(context, 6);
+    return ColoredBox(
+      color: color,
+      child: Center(
+        child: context.iOS
+            ? CupertinoActivityIndicator(
+                radius: 12,
+                color: context.theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+              )
+            : SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: context.theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.45),
+                ),
+              ),
+      ),
+    );
+  }
+
+  Widget _buildFooter(BuildContext context) {
+    if (context.iOS) return _buildIosFooter(context);
+    return _buildExpressiveFooter(context);
+  }
+
+  Widget _buildIosFooter(BuildContext context) {
+    final title = isGroup ? groupTitle : locationTitle!;
+    final subtitle = _footerSubtitle();
+
+    return Container(
+      height: _footerHeight,
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      color: context.tileColor,
+      child: Row(
+        children: [
+          Icon(Icons.location_on, size: 18, color: context.theme.colorScheme.primary),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, maxLines: 1, overflow: TextOverflow.ellipsis, style: context.theme.textTheme.titleSmall),
+                if (subtitle != null)
+                  Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis, style: context.theme.textTheme.bodySmall),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildExpressiveFooter(BuildContext context) {
+    final title = isGroup ? groupTitle : locationTitle!;
+    final subtitle = _footerSubtitle();
+    final subtitleStyle =
+        context.theme.textTheme.bodySmall?.copyWith(color: context.theme.colorScheme.onSurfaceVariant);
+
+    return SizedBox(
+      height: _footerHeight,
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: M3ESpacing.lg),
+        child: Row(
+          children: [
+            Icon(Icons.location_on_outlined, size: 20, color: context.theme.colorScheme.primary),
+            const SizedBox(width: M3ESpacing.md),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, maxLines: 1, overflow: TextOverflow.ellipsis, style: context.theme.textTheme.titleSmall),
+                  if (subtitle != null)
+                    Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis, style: subtitleStyle),
+                ],
+              ),
+            ),
+            if (!loading) Icon(Icons.open_in_full, size: 18, color: context.theme.colorScheme.onSurfaceVariant),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _footerSubtitle() {
+    if (loading) return null;
+    if (isGroup) return _groupParticipantLabel(visibleParticipants.length);
+    return _locationStateLabel(visibleParticipants.first);
+  }
+}
+
+const double _kFindMyMapAspectRatio = 2.2;
+const double _kFindMyFooterHeight = 56;
+
+String _singleChatLocationTitle(FindMyFriend friend) {
+  if (shouldRedactFindMyContactInfo()) return 'Location';
+  final description = (friend.longAddress ?? '').trim();
+  if (description.isEmpty) return 'Location';
+  return description;
+}
+
+String _groupParticipantLabel(int count) => '$count ${count == 1 ? "Person" : "People"}';
+
+String _locationStateLabel(FindMyFriend friend) {
+  final status = friend.status;
+  if (status == null) return 'Location';
+  return '${status.name.capitalize!} Location';
+}

--- a/lib/app/layouts/conversation_details/widgets/participants_findmy_card/participants_findmy_card.dart
+++ b/lib/app/layouts/conversation_details/widgets/participants_findmy_card/participants_findmy_card.dart
@@ -71,7 +71,7 @@ class _ParticipantsFindMyMapCardState extends State<ParticipantsFindMyMapCard> {
       _controller.updateParticipantFilter(_currentParticipants);
     } else {
       _controller = Get.put(
-        FindMyController(participantFilter: _currentParticipants),
+        FindMyController(participantFilter: _currentParticipants, showSelf: true),
         tag: tag,
       );
     }

--- a/lib/app/layouts/conversation_view/pages/conversation_view.dart
+++ b/lib/app/layouts/conversation_view/pages/conversation_view.dart
@@ -8,6 +8,7 @@ import 'package:bluebubbles/app/wrappers/gradient_background_wrapper.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/pages/messages_view.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_participant_prefetch.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
@@ -69,6 +70,7 @@ class ConversationViewState extends State<ConversationView> with ThemeHelpers<Co
     controller.fromSearchResult = widget.initialScrollToGuid != null;
     ChatsSvc.setActiveChatSync(chat);
     ChatsSvc.activeChat?.controller = controller;
+    FindMyParticipantPrefetch.warm(chat);
     Logger.debug("Conversation View initialized for ${chat.guid}");
 
     controller.loadReplyToMessageState(); // P224b
@@ -207,6 +209,7 @@ class ConversationViewState extends State<ConversationView> with ThemeHelpers<Co
   void dispose() {
     routeObserver.unsubscribe(this);
     controller.saveReplyToMessageState(); // P8bda
+    FindMyParticipantPrefetch.dispose(chat.guid);
     super.dispose();
   }
 

--- a/lib/app/layouts/findmy/CLAUDE.md
+++ b/lib/app/layouts/findmy/CLAUDE.md
@@ -3,6 +3,8 @@
 ## Files
 - `findmy_page.dart` — main screen (map + list tabs)
 - `findmy_controller.dart` — state and logic: location polling, device/friend tracking
+- `findmy_handle_matcher.dart` — friend → handle identity (`FindMyHandleMatcher`)
+- `findmy_participant_prefetch.dart` — session snapshot for the conversation-details Location card
 - `findmy_location_clipper.dart` — custom `CustomClipper` for location shape
 - `findmy_pin_clipper.dart` — custom `CustomClipper` for map pin shape
 

--- a/lib/app/layouts/findmy/findmy_controller.dart
+++ b/lib/app/layouts/findmy/findmy_controller.dart
@@ -15,10 +15,22 @@ import 'package:universal_io/io.dart';
 import 'package:flutter/foundation.dart';
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_location_clipper.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_handle_matcher.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_participant_prefetch.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_pin_clipper.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 
 class FindMyController extends GetxController {
+  FindMyController({this.participantFilter});
+
+  /// When set, only friends matching these chat participants are shown (conversation details mode).
+  List<Handle>? participantFilter;
+
+  bool get isParticipantMode => participantFilter != null;
+
+  List<FindMyFriend> get participantFriendsWithLocation =>
+      friendsWithLocation.where((f) => matchesParticipantFilter(f)).toList();
+
   // Scroll Controllers
   final ScrollController devicesController = ScrollController();
   final ScrollController itemsController = ScrollController();
@@ -57,7 +69,14 @@ class FindMyController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    getLocations();
+    if (isParticipantMode) {
+      // Seed from the session snapshot so the details card can paint the real
+      // map on first frame when we already know participants are sharing.
+      _hydrateFromPrefetchSnapshot();
+      _loadParticipantLocations();
+    } else {
+      getLocations();
+    }
 
     // Listen via the event dispatcher rather than the socket itself — the socket is
     // torn down and rebuilt on every restart (backgrounding, a server URL refresh),
@@ -66,11 +85,96 @@ class FindMyController extends GetxController {
       if (event.type == 'new-findmy-location') _handleNewFindMyLocation(event.data);
     });
 
-    _scheduleRefreshGate();
+    if (!isParticipantMode) {
+      _scheduleRefreshGate();
+    }
     _setupRedactionListeners();
   }
 
+  /// Applies the shared prefetch friends list synchronously so
+  /// [participantFriendsWithLocation] is non-empty before the first Obx build
+  /// when the snapshot already has matching sharers.
+  void _hydrateFromPrefetchSnapshot() {
+    final snapshot = FindMyParticipantPrefetch.sessionFriends;
+    if (snapshot.isEmpty) return;
+
+    friends.value = List<FindMyFriend>.from(snapshot);
+    friendsWithLocation.value =
+        friends.where((item) => (item.latitude ?? 0) != 0 && (item.longitude ?? 0) != 0).toList();
+    friendsWithoutLocation.value =
+        friends.where((item) => (item.latitude ?? 0) == 0 && (item.longitude ?? 0) == 0).toList();
+
+    if (participantFriendsWithLocation.isEmpty) return;
+
+    _rebuildParticipantMarkers();
+    fetching2.value = false;
+  }
+
+  Future<void> _loadParticipantLocations() async {
+    await getLocations(refreshFriends: false, suppressErrors: true);
+    if (!_isAlive) return;
+    if (participantFriendsWithLocation.isEmpty && FindMyParticipantPrefetch.canPostParticipantRefresh) {
+      FindMyParticipantPrefetch.recordParticipantRefresh();
+      await getLocations(refreshFriends: true, suppressErrors: true);
+    }
+  }
+
+  bool matchesParticipantFilter(FindMyFriend friend) {
+    if (participantFilter == null) return true;
+    return FindMyHandleMatcher.matchesAny(friend, participantFilter!);
+  }
+
+  void updateParticipantFilter(List<Handle> handles) {
+    participantFilter = handles;
+    _rebuildParticipantMarkers();
+  }
+
+  static bool _isSameFindMyFriend(FindMyFriend a, FindMyFriend b) =>
+      FindMyHandleMatcher.friendIdentifiersMatch(a, b);
+
+  String _friendMarkerKey(FindMyFriend friend) {
+    final primary = friend.stableId ?? friend.handleAddress ?? friend.title;
+    if (primary != null) return primary;
+
+    final segments = <String>{
+      ...FindMyHandleMatcher.friendIdentifiers(friend),
+      if (friend.latitude != null && friend.longitude != null) '${friend.latitude},${friend.longitude}',
+      if (friend.subtitle != null) friend.subtitle!,
+      if (friend.longAddress != null) friend.longAddress!,
+      if (friend.lastUpdated != null) friend.lastUpdated!.millisecondsSinceEpoch.toString(),
+    }..removeWhere((s) => s.isEmpty);
+
+    if (segments.isEmpty) {
+      return 'friend-unknown-${Object.hash(friend.latitude, friend.longitude, friend.longAddress, friend.subtitle)}';
+    }
+
+    final sorted = segments.toList()..sort();
+    return sorted.join('|');
+  }
+
   bool get _isAlive => !isClosed;
+
+  void _rebuildParticipantMarkers() {
+    if (!isParticipantMode) return;
+    final allowedKeys = participantFriendsWithLocation.map(_friendMarkerKey).toSet();
+    markers.removeWhere((key, _) => !allowedKeys.contains(key));
+    for (final friend in participantFriendsWithLocation) {
+      buildFriendMarker(friend);
+    }
+  }
+
+  String friendMarkerKeyFor(FindMyFriend friend) => _friendMarkerKey(friend);
+
+  Handle? handleForFriendMarker(FindMyFriend friend) {
+    if (participantFilter != null) {
+      for (final participant in participantFilter!) {
+        if (FindMyHandleMatcher.matchesFriend(friend, participant)) {
+          return participant;
+        }
+      }
+    }
+    return friend.handle;
+  }
 
   void _scheduleRefreshGate() {
     _refreshTimer?.cancel();
@@ -117,7 +221,7 @@ class FindMyController extends GetxController {
       Logger.info("Received new location for ${friend.handle?.address}");
       if ((friend.latitude ?? 0) == 0 && (friend.longitude ?? 0) == 0) return;
 
-      final existingFriendIndex = friends.indexWhere((e) => e.stableId != null && e.stableId == friend.stableId);
+      final existingFriendIndex = friends.indexWhere((e) => _isSameFindMyFriend(e, friend));
       final existingFriend = existingFriendIndex == -1 ? null : friends[existingFriendIndex];
 
       final shouldUpdate = existingFriend == null ||
@@ -125,6 +229,14 @@ class FindMyController extends GetxController {
           friend.locatingInProgress ||
           LocationStatus.values.indexOf(existingFriend.status!) <=
               LocationStatus.values.indexOf(friend.status ?? LocationStatus.legacy);
+
+      // Keep the session snapshot current for any accepted socket update, even
+      // when this controller is filtered to a single chat's participants.
+      if (shouldUpdate) {
+        FindMyParticipantPrefetch.upsertFriend(friend);
+      }
+
+      if (isParticipantMode && !matchesParticipantFilter(friend)) return;
 
       if (shouldUpdate) {
         Logger.info("Updating map for ${friend.stableId}");
@@ -152,10 +264,10 @@ class FindMyController extends GetxController {
   /// however, the refresh friends endpoint does. The way this was coded assumes that the server
   /// will return the data for both endpoints. A server update will fix this, but for now,
   /// we will "patch" it by only "refreshing" devices when the user manually refreshes the data.
-  Future<void> getLocations({bool refreshFriends = true, bool refreshDevices = false}) async {
+  Future<void> getLocations({bool refreshFriends = true, bool refreshDevices = false, bool suppressErrors = false}) async {
     if (!_isAlive) return;
 
-    if (!(Platform.isLinux && !kIsWeb)) {
+    if (!isParticipantMode && !(Platform.isLinux && !kIsWeb)) {
       LocationPermission granted = await Geolocator.checkPermission();
       if (!_isAlive) return;
       if (granted == LocationPermission.denied) {
@@ -188,7 +300,9 @@ class FindMyController extends GetxController {
         ? await HttpSvc.icloud.refreshFriends().catchError((_) async {
             if (!_isAlive) return Response(requestOptions: RequestOptions(path: ''));
             refreshing2.value = false;
-            showSnackbar("Error", "Something went wrong refreshing FindMy Friends data!");
+            if (!suppressErrors) {
+              showSnackbar("Error", "Something went wrong refreshing FindMy Friends data!");
+            }
             return Response(requestOptions: RequestOptions(path: ''));
           })
         : await HttpSvc.icloud.getFriends().catchError((_) async {
@@ -208,8 +322,13 @@ class FindMyController extends GetxController {
         friendsWithoutLocation.value =
             friends.where((item) => (item.latitude ?? 0) == 0 && (item.longitude ?? 0) == 0).toList();
 
-        for (FindMyFriend e in friendsWithLocation) {
-          buildFriendMarker(e);
+        if (isParticipantMode) {
+          _rebuildParticipantMarkers();
+          FindMyParticipantPrefetch.updateSnapshot(friends);
+        } else {
+          for (final e in friendsWithLocation) {
+            buildFriendMarker(e);
+          }
         }
         fetching2.value = false;
         refreshing2.value = false;
@@ -222,6 +341,14 @@ class FindMyController extends GetxController {
     } else {
       fetching2.value = false;
       refreshing2.value = false;
+    }
+
+    if (isParticipantMode) {
+      if (!refreshFriends && FindMyParticipantPrefetch.canPostParticipantRefresh) {
+        FindMyParticipantPrefetch.recordParticipantRefresh();
+        HttpSvc.icloud.refreshFriends();
+      }
+      return;
     }
 
     // Fetch devices data
@@ -314,7 +441,11 @@ class FindMyController extends GetxController {
   }
 
   void buildFriendMarker(FindMyFriend friend) {
-    final markerKey = friend.stableId ?? randomString(6);
+    final markerKey = _friendMarkerKey(friend);
+    if (isParticipantMode && !matchesParticipantFilter(friend)) {
+      markers.remove(markerKey);
+      return;
+    }
     markers[markerKey] = Marker(
       key: ValueKey('friend-$markerKey'),
       point: markerPointForFriend(friend),
@@ -326,11 +457,16 @@ class FindMyController extends GetxController {
           child: Padding(
             padding: const EdgeInsets.all(3),
             child: ContactAvatarWidget(
-                editable: false, handle: friend.handle ?? Handle(address: friend.title ?? "Unknown")),
+              editable: false,
+              size: 29,
+              scaleSize: false,
+              borderThickness: 0,
+              handle: isParticipantMode ? handleForFriendMarker(friend) : friend.handle,
+            ),
           ),
         ),
       ),
-      alignment: Alignment.topCenter,
+      alignment: isParticipantMode ? Alignment.center : Alignment.topCenter,
     );
   }
 

--- a/lib/app/layouts/findmy/findmy_controller.dart
+++ b/lib/app/layouts/findmy/findmy_controller.dart
@@ -129,6 +129,9 @@ class FindMyController extends GetxController {
     _rebuildParticipantMarkers();
   }
 
+  /// True once the card's [mapController] has attached to a [FlutterMap].
+  bool _participantMapReady = false;
+
   static bool _isSameFindMyFriend(FindMyFriend a, FindMyFriend b) =>
       FindMyHandleMatcher.friendIdentifiersMatch(a, b);
 
@@ -160,6 +163,71 @@ class FindMyController extends GetxController {
     markers.removeWhere((key, _) => !allowedKeys.contains(key));
     for (final friend in participantFriendsWithLocation) {
       buildFriendMarker(friend);
+    }
+  }
+
+  /// Card map finished attaching — later location updates may fit the camera.
+  /// First framing uses [FindMyMapWidget] initialCenter / initialCameraFit so a
+  /// group [MapController.move] does not race the first tile request.
+  void onParticipantMapReady() {
+    _participantMapReady = true;
+  }
+
+  /// Pixel inset when framing 2+ pins on the full-page sheet.
+  static const EdgeInsets _kSheetFitPadding = EdgeInsets.all(40);
+
+  /// Extra inset for the compact details card. Horizontal is larger because
+  /// longitude-extreme pins (e.g. Australia, Central America) sit on the clipped
+  /// left/right edges; vertical stays smaller so the 2.2 aspect preview still fits.
+  static const EdgeInsets _kCardFitPadding = EdgeInsets.symmetric(horizontal: 28, vertical: 16);
+
+  /// Bounds fit for 2+ participant pins. Null for a single pin (use center/zoom 13).
+  ///
+  /// [compact] uses [_kCardFitPadding] for the details-card preview.
+  CameraFit? participantMarkersCameraFit({bool compact = false}) {
+    final points = participantFriendsWithLocation.map(markerPointForFriend).toList(growable: false);
+    if (points.length < 2) return null;
+    return CameraFit.coordinates(
+      coordinates: points,
+      padding: compact ? _kCardFitPadding : _kSheetFitPadding,
+      maxZoom: 13,
+    );
+  }
+
+  /// Fits [target], or the card's [mapController] when omitted.
+  void fitMapToParticipantMarkers({MapController? target}) {
+    if (target == null && isParticipantMode && !_participantMapReady) {
+      return;
+    }
+
+    final map = target ?? mapController;
+    if (!_mapHasLayoutSize(map)) return;
+
+    // Use markerPointForFriend so redacted mode centers on decoy pins, not real coords.
+    final points = participantFriendsWithLocation.map(markerPointForFriend).toList(growable: false);
+    if (points.isEmpty) return;
+
+    void apply() {
+      if (!_mapHasLayoutSize(map)) return;
+      if (points.length == 1) {
+        map.move(points.first, 13);
+        return;
+      }
+      // This path always frames the details card (the sheet has its own MapController).
+      final fit = participantMarkersCameraFit(compact: true);
+      if (fit != null) map.fitCamera(fit);
+    }
+
+    apply();
+    WidgetsBinding.instance.addPostFrameCallback((_) => apply());
+  }
+
+  static bool _mapHasLayoutSize(MapController map) {
+    try {
+      final size = map.camera.nonRotatedSize;
+      return size.width > 0 && size.height > 0;
+    } catch (_) {
+      return false;
     }
   }
 
@@ -200,6 +268,7 @@ class FindMyController extends GetxController {
       buildDeviceMarker(device);
     }
     markers.refresh();
+    if (isParticipantMode) fitMapToParticipantMarkers();
   }
 
   LatLng markerPointForFriend(FindMyFriend friend) => resolveFindMyMarkerPoint(
@@ -252,6 +321,7 @@ class FindMyController extends GetxController {
             friends.where((item) => (item.latitude ?? 0) == 0 && (item.longitude ?? 0) == 0).toList();
 
         buildFriendMarker(friend);
+        if (isParticipantMode) fitMapToParticipantMarkers();
       }
     } catch (e, s) {
       Logger.warn("Failed to fetch FindMy locations", error: e, trace: s, tag: 'FindMyController');
@@ -324,6 +394,7 @@ class FindMyController extends GetxController {
 
         if (isParticipantMode) {
           _rebuildParticipantMarkers();
+          fitMapToParticipantMarkers();
           FindMyParticipantPrefetch.updateSnapshot(friends);
         } else {
           for (final e in friendsWithLocation) {

--- a/lib/app/layouts/findmy/findmy_controller.dart
+++ b/lib/app/layouts/findmy/findmy_controller.dart
@@ -21,12 +21,18 @@ import 'package:bluebubbles/app/layouts/findmy/findmy_pin_clipper.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 
 class FindMyController extends GetxController {
-  FindMyController({this.participantFilter});
+  FindMyController({this.participantFilter, this.showSelf = false});
 
   /// When set, only friends matching these chat participants are shown (conversation details mode).
   List<Handle>? participantFilter;
 
+  /// Conversation-details card/sheet only: also show the user's own GPS marker.
+  /// The main Find My page ignores this and tracks self via [!isParticipantMode].
+  final bool showSelf;
+
   bool get isParticipantMode => participantFilter != null;
+
+  static const String _kCurrentMarkerKey = 'current';
 
   List<FindMyFriend> get participantFriendsWithLocation =>
       friendsWithLocation.where((f) => matchesParticipantFilter(f)).toList();
@@ -131,6 +137,11 @@ class FindMyController extends GetxController {
 
   /// True once the card's [mapController] has attached to a [FlutterMap].
   bool _participantMapReady = false;
+  bool _ownLocationStarted = false;
+  bool _pendingOwnLocationFit = false;
+
+  /// Expanded-sheet map, if open. Fitted alongside the card when own GPS arrives.
+  MapController? participantSheetMapController;
 
   static bool _isSameFindMyFriend(FindMyFriend a, FindMyFriend b) =>
       FindMyHandleMatcher.friendIdentifiersMatch(a, b);
@@ -160,10 +171,15 @@ class FindMyController extends GetxController {
   void _rebuildParticipantMarkers() {
     if (!isParticipantMode) return;
     final allowedKeys = participantFriendsWithLocation.map(_friendMarkerKey).toSet();
-    markers.removeWhere((key, _) => !allowedKeys.contains(key));
+    markers.removeWhere((key, _) => !_keepParticipantMarker(key, allowedKeys));
     for (final friend in participantFriendsWithLocation) {
       buildFriendMarker(friend);
     }
+  }
+
+  bool _keepParticipantMarker(String key, Set<String> allowedKeys) {
+    if (allowedKeys.contains(key)) return true;
+    return showSelf && key == _kCurrentMarkerKey;
   }
 
   /// Card map finished attaching — later location updates may fit the camera.
@@ -171,6 +187,9 @@ class FindMyController extends GetxController {
   /// group [MapController.move] does not race the first tile request.
   void onParticipantMapReady() {
     _participantMapReady = true;
+    if (!_pendingOwnLocationFit) return;
+    _pendingOwnLocationFit = false;
+    fitMapToParticipantMarkers();
   }
 
   /// Pixel inset when framing 2+ pins on the full-page sheet.
@@ -181,12 +200,13 @@ class FindMyController extends GetxController {
   /// left/right edges; vertical stays smaller so the 2.2 aspect preview still fits.
   static const EdgeInsets _kCardFitPadding = EdgeInsets.symmetric(horizontal: 28, vertical: 16);
 
-  /// Bounds fit for 2+ participant pins. Null for a single pin (use center/zoom 13).
+  /// Bounds fit for 2+ spread-out pins. Null for a single pin or stacked pins
+  /// (use center/zoom 13) — a zero-size CameraFit produces LatLng(NaN,NaN).
   ///
   /// [compact] uses [_kCardFitPadding] for the details-card preview.
   CameraFit? participantMarkersCameraFit({bool compact = false}) {
-    final points = participantFriendsWithLocation.map(markerPointForFriend).toList(growable: false);
-    if (points.length < 2) return null;
+    final points = _participantCameraPoints(includeSelf: !compact);
+    if (!_canCameraFit(points)) return null;
     return CameraFit.coordinates(
       coordinates: points,
       padding: compact ? _kCardFitPadding : _kSheetFitPadding,
@@ -194,32 +214,85 @@ class FindMyController extends GetxController {
     );
   }
 
-  /// Fits [target], or the card's [mapController] when omitted.
+  List<LatLng> _participantCameraPoints({bool includeSelf = true}) {
+    final points = participantFriendsWithLocation
+        .map(markerPointForFriend)
+        .where(isFiniteLatLng)
+        .toList();
+    if (!includeSelf || !showSelf) return points;
+    final own = markers[_kCurrentMarkerKey]?.point;
+    if (own != null && isFiniteLatLng(own)) points.add(own);
+    return points;
+  }
+
+  /// False when CameraFit.coordinates would divide by zero / emit NaN zoom.
+  static bool _canCameraFit(List<LatLng> points) {
+    if (points.length < 2) return false;
+    var minLat = points.first.latitude;
+    var maxLat = minLat;
+    var minLng = points.first.longitude;
+    var maxLng = minLng;
+    for (final point in points.skip(1)) {
+      if (point.latitude < minLat) minLat = point.latitude;
+      if (point.latitude > maxLat) maxLat = point.latitude;
+      if (point.longitude < minLng) minLng = point.longitude;
+      if (point.longitude > maxLng) maxLng = point.longitude;
+    }
+    // ~11m. Stacked/identical pins must not go through CameraFit.
+    const epsilon = 1e-4;
+    return (maxLat - minLat) > epsilon || (maxLng - minLng) > epsilon;
+  }
+
+  /// Fits [target], or the card (and open sheet) when omitted.
   void fitMapToParticipantMarkers({MapController? target}) {
-    if (target == null && isParticipantMode && !_participantMapReady) {
+    if (target != null) {
+      _fitParticipantCamera(target, compact: false);
       return;
     }
+    if (isParticipantMode && !_participantMapReady) return;
 
-    final map = target ?? mapController;
+    _fitParticipantCamera(mapController, compact: true);
+    final sheet = participantSheetMapController;
+    if (sheet != null) _fitParticipantCamera(sheet, compact: false);
+  }
+
+  void _fitParticipantCamera(MapController map, {required bool compact}) {
     if (!_mapHasLayoutSize(map)) return;
 
     // Use markerPointForFriend so redacted mode centers on decoy pins, not real coords.
-    final points = participantFriendsWithLocation.map(markerPointForFriend).toList(growable: false);
+    final points = _participantCameraPoints(includeSelf: !compact);
     if (points.isEmpty) return;
 
     void apply() {
       if (!_mapHasLayoutSize(map)) return;
-      if (points.length == 1) {
-        map.move(points.first, 13);
-        return;
-      }
-      // This path always frames the details card (the sheet has its own MapController).
-      final fit = participantMarkersCameraFit(compact: true);
-      if (fit != null) map.fitCamera(fit);
+      final size = map.camera.nonRotatedSize;
+      final padding = compact ? _kCardFitPadding : _kSheetFitPadding;
+      final canFit = _canCameraFit(points) &&
+          size.width > padding.horizontal &&
+          size.height > padding.vertical;
+
+      try {
+        if (canFit) {
+          map.fitCamera(CameraFit.coordinates(
+            coordinates: points,
+            padding: padding,
+            maxZoom: 13,
+          ));
+        } else {
+          map.move(points.first, 13);
+        }
+        final center = map.camera.center;
+        if (!isFiniteLatLng(center) || !map.camera.zoom.isFinite) {
+          map.move(points.first, 13);
+        }
+      } catch (_) {}
     }
 
     apply();
-    WidgetsBinding.instance.addPostFrameCallback((_) => apply());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_isAlive) return;
+      apply();
+    });
   }
 
   static bool _mapHasLayoutSize(MapController map) {
@@ -266,6 +339,10 @@ class FindMyController extends GetxController {
     }
     for (final device in devices.where((e) => e.location?.latitude != null && e.location?.longitude != null)) {
       buildDeviceMarker(device);
+    }
+    final loc = location.value;
+    if (loc != null && (!isParticipantMode || showSelf)) {
+      buildLocationMarker(loc);
     }
     markers.refresh();
     if (isParticipantMode) fitMapToParticipantMarkers();
@@ -337,32 +414,11 @@ class FindMyController extends GetxController {
   Future<void> getLocations({bool refreshFriends = true, bool refreshDevices = false, bool suppressErrors = false}) async {
     if (!_isAlive) return;
 
-    if (!isParticipantMode && !(Platform.isLinux && !kIsWeb)) {
-      LocationPermission granted = await Geolocator.checkPermission();
-      if (!_isAlive) return;
-      if (granted == LocationPermission.denied) {
-        granted = await Geolocator.requestPermission();
-        if (!_isAlive) return;
-      }
-
-      if (granted == LocationPermission.whileInUse || granted == LocationPermission.always) {
-        Geolocator.getCurrentPosition().then((loc) {
-          if (!_isAlive) return;
-          location.value = loc;
-          buildLocationMarker(location.value!);
-          if (!kIsDesktop) {
-            locationSub = Geolocator.getPositionStream().listen((event) {
-              if (!_isAlive) return;
-              buildLocationMarker(event);
-
-              if (!hasMovedToCurrentLocation.value) {
-                mapController.move(LatLng(event.latitude, event.longitude), 10);
-                hasMovedToCurrentLocation.value = true;
-              }
-            });
-          }
-        });
-      }
+    if (!isParticipantMode) {
+      await _startOwnLocationTracking();
+    } else if (showSelf) {
+      // Don't block friend fetch on the GPS permission prompt.
+      unawaited(_startOwnLocationTracking());
     }
 
     // Fetch friends data
@@ -541,9 +597,67 @@ class FindMyController extends GetxController {
     );
   }
 
+  Future<void> _startOwnLocationTracking() async {
+    if (_ownLocationStarted) return;
+    if (Platform.isLinux && !kIsWeb) return;
+    _ownLocationStarted = true;
+
+    LocationPermission granted = await Geolocator.checkPermission();
+    if (!_isAlive) return;
+    if (granted == LocationPermission.denied) {
+      granted = await Geolocator.requestPermission();
+      if (!_isAlive) return;
+    }
+
+    if (granted != LocationPermission.whileInUse && granted != LocationPermission.always) {
+      return;
+    }
+
+    Geolocator.getCurrentPosition().then((loc) {
+      if (!_isAlive) return;
+      _onOwnLocation(loc, fromStream: false);
+      if (kIsDesktop) return;
+
+      locationSub = Geolocator.getPositionStream().listen((event) {
+        if (!_isAlive) return;
+        _onOwnLocation(event, fromStream: true);
+      });
+    }).catchError((_) {});
+  }
+
+  bool _isUsablePosition(Position pos) {
+    final point = LatLng(pos.latitude, pos.longitude);
+    return isFiniteLatLng(point);
+  }
+
+  void _onOwnLocation(Position pos, {required bool fromStream}) {
+    if (!_isUsablePosition(pos)) return;
+
+    final isFirst = !markers.containsKey(_kCurrentMarkerKey);
+    location.value = pos;
+    buildLocationMarker(pos);
+
+    if (isParticipantMode) {
+      if (!showSelf || !isFirst) return;
+      if (_participantMapReady) {
+        fitMapToParticipantMarkers();
+      } else {
+        _pendingOwnLocationFit = true;
+      }
+      return;
+    }
+
+    if (fromStream && !hasMovedToCurrentLocation.value) {
+      mapController.move(LatLng(pos.latitude, pos.longitude), 10);
+      hasMovedToCurrentLocation.value = true;
+    }
+  }
+
   void buildLocationMarker(Position pos) {
-    markers['current'] = Marker(
-      key: const ValueKey('current'),
+    if (isParticipantMode && !showSelf) return;
+    if (!_isUsablePosition(pos)) return;
+    markers[_kCurrentMarkerKey] = Marker(
+      key: const ValueKey(_kCurrentMarkerKey),
       point: LatLng(pos.latitude, pos.longitude),
       width: 25,
       height: 55,

--- a/lib/app/layouts/findmy/findmy_handle_matcher.dart
+++ b/lib/app/layouts/findmy/findmy_handle_matcher.dart
@@ -1,0 +1,206 @@
+import 'dart:math' as math;
+
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/models/models.dart' show HandleLookupKey;
+
+/// Matches Find My friends to handles when they use different identifiers
+/// (e.g. iCloud email in Find My vs phone in chat).
+///
+/// Matching is intentionally conservative — only deterministic identity signals:
+/// handle IDs, address equality (normalized), shared [ContactV2] records, and
+/// contact phone/email entries. Display names are never compared.
+///
+/// [resolveFriendHandle] memoizes ObjectBox lookups for the process lifetime:
+/// positives are sticky; nulls use an exponential TTL backoff.
+class FindMyHandleMatcher {
+  FindMyHandleMatcher._();
+
+  static const Duration _nullTtlBase = Duration(seconds: 2);
+  static const int _nullTtlFactor = 2;
+  static const Duration _nullTtlCap = Duration(minutes: 10);
+
+  static final Map<String, _ResolveCacheEntry> _resolveCache = <String, _ResolveCacheEntry>{};
+
+  static bool matchesAny(FindMyFriend friend, List<Handle> handles) =>
+      handles.any((handle) => matchesFriend(friend, handle));
+
+  static bool matchesFriend(FindMyFriend friend, Handle handle) {
+    final resolvedFriendHandle = resolveFriendHandle(friend);
+
+    if (friend.handle != null) {
+      if (friend.handle!.id != null && handle.id != null && friend.handle!.id == handle.id) return true;
+      if (friend.handle!.uniqueAddressAndService == handle.uniqueAddressAndService) return true;
+      if (_handlesShareContact(friend.handle!, handle)) return true;
+    }
+
+    if (resolvedFriendHandle != null && _handlesShareContact(resolvedFriendHandle, handle)) return true;
+
+    for (final participantId in _handleIdentifiers(handle)) {
+      for (final friendId in _friendIdentifiers(friend)) {
+        if (_identifiersMatch(participantId, friendId)) return true;
+      }
+    }
+
+    for (final contact in handle.contactsV2) {
+      for (final friendId in _friendIdentifiers(friend)) {
+        if (_contactMatchesIdentifier(contact, friendId)) return true;
+      }
+    }
+
+    return false;
+  }
+
+  static bool friendIdentifiersMatch(FindMyFriend a, FindMyFriend b) {
+    if (a.stableId != null && b.stableId != null && a.stableId == b.stableId) return true;
+    for (final aId in friendIdentifiers(a)) {
+      for (final bId in friendIdentifiers(b)) {
+        if (identifiersMatch(aId, bId)) return true;
+      }
+    }
+    return false;
+  }
+
+  static Set<String> friendIdentifiers(FindMyFriend friend) => _friendIdentifiers(friend);
+
+  static bool identifiersMatch(String a, String b) => _identifiersMatch(a, b);
+
+  /// Resolves a friend without a hydrated [FindMyFriend.handle] via local DB lookup.
+  /// Results are cached: positives stick; nulls back off with an increasing TTL.
+  static Handle? resolveFriendHandle(FindMyFriend friend) {
+    if (friend.handle != null) return friend.handle;
+
+    final key = _cacheKey(friend);
+    if (key != null) {
+      final cached = _resolveCache[key];
+      if (cached != null) {
+        if (cached.handle != null) return cached.handle;
+        final expiresAt = cached.expiresAt;
+        if (expiresAt != null && DateTime.now().isBefore(expiresAt)) return null;
+      }
+    }
+
+    final resolved = _lookupFriendHandle(friend);
+
+    if (key == null) return resolved;
+
+    if (resolved != null) {
+      _resolveCache[key] = _ResolveCacheEntry(handle: resolved);
+      return resolved;
+    }
+
+    final previousFails = _resolveCache[key]?.failCount ?? 0;
+    final failCount = previousFails + 1;
+    final ttlMs = math.min(
+      _nullTtlCap.inMilliseconds,
+      _nullTtlBase.inMilliseconds * math.pow(_nullTtlFactor, failCount - 1).toInt(),
+    );
+    _resolveCache[key] = _ResolveCacheEntry(
+      handle: null,
+      failCount: failCount,
+      expiresAt: DateTime.now().add(Duration(milliseconds: ttlMs)),
+    );
+    return null;
+  }
+
+  static String? _cacheKey(FindMyFriend friend) {
+    final key = friend.stableId ?? friend.handleAddress ?? friend.title;
+    if (key == null || key.isEmpty) return null;
+    return key;
+  }
+
+  static Handle? _lookupFriendHandle(FindMyFriend friend) {
+    for (final id in _friendIdentifiers(friend)) {
+      final addr = id.contains('/') ? id.split('/').first : id;
+      if (!addr.contains('@')) continue;
+      final resolved = Handle.findOne(addressAndService: HandleLookupKey(addr, 'iMessage'));
+      if (resolved != null) return resolved;
+    }
+    return null;
+  }
+
+  static bool _handlesShareContact(Handle a, Handle b) {
+    for (final ca in a.contactsV2) {
+      for (final cb in b.contactsV2) {
+        if (ca.id == cb.id) return true;
+      }
+    }
+    return false;
+  }
+
+  static Set<String> _handleIdentifiers(Handle handle) {
+    final ids = <String>{
+      handle.uniqueAddressAndService,
+      handle.address,
+      if (handle.formattedAddress != null) handle.formattedAddress!,
+    };
+    if (handle.uniqueAddressAndService.contains('/')) {
+      ids.add(handle.uniqueAddressAndService.split('/').first);
+    }
+    return ids;
+  }
+
+  static Set<String> _friendIdentifiers(FindMyFriend friend) {
+    final ids = <String>{};
+    if (friend.stableId != null) ids.add(friend.stableId!);
+    if (friend.handleAddress != null) ids.add(friend.handleAddress!);
+    if (friend.handle != null) {
+      ids.add(friend.handle!.address);
+      ids.add(friend.handle!.uniqueAddressAndService);
+    }
+    if (friend.subtitle != null && _looksLikeAddress(friend.subtitle!)) {
+      ids.add(friend.subtitle!);
+    }
+    if (friend.title != null && _looksLikeAddress(friend.title!)) {
+      ids.add(friend.title!);
+    }
+    return ids;
+  }
+
+  /// True when [value] is an email or phone-like string, not a display name.
+  static bool _looksLikeAddress(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return false;
+    if (trimmed.contains('@')) return true;
+    final digits = trimmed.replaceAll(RegExp(r'[^\d]'), '');
+    return digits.length >= 7;
+  }
+
+  static bool _identifiersMatch(String a, String b) {
+    if (a == b) return true;
+
+    final aIsEmail = a.contains('@');
+    final bIsEmail = b.contains('@');
+    if (aIsEmail != bIsEmail) return false;
+
+    if (aIsEmail) {
+      return ContactV2.normalizeEmail(a) == ContactV2.normalizeEmail(b);
+    }
+
+    final na = ContactV2.normalizePhoneNumber(a);
+    final nb = ContactV2.normalizePhoneNumber(b);
+    return na.isNotEmpty && na == nb;
+  }
+
+  static bool _contactMatchesIdentifier(ContactV2 contact, String identifier) {
+    if (contact.hasMatchingAddress(identifier)) return true;
+    for (final phone in contact.phoneNumbers) {
+      if (_identifiersMatch(phone.number, identifier)) return true;
+    }
+    for (final email in contact.emailAddresses) {
+      if (_identifiersMatch(email.address, identifier)) return true;
+    }
+    return false;
+  }
+}
+
+class _ResolveCacheEntry {
+  _ResolveCacheEntry({
+    required this.handle,
+    this.failCount = 0,
+    this.expiresAt,
+  });
+
+  final Handle? handle;
+  final int failCount;
+  final DateTime? expiresAt;
+}

--- a/lib/app/layouts/findmy/findmy_participant_prefetch.dart
+++ b/lib/app/layouts/findmy/findmy_participant_prefetch.dart
@@ -22,8 +22,12 @@ class FindMyParticipantPrefetch {
   static Future<void>? _inFlight;
   static DateTime? _lastPostAt;
 
-  /// Same capability gate as the Find My nav entry (plus web exclusion).
-  static bool get isSupported => !kIsWeb && SettingsSvc.serverDetails.isMinCatalina;
+  /// Same capability gate as the Find My nav entry (plus web exclusion), and
+  /// off when [Settings.hideFindMyInConversationDetails] is enabled.
+  static bool get isSupported =>
+      !kIsWeb &&
+      SettingsSvc.serverDetails.isMinCatalina &&
+      !SettingsSvc.settings.hideFindMyInConversationDetails.value;
 
   static String controllerTag(String chatGuid) => 'conversation-findmy-location-$chatGuid';
 

--- a/lib/app/layouts/findmy/findmy_participant_prefetch.dart
+++ b/lib/app/layouts/findmy/findmy_participant_prefetch.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:bluebubbles/app/layouts/findmy/findmy_handle_matcher.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/foundation.dart';
+
+/// Maintains a single in-memory snapshot of Find My friends (server cache reads
+/// only, never Apple) so the conversation-details card can predetermine whether
+/// any participant is sharing their location and reserve space on first paint.
+///
+/// The snapshot is refreshed on stale conversation opens, deduped by a shared
+/// in-flight future and bounded by [_ttl].
+class FindMyParticipantPrefetch {
+  FindMyParticipantPrefetch._();
+
+  static const Duration _ttl = Duration(minutes: 30);
+  static const Duration _postCooldown = Duration(seconds: 30);
+
+  static List<FindMyFriend> _snapshot = <FindMyFriend>[];
+  static DateTime? _fetchedAt;
+  static Future<void>? _inFlight;
+  static DateTime? _lastPostAt;
+
+  /// Same capability gate as the Find My nav entry (plus web exclusion).
+  static bool get isSupported => !kIsWeb && SettingsSvc.serverDetails.isMinCatalina;
+
+  static String controllerTag(String chatGuid) => 'conversation-findmy-location-$chatGuid';
+
+  /// True once a snapshot has been fetched at least once — lets callers
+  /// distinguish "nobody is sharing" (known false) from "not loaded yet".
+  static bool get hasSnapshot => _fetchedAt != null;
+
+  /// The most recent friends snapshot (may be empty).
+  static List<FindMyFriend> get sessionFriends => _snapshot;
+
+  static List<Handle> participantsFor(Chat chat) {
+    final state = ChatsSvc.chatStates[chat.guid];
+    if (state != null) return state.participants.map((hs) => hs.handle).toList();
+    return chat.handles.toList();
+  }
+
+  /// Refreshes the snapshot via a server-cache GET (no Apple). Skips when a
+  /// fresh snapshot exists (unless [force]) and reuses any in-flight request.
+  static Future<void> refreshSnapshot({bool force = false}) {
+    if (!isSupported) return Future.value();
+    if (_inFlight != null) return _inFlight!;
+    if (!force && _fetchedAt != null && DateTime.now().difference(_fetchedAt!) < _ttl) {
+      return Future.value();
+    }
+    _inFlight = _doRefresh().whenComplete(() => _inFlight = null);
+    return _inFlight!;
+  }
+
+  static Future<void> _doRefresh() async {
+    try {
+      final response = await HttpSvc.icloud.getFriends();
+      if (response.statusCode == 200 && response.data['data'] != null) {
+        _snapshot = (response.data['data'] as List)
+            .map((e) => FindMyFriend.fromJson(e))
+            .toList()
+            .cast<FindMyFriend>();
+        _fetchedAt = DateTime.now();
+      }
+    } catch (_) {
+      // Best-effort server cache read; ignore failures.
+    }
+  }
+
+  /// Called on conversation open — keeps the snapshot fresh (TTL-gated) so the
+  /// details card can answer [hasParticipantSharing] without a round trip.
+  static void warm(Chat chat) {
+    if (!isSupported) return;
+    unawaited(refreshSnapshot());
+  }
+
+  /// Whether any participant of [chat] has a friend-with-location in the
+  /// current snapshot. Derived on demand — no per-chat caching required.
+  static bool hasParticipantSharing(Chat chat) {
+    if (_snapshot.isEmpty) return false;
+    final sharers =
+        _snapshot.where((f) => (f.latitude ?? 0) != 0 && (f.longitude ?? 0) != 0).toList(growable: false);
+    if (sharers.isEmpty) return false;
+    final participants = participantsFor(chat);
+    return sharers.any((f) => FindMyHandleMatcher.matchesAny(f, participants));
+  }
+
+  /// Shared cooldown so opening details on several chats within [_postCooldown]
+  /// does not trigger repeated Apple refreshes.
+  static bool get canPostParticipantRefresh =>
+      _lastPostAt == null || DateTime.now().difference(_lastPostAt!) >= _postCooldown;
+
+  static void recordParticipantRefresh() => _lastPostAt = DateTime.now();
+
+  /// Writes an authoritative friends list (from a details live fetch) back into
+  /// the snapshot so subsequent sharing checks reflect the freshest data.
+  static void updateSnapshot(List<FindMyFriend> friends) {
+    _snapshot = List<FindMyFriend>.from(friends);
+    _fetchedAt = DateTime.now();
+  }
+
+  /// Merges a single friend from a live socket update into the snapshot so
+  /// reopening Details hydrates the latest coords instead of a stale GET.
+  static void upsertFriend(FindMyFriend friend) {
+    final index = _snapshot.indexWhere((e) => FindMyHandleMatcher.friendIdentifiersMatch(e, friend));
+    if (index == -1) {
+      _snapshot = [..._snapshot, friend];
+    } else {
+      final next = List<FindMyFriend>.from(_snapshot);
+      next[index] = friend;
+      _snapshot = next;
+    }
+    _fetchedAt = DateTime.now();
+  }
+
+  static void dispose(String chatGuid) {
+    // No per-chat resources are retained; sharing is derived on demand.
+  }
+}

--- a/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
@@ -12,31 +12,68 @@ import 'package:url_launcher/url_launcher.dart';
 
 class FindMyMapWidget extends StatelessWidget {
   final FindMyController controller;
+  final bool interactive;
+  final MapController? mapController;
+  final VoidCallback? onMapReady;
+  final double? initialZoom;
 
-  const FindMyMapWidget({super.key, required this.controller});
+  const FindMyMapWidget({
+    super.key,
+    required this.controller,
+    this.interactive = true,
+    this.mapController,
+    this.onMapReady,
+    this.initialZoom,
+  });
+
+  LatLng _initialCenter() {
+    if (controller.location.value != null) {
+      return LatLng(controller.location.value!.latitude, controller.location.value!.longitude);
+    }
+    final participants = controller.participantFriendsWithLocation;
+    if (participants.isNotEmpty) {
+      // Prefer marker points so redacted decoys aren't flashed as real coords.
+      return controller.markerPointForFriend(participants.first);
+    }
+    return const LatLng(0, 0);
+  }
+
+  double _initialZoom() {
+    if (initialZoom != null) return initialZoom!;
+    if (controller.isParticipantMode) return 13;
+    return 5;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return TrackpadBugWrapper(builder: (context, bugDetected) {
+    final activeMapController = mapController ?? controller.mapController;
+    final content = TrackpadBugWrapper(builder: (context, bugDetected) {
       return Obx(() => FlutterMap(
-            mapController: controller.mapController,
+            mapController: activeMapController,
             options: MapOptions(
-              initialZoom: 5.0,
-              minZoom: 1.0,
+              initialZoom: _initialZoom(),
+              // Zoom 1 shows the world in 512px. The compact card is narrower than
+              // that, so longitude-extreme pins need zoom < 1 for CameraFit padding
+              // to take effect. Interactive maps keep 1.0 to avoid a tiny world view.
+              minZoom: controller.isParticipantMode && !interactive ? 0 : 1.0,
               maxZoom: 18.0,
-              initialCenter: controller.location.value == null
-                  ? const LatLng(0, 0)
-                  : LatLng(controller.location.value!.latitude, controller.location.value!.longitude),
-              onTap: (_, _) => controller.popupController.hideAllPopups(),
-              keepAlive: true,
+              initialCenter: _initialCenter(),
+              initialCameraFit: controller.isParticipantMode
+                  ? controller.participantMarkersCameraFit(compact: !interactive)
+                  : null,
+              // Only interactive maps own popups; previews must not subscribe to
+              // the shared PopupController or a sheet tap reparents GlobalKeys.
+              onTap: interactive ? (_, _) => controller.popupController.hideAllPopups() : null,
+              keepAlive: mapController == null,
               interactionOptions: InteractionOptions(
-                flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+                flags: interactive ? InteractiveFlag.all & ~InteractiveFlag.rotate : InteractiveFlag.none,
                 forceOnlySinglePinchGesture: bugDetected,
               ),
               onMapReady: () {
-                if (!controller.completer.isCompleted) {
+                if (mapController == null && !controller.completer.isCompleted) {
                   controller.completer.complete();
                 }
+                onMapReady?.call();
               },
             ),
             children: [
@@ -44,26 +81,33 @@ class FindMyMapWidget extends StatelessWidget {
                 urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 userAgentPackageName: 'com.bluebubbles.app',
               ),
-              PopupMarkerLayer(
-                options: PopupMarkerLayerOptions(
-                  popupController: controller.popupController,
-                  markers: controller.markers.values.toList(),
-                  popupDisplayOptions: PopupDisplayOptions(
-                    builder: (context, marker) => _buildMarkerPopup(context, marker),
+              if (interactive)
+                PopupMarkerLayer(
+                  options: PopupMarkerLayerOptions(
+                    popupController: controller.popupController,
+                    markers: controller.markers.values.toList(),
+                    popupDisplayOptions: PopupDisplayOptions(
+                      builder: (context, marker) => _buildMarkerPopup(context, marker),
+                    ),
                   ),
+                )
+              else
+                MarkerLayer(markers: controller.markers.values.toList()),
+              if (interactive)
+                RichAttributionWidget(
+                  attributions: [
+                    TextSourceAttribution(
+                      'OpenStreetMap contributors',
+                      onTap: () => launchUrl(Uri.parse('https://openstreetmap.org/copyright')),
+                    ),
+                  ],
                 ),
-              ),
-              RichAttributionWidget(
-                attributions: [
-                  TextSourceAttribution(
-                    'OpenStreetMap contributors',
-                    onTap: () => launchUrl(Uri.parse('https://openstreetmap.org/copyright')),
-                  ),
-                ],
-              ),
             ],
           ));
     });
+
+    if (!interactive) return IgnorePointer(child: content);
+    return content;
   }
 
   Widget _buildMarkerPopup(BuildContext context, Marker marker) {
@@ -77,8 +121,10 @@ class FindMyMapWidget extends StatelessWidget {
       if (item == null) return const SizedBox();
       return _buildDevicePopup(context, item);
     } else if (keyStr.startsWith("friend-")) {
-      final stableId = keyStr.substring("friend-".length);
-      final item = controller.friends.firstWhereOrNull((e) => e.stableId == stableId);
+      final markerKey = keyStr.substring("friend-".length);
+      final item = controller.friends.firstWhereOrNull(
+        (e) => controller.friendMarkerKeyFor(e) == markerKey || e.stableId == markerKey,
+      );
       if (item == null) return const SizedBox();
       return _buildFriendPopup(context, item);
     }

--- a/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_controller.dart';
 import 'package:bluebubbles/app/wrappers/trackpad_bug_wrapper.dart';
 import 'package:bluebubbles/database/models.dart';
@@ -135,28 +136,20 @@ class FindMyMapWidget extends StatelessWidget {
   Widget _buildDevicePopup(BuildContext context, FindMyDevice item) {
     return Obx(() {
       final hideContactInfo = shouldRedactFindMyContactInfo();
-      return Padding(
-        padding: const EdgeInsets.only(bottom: 5.0),
-        child: Container(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            color: context.theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.8),
+      return _popupShell(
+        context,
+        children: [
+          Text(
+            hideContactInfo ? "Device" : (item.name ?? "Unknown Device"),
+            style: context.theme.textTheme.labelLarge,
           ),
-          padding: const EdgeInsets.all(10),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(hideContactInfo ? "Device" : (item.name ?? "Unknown Device"),
-                  style: context.theme.textTheme.labelLarge),
-              Text(
-                  hideContactInfo
-                      ? "Location"
-                      : (item.address?.label ?? item.address?.mapItemFullAddress ?? "No location found"),
-                  style: context.theme.textTheme.bodySmall),
-            ],
+          Text(
+            hideContactInfo
+                ? "Location"
+                : (item.address?.label ?? item.address?.mapItemFullAddress ?? "No location found"),
+            style: context.theme.textTheme.bodySmall,
           ),
-        ),
+        ],
       );
     });
   }
@@ -169,29 +162,39 @@ class FindMyMapWidget extends StatelessWidget {
           ? (handleState?.fakeName ?? 'Contact')
           : (item.handle?.displayName ?? item.title ?? "Unknown Friend");
 
-      return Padding(
-        padding: const EdgeInsets.only(bottom: 5.0),
-        child: Container(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            color: context.theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.8),
-          ),
-          padding: const EdgeInsets.all(10),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(displayName, style: context.theme.textTheme.labelLarge),
-              Text(hideContactInfo ? "Location" : (item.longAddress ?? "No location found"),
-                  style: context.theme.textTheme.bodySmall),
-              if (item.lastUpdated != null && item.status != LocationStatus.live)
-                Text("Last updated ${buildDate(item.lastUpdated)}", style: context.theme.textTheme.bodySmall),
-              if (item.status != null)
-                Text("${item.status!.name.capitalize!} Location", style: context.theme.textTheme.bodySmall),
-            ],
-          ),
-        ),
+      return _popupShell(
+        context,
+        children: [
+          Text(displayName, style: context.theme.textTheme.labelLarge),
+          Text(hideContactInfo ? "Location" : (item.longAddress ?? "No location found"),
+              style: context.theme.textTheme.bodySmall),
+          if (item.lastUpdated != null && item.status != LocationStatus.live)
+            Text("Last updated ${buildDate(item.lastUpdated)}", style: context.theme.textTheme.bodySmall),
+          if (item.status != null)
+            Text("${item.status!.name.capitalize!} Location", style: context.theme.textTheme.bodySmall),
+        ],
       );
     });
+  }
+
+  Widget _popupShell(BuildContext context, {required List<Widget> children}) {
+    final isIos = context.iOS;
+    return Padding(
+      padding: EdgeInsets.only(bottom: isIos ? 5.0 : M3ESpacing.xs),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(isIos ? 10 : M3EShapes.md),
+          color: isIos
+              ? context.theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.8)
+              : context.tileColor.withValues(alpha: 0.9),
+        ),
+        padding: EdgeInsets.all(isIos ? 10 : M3ESpacing.md),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: children,
+        ),
+      ),
+    );
   }
 }

--- a/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
@@ -27,14 +27,28 @@ class FindMyMapWidget extends StatelessWidget {
     this.initialZoom,
   });
 
+  /// Participant preview hides the self pin; the interactive sheet (and the
+  /// main Find My page) keep it.
+  List<Marker> _visibleMarkers() {
+    final markers = controller.markers.values;
+    if (interactive || !controller.isParticipantMode) return markers.toList();
+    return markers.where((m) {
+      final key = (m.key as ValueKey?)?.value;
+      return key != 'current';
+    }).toList();
+  }
+
   LatLng _initialCenter() {
-    if (controller.location.value != null) {
-      return LatLng(controller.location.value!.latitude, controller.location.value!.longitude);
+    if (controller.isParticipantMode) {
+      final participants = controller.participantFriendsWithLocation;
+      if (participants.isNotEmpty) {
+        // Prefer marker points so redacted decoys aren't flashed as real coords.
+        return controller.markerPointForFriend(participants.first);
+      }
     }
-    final participants = controller.participantFriendsWithLocation;
-    if (participants.isNotEmpty) {
-      // Prefer marker points so redacted decoys aren't flashed as real coords.
-      return controller.markerPointForFriend(participants.first);
+    if (controller.location.value != null) {
+      final point = LatLng(controller.location.value!.latitude, controller.location.value!.longitude);
+      if (isFiniteLatLng(point)) return point;
     }
     return const LatLng(0, 0);
   }
@@ -86,14 +100,14 @@ class FindMyMapWidget extends StatelessWidget {
                 PopupMarkerLayer(
                   options: PopupMarkerLayerOptions(
                     popupController: controller.popupController,
-                    markers: controller.markers.values.toList(),
+                    markers: _visibleMarkers(),
                     popupDisplayOptions: PopupDisplayOptions(
                       builder: (context, marker) => _buildMarkerPopup(context, marker),
                     ),
                   ),
                 )
               else
-                MarkerLayer(markers: controller.markers.values.toList()),
+                MarkerLayer(markers: _visibleMarkers()),
               if (interactive)
                 RichAttributionWidget(
                   attributions: [
@@ -114,7 +128,15 @@ class FindMyMapWidget extends StatelessWidget {
   Widget _buildMarkerPopup(BuildContext context, Marker marker) {
     final ValueKey? key = marker.key as ValueKey?;
     final keyStr = key?.value as String? ?? '';
-    if (keyStr == "current") return const SizedBox();
+    if (keyStr == "current") {
+      if (!controller.isParticipantMode) return const SizedBox();
+      return _popupShell(
+        context,
+        children: [
+          Text("You", style: context.theme.textTheme.labelLarge),
+        ],
+      );
+    }
 
     if (keyStr.startsWith("device-")) {
       final deviceId = keyStr.substring("device-".length);

--- a/lib/app/layouts/settings/pages/message_view/conversation_panel.dart
+++ b/lib/app/layouts/settings/pages/message_view/conversation_panel.dart
@@ -261,6 +261,20 @@ class _ConversationPanelState extends State<ConversationPanel> with ThemeHelpers
                             "Enable this to hide names under participant avatars when you view a message's reactions",
                         backgroundColor: tileColor,
                       )),
+                  if (!kIsWeb) const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                  if (!kIsWeb)
+                    Obx(() => SettingsSwitch(
+                          onChanged: (bool val) {
+                            SettingsSvc.settings.hideFindMyInConversationDetails.value = val;
+                            SettingsSvc.settings.saveOneAsync("hideFindMyInConversationDetails");
+                          },
+                          initialVal: SettingsSvc.settings.hideFindMyInConversationDetails.value,
+                          title: "Hide Find My in Conversation Details",
+                          subtitle:
+                              "Hides the participant location map on the conversation details screen",
+                          backgroundColor: tileColor,
+                          isThreeLine: true,
+                        )),
                 ],
               ),
               if (!kIsWeb)

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -351,6 +351,7 @@ List<Widget> buildSettingItemList({
             "Sync Group Chat Icons",
             "Store Last Read Message",
             "Hide Names in Reaction Details",
+            "Hide Find My in Conversation Details",
             "Add Send/Receive Sound",
             "Send/Receive Sound Volume",
             "Auto-open Keyboard",

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -132,6 +132,7 @@ class Settings {
   final RxString userName = "You".obs;
   final RxnString userAvatarPath = RxnString();
   final RxBool hideNamesForReactions = false.obs;
+  final RxBool hideFindMyInConversationDetails = false.obs;
   final RxBool replaceEmoticonsWithEmoji = false.obs;
 
   // final RxString emojiFontFamily;
@@ -451,6 +452,7 @@ class Settings {
       'useDesktopAccent': useDesktopAccent.value,
       'logLevel': logLevel.value.index,
       'hideNamesForReactions': hideNamesForReactions.value,
+      'hideFindMyInConversationDetails': hideFindMyInConversationDetails.value,
       'replaceEmoticonsWithEmoji': replaceEmoticonsWithEmoji.value,
       'lastReviewRequestTimestamp': lastReviewRequestTimestamp.value,
       'serverPrivateAPI': serverPrivateAPI.value,
@@ -731,6 +733,8 @@ class Settings {
         map['logLevel'] != null ? Level.values[map['logLevel']] : SettingsSvc.settings.logLevel.value;
     SettingsSvc.settings.hideNamesForReactions.value =
         map['hideNamesForReactions'] ?? SettingsSvc.settings.hideNamesForReactions.value;
+    SettingsSvc.settings.hideFindMyInConversationDetails.value =
+        map['hideFindMyInConversationDetails'] ?? SettingsSvc.settings.hideFindMyInConversationDetails.value;
     SettingsSvc.settings.replaceEmoticonsWithEmoji.value =
         map['replaceEmoticonsWithEmoji'] ?? SettingsSvc.settings.replaceEmoticonsWithEmoji.value;
     SettingsSvc.settings.lastReviewRequestTimestamp.value =
@@ -899,6 +903,7 @@ class Settings {
     s.firstFcmRegisterDate.value = map['firstFcmRegisterDate'] ?? 0;
     s.logLevel.value = map['logLevel'] != null ? Level.values[map['logLevel']] : Level.info;
     s.hideNamesForReactions.value = map['hideNamesForReactions'] ?? false;
+    s.hideFindMyInConversationDetails.value = map['hideFindMyInConversationDetails'] ?? false;
     s.replaceEmoticonsWithEmoji.value = map['replaceEmoticonsWithEmoji'] ?? false;
     s.lastReviewRequestTimestamp.value = map['lastReviewRequestTimestamp'] ?? 0;
     return s;

--- a/lib/helpers/ui/findmy_helpers.dart
+++ b/lib/helpers/ui/findmy_helpers.dart
@@ -32,6 +32,13 @@ LatLng redactedFindMyPoint(String key) {
   return LatLng(center.lat + latJitter, center.lng + lngJitter);
 }
 
+/// True when [point] can be projected by flutter_map (finite, in-range).
+bool isFiniteLatLng(LatLng point) =>
+    point.latitude.isFinite &&
+    point.longitude.isFinite &&
+    point.latitude.abs() <= 90 &&
+    point.longitude.abs() <= 180;
+
 /// Returns [redactedFindMyPoint] when contact info is hidden, otherwise the real coordinates.
 LatLng resolveFindMyMarkerPoint({
   required String stableKey,


### PR DESCRIPTION
This PR adds FindMy functionality inside the conversation details page, similar to native iOS.

- Adds a FindMy card widget to the conversation details page. The map is bound to any participants that are sharing, plus the user's own location when available.
  If no participants are sharing their location, no card is displayed.
- Tapping the card widget opens a bottomsheet with the fully navigable map, displaying just the conversation participants (and you).
- The card and bottomsheet are styled to match iOS, Material, and Samsung variants.
- Opening a conversation does a light prefetch so the details page already knows whether to reserve space for the card, avoiding layout shift.
- A Conversation settings toggle, **Hide Find My in Conversation Details**, can turn the card off (shown by default).

> I use then when I'm meeting up with friends and need to quickly find what block/building they're at.
<table width="100%">
  <thead>
    <tr>
      <th width="33%">Details</th>
      <th width="33%">Bottomsheet</th>
      <th width="33%">Group Details</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td colspan="3" align="center"><strong>iOS</strong></td>
    </tr>
    <tr>
      <td width="33%" valign="top"><img width="100%" alt="Screenshot_20260818_071821_BlueBubbles_Beta" src="https://github.com/user-attachments/assets/abde4dde-4dcb-48b2-a0c5-8b0afcfe5447" /></td>
      <td width="33%" valign="top"><img width="100%" alt="Screenshot_20260818_071851_BlueBubbles_Beta" src="https://github.com/user-attachments/assets/3111a7a5-221c-41d3-add9-b7fb62cb36d9" /></td>
      <td width="33%" valign="top"><img width="100%" alt="Screenshot_20260818_071911_BlueBubbles_Beta" src="https://github.com/user-attachments/assets/b7b05d25-d96d-4383-bdab-b7f93dea432b" /></td>
    </tr>
    <tr>
      <td colspan="3" align="center"><strong>Material / Samsung</strong></td>
    </tr>
    <tr>
      <td width="33%" valign="top"><img width="100%" alt="Screenshot_20260818_071934_BlueBubbles_Beta" src="https://github.com/user-attachments/assets/5b4a20f3-4d6d-446d-bd37-b62a8cf57489" /></td>
      <td width="33%" valign="top"><img width="100%" alt="Screenshot_20260818_072001_BlueBubbles_Beta" src="https://github.com/user-attachments/assets/388c5bf8-9881-4e27-91fe-3d0bd1a6a097" /></td>
      <td width="33%" valign="top"><img width="100%" alt="Screenshot_20260818_072016_BlueBubbles_Beta" src="https://github.com/user-attachments/assets/6356f9aa-1548-4db8-b5df-8cf9f3fed2a8" /></td>
    </tr>
  </tbody>
</table>


Most of the design references were taken from my iPad and just googling. Please let me know if you need any changes or have any suggestions. You can also find me as @DeveloperBlue in the discord.

## Developer Notes
1. The largest core change is to `lib/app/layouts/findmy/findmy_controller.dart`.
   I added filtering by contact handles, fit-to-participants bounding, and an optional own-location marker for conversation details. It does not change the behavior on the main FindMy page.
2. If no one in your conversation is sharing their location, there is no card widget.
   On native iOS, there would instead be two buttons "Request Location" and "Share my Location". I don't think BB supports requesting locations just yet.
3. I added a `findmy_handle_matcher` helper that matches FindMy markers to their actual contacts (e.g. iCloud emails to contacts/chat participants). It's not wired up into the main FindMy feature, but it would also partially solve issue #2619.

<details>
<summary>File changes</summary>

`findmy_controller.dart` — participant filtering, camera fit, own-location marker, scoped socket cleanup
`findmy_handle_matcher.dart` — match FindMy friends to chat participant handles
`findmy_participant_prefetch.dart` — session snapshot so the card can be shown/hidden without layout shift
`findmy_map_widget.dart` — preview mode and participant-map camera fitting
`participants_findmy_card.dart` — conversation details map preview card
`participants_findmy_sheet.dart` — expandable navigable map bottomsheet
`conversation_details.dart` — mounts the card when FindMy is supported
`conversation_view.dart` — warms the prefetch when a conversation opens
`settings.dart` / `conversation_panel.dart` / `settings_items_list.dart` — hide-in-conversation-details setting
`findmy_helpers.dart` — finite-coordinate guard for map projection
</details>