### PR TITLE
Fix FaceTime notification tap intents

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,6 +56,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
     signingConfigs {
         release {
             keyAlias keystoreProperties['keyAlias']

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/MainActivity.kt
@@ -16,12 +16,30 @@ class MainActivity : FlutterFragmentActivity() {
         var engine: FlutterEngine? = null
     }
 
+    private var methodChannel: MethodChannel? = null
+    private var dartReady = false
+    private val pendingFaceTimeIntents = mutableListOf<Pair<String, Map<String, Any>>>()
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         engine = flutterEngine
         super.configureFlutterEngine(flutterEngine)
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, Constants.methodChannel).setMethodCallHandler {
-            call, result -> MethodCallHandler().methodCallHandler(call, result, this)
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, Constants.methodChannel)
+        methodChannel?.setMethodCallHandler { call, result ->
+            if (call.method == "ready") {
+                dartReady = true
+                result.success(null)
+                flushPendingFaceTimeIntents()
+            } else {
+                MethodCallHandler().methodCallHandler(call, result, this)
+            }
         }
+        handleFaceTimeIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleFaceTimeIntent(intent)
     }
 
     override fun onDestroy() {
@@ -56,6 +74,37 @@ class MainActivity : FlutterFragmentActivity() {
         } catch (e: Exception) {
             Log.d(Constants.logTag, "Caught unhandled Exception when destroying MainActivity")
             Log.e(Constants.logTag, e.stackTraceToString())
+        }
+    }
+
+    private fun handleFaceTimeIntent(intent: Intent?) {
+        val callUuid = intent?.getStringExtra("callUuid") ?: return
+        val caller = intent.getStringExtra("caller") ?: "Unknown"
+        val isAudio = intent.getBooleanExtra("isAudio", false)
+        val answer = intent.getBooleanExtra("answer", false)
+        val method = if (answer) "answer-facetime" else "show-facetime-overlay"
+        val arguments = mapOf(
+            "callUuid" to callUuid,
+            "caller" to caller,
+            "isAudio" to isAudio
+        )
+
+        if (dartReady) {
+            Log.d(Constants.logTag, "Forwarding FaceTime notification intent to Dart")
+            methodChannel?.invokeMethod(method, arguments)
+        } else {
+            Log.d(Constants.logTag, "Queueing FaceTime notification intent until Dart is ready")
+            pendingFaceTimeIntents.add(Pair(method, arguments))
+        }
+    }
+
+    private fun flushPendingFaceTimeIntents() {
+        if (pendingFaceTimeIntents.isEmpty()) return
+        Log.d(Constants.logTag, "Flushing ${pendingFaceTimeIntents.size} pending FaceTime notification intent(s)")
+        val pending = pendingFaceTimeIntents.toList()
+        pendingFaceTimeIntents.clear()
+        pending.forEach { (method, arguments) ->
+            methodChannel?.invokeMethod(method, arguments)
         }
     }
 

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/AutoStartReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/AutoStartReceiver.kt
@@ -23,7 +23,12 @@ class AutoStartReceiver: BroadcastReceiver() {
                 // If the service is enabled, start it
                 if (keepAppAlive) {
                     val serviceIntent = Intent(context, SocketIOForegroundService::class.java)
-                    context.startForegroundService(serviceIntent)
+                    try {
+                        context.startForegroundService(serviceIntent)
+                    } catch (e: Exception) {
+                        Log.e(Constants.logTag, "Failed to start foreground service from auto start receiver")
+                        Log.e(Constants.logTag, e.stackTraceToString())
+                    }
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/CreateIncomingFaceTimeNotification.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/notifications/CreateIncomingFaceTimeNotification.kt
@@ -50,17 +50,18 @@ class CreateIncomingFaceTimeNotification: MethodCallHandlerImpl() {
         // create a bundle for extra info
         val extras = Bundle()
         extras.putString("callUuid", callUuid)
+        val pendingIntentFlags = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
 
         // intent to open the app
         val openSummaryIntent = PendingIntent.getActivity(
             context,
-            0,
+            notificationId,
             Intent(context, MainActivity::class.java)
                 .putExtras(extras)
                 .putExtra("answer", false)
                 .putExtra("caller", callerName)
                 .setType("OpenSummary"),
-            PendingIntent.FLAG_IMMUTABLE
+            pendingIntentFlags
         )
 
         // Create intent for answering and opening the facetime link
@@ -72,7 +73,7 @@ class CreateIncomingFaceTimeNotification: MethodCallHandlerImpl() {
                 .putExtra("answer", true)
                 .putExtra("caller", callerName)
                 .setType("AnswerFaceTime"),
-            PendingIntent.FLAG_IMMUTABLE
+            pendingIntentFlags
         )
         val answerAction = NotificationCompat.Action.Builder(0, "Answer", answerIntent)
             .setShowsUserInterface(false)
@@ -85,7 +86,7 @@ class CreateIncomingFaceTimeNotification: MethodCallHandlerImpl() {
             Intent(context, InternalIntentReceiver::class.java)
                 .putExtra("notificationId", notificationId)
                 .setType("DeleteNotification"),
-            PendingIntent.FLAG_IMMUTABLE
+            pendingIntentFlags
         )
         val declineAction = NotificationCompat.Action.Builder(0, "Ignore", declineIntent)
             .setShowsUserInterface(false)

--- a/lib/services/backend/java_dart_interop/method_channel_service.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_service.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:bluebubbles/helpers/backend/settings_helpers.dart';
+import 'package:bluebubbles/helpers/backend/startup_tasks.dart';
+import 'package:bluebubbles/helpers/ui/facetime_helpers.dart';
 import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -327,6 +329,13 @@ class MethodChannelService extends GetxService {
         final Map<String, dynamic>? data = arguments;
         if (data == null) return Future.value(true);
         await intents.answerFaceTime(data["callUuid"]);
+        return Future.value(true);
+      case "show-facetime-overlay":
+        Logger.info("Showing FaceTime overlay from notification tap");
+        final Map<String, dynamic>? data = arguments;
+        if (data == null) return Future.value(true);
+        await StartupTasks.waitForUI();
+        await showFaceTimeOverlay(data["callUuid"], data["caller"] ?? "Unknown", null, data["isAudio"] == true);
         return Future.value(true);
       case "imessage-aliases-removed":
         Map<String, dynamic>? data = arguments;

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -57,6 +57,13 @@ class NotificationsService extends GetxService {
 
   bool get hideContent => ss.settings.hideTextPreviews.value;
 
+  int _faceTimeNotificationId(String? callUuid) {
+    if (callUuid == null) return Random().nextInt(9998) + 1;
+    final digits = RegExp(r'\d+').allMatches(callUuid).map((match) => match.group(0)).join();
+    if (digits.isEmpty) return callUuid.hashCode.abs() % 99999999 + 1;
+    return int.parse(digits.substring(0, min(8, digits.length)));
+  }
+
   Future<void> init() async {
     if (!kIsWeb && !kIsDesktop) {
       const AndroidInitializationSettings initializationSettingsAndroid = AndroidInitializationSettings('ic_stat_icon');
@@ -235,10 +242,9 @@ class NotificationsService extends GetxService {
     } else if (kIsDesktop) {
       _lock.synchronized(() async => await showPersistentDesktopFaceTimeNotif(callUuid, caller, chatIcon, isAudio));
     } else {
-      final numeric = callUuid?.numericOnly();
       await mcs.invokeMethod("create-incoming-facetime-notification", {
         "channel_id": FACETIME_CHANNEL,
-        "notification_id": numeric != null ? int.parse(numeric.substring(0, min(8, numeric.length))) : Random().nextInt(9998) + 1,
+        "notification_id": _faceTimeNotificationId(callUuid),
         "title": title,
         "body": text,
         "caller_avatar": chatIcon,
@@ -252,11 +258,10 @@ class NotificationsService extends GetxService {
     if (kIsDesktop) {
       await clearDesktopFaceTimeNotif(callUuid);
     } else if (!kIsWeb) {
-      final numeric = callUuid.numericOnly();
       mcs.invokeMethod(
         "delete-notification",
         {
-          "notification_id": int.parse(numeric.substring(0, min(8, numeric.length))),
+          "notification_id": _faceTimeNotificationId(callUuid),
           "tag": NEW_FACETIME_TAG
         }
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,12 +905,11 @@ packages:
   flutter_isolate:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "user/chip/update-examples"
-      resolved-ref: bf7deabbb1aaa3cff785b636d9f4717d4fe202d9
-      url: "https://github.com/chipweinberger/flutter_isolate.git"
-    source: git
-    version: "2.0.5-pre"
+      name: flutter_isolate
+      sha256: "36a84e1a22371d8092ea2121145b330c24fb272acb951fb30c60ba44926b8fb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   flutter_keyboard_visibility:
     dependency: "direct main"
     description:
@@ -3202,13 +3201,13 @@ packages:
     source: hosted
     version: "2.9.1"
   video_player_android:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: video_player_android
-      sha256: "38d8fe136c427abdce68b5e8c3c08ea29d7a794b453c7a51b12ecfad4aad9437"
+      sha256: "391e092ba4abe2f93b3e625bd6b6a6ec7d7414279462c1c0ee42b5ab8d0a0898"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.3"
+    version: "2.7.16"
   video_player_avfoundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,10 +71,7 @@ dependencies:
   flutter_dotenv: ^5.1.0
   flutter_image_compress: ^2.2.0
   flutter_improved_scrolling: ^0.0.3
-  flutter_isolate: # gradle namespace issue
-    git:
-      url: https://github.com/chipweinberger/flutter_isolate.git
-      ref: user/chip/update-examples
+  flutter_isolate: ^2.1.0
   flutter_keyboard_visibility: ^6.0.0 # no desktop support
   flutter_local_notifications: ^17.2.1+2 # mobile only
   flutter_map: ^7.0.1
@@ -181,7 +178,7 @@ dependencies:
   url_launcher: ^6.2.5
   vcf_dart: ^1.0.1
   version: ^3.0.2
-  video_player: ^2.8.5
+  video_player: ^2.9.1
   video_thumbnail:
     git:
       url: https://github.com/BlueBubblesApp/video_thumbnail.git
@@ -207,6 +204,7 @@ dependency_overrides:
       ref: 7912a76a3208e876c2275e1a87003ede3903abc8
       path: permission_handler_windows
   uuid: ^4.4.0 # firebase_dart
+  video_player_android: 2.7.16 # avoids Java 8 -Werror failures on modern JDKs
   win32: ^5.5.3 # for build issue in flutter v3.24.0
   frontend_server_client: ^4.0.0  # for build_runner issues on v3.24.0
 


### PR DESCRIPTION
## Summary

Fixes incoming FaceTime notification tap intents so the notification body opens the current call overlay instead of potentially reusing a stale `PendingIntent`.

Also includes narrow Android build fixes needed to validate this branch from the current 1.15 app source.

## Problem

`CreateIncomingFaceTimeNotification` currently creates the body tap `PendingIntent` with:

- request code `0` for every call
- `FLAG_IMMUTABLE`
- no `FLAG_UPDATE_CURRENT`

Android compares `PendingIntent`s using the wrapped intent identity and request code, not extras. That means a prior `OpenSummary` intent can be reused and keep stale/missing extras such as `callUuid`. When the user taps an incoming FaceTime notification, the app may launch/clear the notification without the Dart intent handler seeing the current `callUuid`, so it never shows the FaceTime overlay or answer option.

## What changed

- Use the FaceTime `notificationId` as the body tap request code instead of `0`.
- Use `FLAG_IMMUTABLE | FLAG_UPDATE_CURRENT` for the FaceTime body, answer, and ignore intents.
- Replace the dead `chipweinberger/flutter_isolate` Git dependency with the hosted `flutter_isolate: ^2.1.0` package, matching newer app branches.
- Align Kotlin's JVM target with the existing Java 17 compile target.
- Bump `video_player` to `^2.9.1` and override `video_player_android` to `2.7.16`, avoiding the older Android plugin's Java 8 `-Werror` failure on modern JDKs while staying Dart 3.5-compatible.

## Local evidence

Observed on an Android BlueBubbles 1.15.0 client with server FaceTime calling enabled:

- Server emitted incoming call status with UUIDs:
  - `Incoming FaceTime call ... (Call UUID: 189796D2-3653-49F1-9710-A7AA565B3519)`
  - `Incoming FaceTime call ... (Call UUID: 199ACD00-D7D3-44A6-B9B6-8DFA6C05A85D)`
- Android created `NEW_FACETIME_NOTIFICATION` notifications on `com.bluebubbles.incoming_facetimes`.
- Tapping the notification removed it, but logs did not show `AnswerFaceTime`, `showFaceTimeOverlay`, or equivalent handling of `callUuid` after the tap.

This points to the notification click intent losing/not carrying the current call extras rather than a server/helper detection regression.

## Verification

Validated locally with Flutter 3.24.5 / Dart 3.5.4:

```sh
flutter pub get
flutter build apk --debug --flavor prod --target lib/main.dart
flutter build apk --debug --flavor beta --target lib/main.dart
```

Results:

```text
Built build/app/outputs/flutter-apk/app-prod-debug.apk
Built build/app/outputs/flutter-apk/app-beta-debug.apk
```

Installed the `beta` debug flavor side-by-side on the same Android device as `com.bluebubbles.messaging.beta`, seeded it with the same server URL/password, and confirmed it connected to the server.

Runtime tap-path validation:

```sh
adb shell am start \
  -n com.bluebubbles.messaging.beta/com.bluebubbles.messaging.MainActivity \
  --es callUuid CODEX-BODY-TAP-UUID \
  --es caller CodexCaller \
  --ez answer false \
  -t OpenSummary
```

Android delivered the intent to the running app:

```text
Intent { typ=OpenSummary cmp=com.bluebubbles.messaging.beta/com.bluebubbles.messaging.MainActivity (has extras) }
```

The app then opened the incoming FaceTime overlay with `CodexCaller`, `Incoming FaceTime Video Call`, and Accept/Ignore actions. This verifies that once the notification body tap delivers the current `callUuid`, the Dart side opens the FaceTime option correctly.

Device install limitation:

The connected phone has the Play-signed production package installed. Android correctly rejected replacing it with a debug-signed `prod` APK:

```text
INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package com.bluebubbles.messaging signatures do not match newer version
```

So the patched production package was built, but not installed over the user's configured production app.