### PR TITLE
fix: redacted mode leaks for FindMy and custom chat display names

### DIFF
--- a/lib/app/layouts/conversation_list/pages/search/search_view.dart
+++ b/lib/app/layouts/conversation_list/pages/search/search_view.dart
@@ -366,7 +366,7 @@ class SearchViewState extends State<SearchView> with ThemeHelpers {
                             title: RichText(
                               text: TextSpan(
                                 children: MessageHelper.buildEmojiText(
-                                  chat.getTitle(),
+                                  ChatsSvc.getChatState(chat.guid)?.title.value ?? chat.getTitle(),
                                   context.theme.textTheme.bodyLarge!,
                                 ),
                               ),
@@ -514,7 +514,9 @@ class SearchViewState extends State<SearchView> with ThemeHelpers {
                                         )),
                                   ),
                                   label: selectedChat.value != null
-                                      ? Text(selectedChat.value!.getTitle(),
+                                      ? Text(
+                                          ChatsSvc.getChatState(selectedChat.value!.guid)?.title.value ??
+                                              selectedChat.value!.getTitle(),
                                           style: TextStyle(
                                               fontSize: 14,
                                               fontWeight: FontWeight.normal,

--- a/lib/app/layouts/findmy/findmy_controller.dart
+++ b/lib/app/layouts/findmy/findmy_controller.dart
@@ -50,6 +50,8 @@ class FindMyController extends GetxController {
 
   StreamSubscription? locationSub;
   Timer? _refreshTimer;
+  StreamSubscription? _redactedModeListener;
+  StreamSubscription? _hideContactInfoListener;
 
   @override
   void onInit() {
@@ -60,6 +62,7 @@ class FindMyController extends GetxController {
     SocketSvc.socket?.on("new-findmy-location", _handleNewFindMyLocation);
 
     _scheduleRefreshGate();
+    _setupRedactionListeners();
   }
 
   bool get _isAlive => !isClosed;
@@ -71,6 +74,36 @@ class FindMyController extends GetxController {
       canRefresh.value = true;
     });
   }
+
+  void _setupRedactionListeners() {
+    _redactedModeListener?.cancel();
+    _hideContactInfoListener?.cancel();
+    _redactedModeListener = SettingsSvc.settings.redactedMode.listen((_) => _rebuildAllMarkers());
+    _hideContactInfoListener = SettingsSvc.settings.hideContactInfo.listen((_) => _rebuildAllMarkers());
+  }
+
+  void _rebuildAllMarkers() {
+    if (!_isAlive) return;
+    for (final friend in friendsWithLocation) {
+      buildFriendMarker(friend);
+    }
+    for (final device in devices.where((e) => e.location?.latitude != null && e.location?.longitude != null)) {
+      buildDeviceMarker(device);
+    }
+    markers.refresh();
+  }
+
+  LatLng markerPointForFriend(FindMyFriend friend) => resolveFindMyMarkerPoint(
+        stableKey: friend.stableId ?? friend.title ?? 'friend',
+        latitude: friend.latitude!,
+        longitude: friend.longitude!,
+      );
+
+  LatLng markerPointForDevice(FindMyDevice device) => resolveFindMyMarkerPoint(
+        stableKey: device.id ?? device.name ?? 'device',
+        latitude: device.location!.latitude!,
+        longitude: device.location!.longitude!,
+      );
 
   void _handleNewFindMyLocation(dynamic data) {
     if (!_isAlive) return;
@@ -241,7 +274,7 @@ class FindMyController extends GetxController {
   void buildDeviceMarker(FindMyDevice e) {
     markers[e.id ?? randomString(6)] = Marker(
       key: ValueKey('device-${e.id ?? randomString(6)}'),
-      point: LatLng(e.location!.latitude!, e.location!.longitude!),
+      point: markerPointForDevice(e),
       width: 30,
       height: 35,
       child: ClipShadowPath(
@@ -279,7 +312,7 @@ class FindMyController extends GetxController {
     final markerKey = friend.stableId ?? randomString(6);
     markers[markerKey] = Marker(
       key: ValueKey('friend-$markerKey'),
-      point: LatLng(friend.latitude!, friend.longitude!),
+      point: markerPointForFriend(friend),
       width: 35,
       height: 35,
       child: Container(
@@ -350,6 +383,8 @@ class FindMyController extends GetxController {
   @override
   void onClose() {
     _refreshTimer?.cancel();
+    _redactedModeListener?.cancel();
+    _hideContactInfoListener?.cancel();
     locationSub?.cancel();
     mapController.dispose();
     popupController.dispose();

--- a/lib/app/layouts/findmy/widgets/findmy_device_list_tile.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_device_list_tile.dart
@@ -1,10 +1,9 @@
 import 'package:bluebubbles/app/layouts/findmy/findmy_controller.dart';
 import 'package:bluebubbles/app/layouts/findmy/widgets/findmy_raw_data_dialog.dart';
 import 'package:bluebubbles/database/models.dart';
-import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:maps_launcher/maps_launcher.dart';
 
 class FindMyDeviceListTile extends StatelessWidget {
@@ -22,29 +21,34 @@ class FindMyDeviceListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Obx(() {
-      final displayName = SettingsSvc.settings.redactedMode.value
+      final hideContactInfo = shouldRedactFindMyContactInfo();
+
+      final displayName = hideContactInfo
           ? (isItem ? "Item" : "Device")
           : (item.name ?? (isItem ? "Unknown Item" : "Unknown Device"));
 
-      final displayLocation = SettingsSvc.settings.redactedMode.value
+      final displayLocation = hideContactInfo
           ? "Location"
           : (item.address?.label ?? item.address?.mapItemFullAddress ?? "No location found");
+
+      final hasLocation = item.location?.latitude != null && item.location?.longitude != null;
+      final markerPoint = hasLocation ? controller.markerPointForDevice(item) : null;
 
       return ListTile(
         mouseCursor: MouseCursor.defer,
         title: Text(displayName),
         subtitle: Text(displayLocation),
-        onTap: item.location?.latitude != null && item.location?.longitude != null
+        onTap: markerPoint != null
             ? () async {
                 await controller.panelController.close();
                 await controller.completer.future;
                 final marker = controller.markers[item.id];
                 if (marker == null) return;
                 controller.popupController.showPopupsOnlyFor([marker]);
-                controller.mapController.move(LatLng(item.location!.latitude!, item.location!.longitude!), 10);
+                controller.mapController.move(markerPoint, 10);
               }
             : null,
-        trailing: item.location?.latitude != null && item.location?.longitude != null
+        trailing: markerPoint != null
             ? ButtonTheme(
                 minWidth: 1,
                 child: TextButton(
@@ -53,19 +57,21 @@ class FindMyDeviceListTile extends StatelessWidget {
                     backgroundColor: context.theme.colorScheme.primaryContainer,
                   ),
                   onPressed: () async {
-                    await MapsLauncher.launchCoordinates(item.location!.latitude!, item.location!.longitude!);
+                    await MapsLauncher.launchCoordinates(markerPoint.latitude, markerPoint.longitude);
                   },
                   child: const Icon(Icons.directions, size: 20),
                 ),
               )
             : null,
-        onLongPress: () async {
-          showDialog(
-            context: context,
-            builder: (context) => FindMyRawDataDialog(item: item),
-          );
-        },
+        onLongPress: hideContactInfo
+            ? null
+            : () async {
+                showDialog(
+                  context: context,
+                  builder: (context) => FindMyRawDataDialog(item: item),
+                );
+              },
       );
-    }); // end Obx
+    });
   }
 }

--- a/lib/app/layouts/findmy/widgets/findmy_friend_list_tile.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_friend_list_tile.dart
@@ -7,7 +7,6 @@ import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:maps_launcher/maps_launcher.dart';
 
 class FindMyFriendListTile extends StatelessWidget {
@@ -25,18 +24,30 @@ class FindMyFriendListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Obx(() {
-      final displayLocation = SettingsSvc.settings.redactedMode.value
-          ? "Location"
+      final hideContactInfo = shouldRedactFindMyContactInfo();
+      final lastUpdatedSuffix = item.lastUpdated == null || item.status == LocationStatus.live
+          ? ""
+          : "\nLast updated ${buildDate(item.lastUpdated)}";
+      final displayLocation = hideContactInfo
+          ? (withLocation ? "Location$lastUpdatedSuffix" : "Location")
           : withLocation
-              ? ("${item.shortAddress ?? "No location found"}${item.lastUpdated == null || item.status == LocationStatus.live ? "" : "\nLast updated ${buildDate(item.lastUpdated)}"}")
+              ? ("${item.shortAddress ?? "No location found"}$lastUpdatedSuffix")
               : (item.longAddress ?? "No location found");
+
+      final handleState = item.handle != null ? HandleSvc.getOrCreateHandleState(item.handle!) : null;
+      final displayName = hideContactInfo
+          ? (handleState?.fakeName ?? 'Contact')
+          : (item.handle?.displayName ?? item.title ?? "Unknown Friend");
+
+      final hasLocation = item.latitude != null && item.longitude != null;
+      final markerPoint = hasLocation ? controller.markerPointForFriend(item) : null;
 
       return ListTile(
         mouseCursor: MouseCursor.defer,
         leading: ContactAvatarWidget(handle: item.handle),
-        title: Text(item.handle?.displayName ?? item.title ?? "Unknown Friend"),
+        title: Text(displayName),
         subtitle: Text(displayLocation),
-        trailing: withLocation && item.latitude != null && item.longitude != null
+        trailing: withLocation && hasLocation
             ? Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -50,7 +61,8 @@ class FindMyFriendListTile extends StatelessWidget {
                         backgroundColor: context.theme.colorScheme.primaryContainer,
                       ),
                       onPressed: () async {
-                        await MapsLauncher.launchCoordinates(item.latitude!, item.longitude!);
+                        if (markerPoint == null) return;
+                        await MapsLauncher.launchCoordinates(markerPoint.latitude, markerPoint.longitude);
                       },
                       child: const Icon(Icons.directions, size: 20),
                     ),
@@ -58,7 +70,7 @@ class FindMyFriendListTile extends StatelessWidget {
                 ],
               )
             : null,
-        onTap: withLocation
+        onTap: withLocation && markerPoint != null
             ? () async {
                 if (context.isPhone) {
                   await controller.panelController.close();
@@ -67,15 +79,17 @@ class FindMyFriendListTile extends StatelessWidget {
                 final marker = controller.markers[item.stableId];
                 if (marker == null) return;
                 controller.popupController.showPopupsOnlyFor([marker]);
-                controller.mapController.move(LatLng(item.latitude!, item.longitude!), 10);
+                controller.mapController.move(markerPoint, 10);
               }
             : null,
-        onLongPress: () async {
-          showDialog(
-            context: context,
-            builder: (context) => FindMyRawDataDialog(item: item),
-          );
-        },
+        onLongPress: hideContactInfo
+            ? null
+            : () async {
+                showDialog(
+                  context: context,
+                  builder: (context) => FindMyRawDataDialog(item: item),
+                );
+              },
       );
     });
   }

--- a/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
@@ -87,7 +87,9 @@ class FindMyMapWidget extends StatelessWidget {
   }
 
   Widget _buildDevicePopup(BuildContext context, FindMyDevice item) {
-    return Obx(() => Padding(
+    return Obx(() {
+      final hideContactInfo = shouldRedactFindMyContactInfo();
+      return Padding(
           padding: const EdgeInsets.only(bottom: 5.0),
           child: Container(
             decoration: BoxDecoration(
@@ -99,21 +101,29 @@ class FindMyMapWidget extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(SettingsSvc.settings.redactedMode.value ? "Device" : (item.name ?? "Unknown Device"),
+                Text(hideContactInfo ? "Device" : (item.name ?? "Unknown Device"),
                     style: context.theme.textTheme.labelLarge),
                 Text(
-                    SettingsSvc.settings.redactedMode.value
+                    hideContactInfo
                         ? "Location"
                         : (item.address?.label ?? item.address?.mapItemFullAddress ?? "No location found"),
                     style: context.theme.textTheme.bodySmall),
               ],
             ),
           ),
-        ));
+        );
+    });
   }
 
   Widget _buildFriendPopup(BuildContext context, FindMyFriend item) {
-    return Obx(() => Padding(
+    return Obx(() {
+      final hideContactInfo = shouldRedactFindMyContactInfo();
+      final handleState = item.handle != null ? HandleSvc.getOrCreateHandleState(item.handle!) : null;
+      final displayName = hideContactInfo
+          ? (handleState?.fakeName ?? 'Contact')
+          : (item.handle?.displayName ?? item.title ?? "Unknown Friend");
+
+      return Padding(
           padding: const EdgeInsets.only(bottom: 5.0),
           child: Container(
             decoration: BoxDecoration(
@@ -125,9 +135,8 @@ class FindMyMapWidget extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(item.handle?.displayName ?? item.title ?? "Unknown Friend",
-                    style: context.theme.textTheme.labelLarge),
-                Text(SettingsSvc.settings.redactedMode.value ? "Location" : (item.longAddress ?? "No location found"),
+                Text(displayName, style: context.theme.textTheme.labelLarge),
+                Text(hideContactInfo ? "Location" : (item.longAddress ?? "No location found"),
                     style: context.theme.textTheme.bodySmall),
                 if (item.lastUpdated != null && item.status != LocationStatus.live)
                   Text("Last updated ${buildDate(item.lastUpdated)}", style: context.theme.textTheme.bodySmall),
@@ -136,6 +145,7 @@ class FindMyMapWidget extends StatelessWidget {
               ],
             ),
           ),
-        ));
+        );
+    });
   }
 }

--- a/lib/app/state/chat_state.dart
+++ b/lib/app/state/chat_state.dart
@@ -427,6 +427,11 @@ class ChatState {
     chat.lockChatName = updatedChat.lockChatName;
     chat.lockChatIcon = updatedChat.lockChatIcon;
     chat.lastReadMessageGuid = updatedChat.lastReadMessageGuid;
+
+    // Re-apply redaction over the fresh values if redacted mode is active.
+    if (SettingsSvc.settings.redactedMode.value) {
+      redactFields();
+    }
   }
 
   // ========== Internal Lifecycle State Update Methods ==========
@@ -470,6 +475,7 @@ class ChatState {
     if (!SettingsSvc.settings.redactedMode.value) return;
     if (!SettingsSvc.settings.hideContactInfo.value) return;
 
+    updateDisplayNameInternal(_cachedFakeName);
     updateTitleInternal(_cachedFakeName);
     updateChatCreatorSubtitleInternal('');
     // Recompute the message-preview subtitle so contact names and/or message
@@ -481,6 +487,7 @@ class ChatState {
 
   /// Restore contact information to original values from the underlying DB model.
   void unredactContactInfo() {
+    updateDisplayNameInternal(chat.displayName);
     updateTitleInternal(_computeTitle());
     updateChatCreatorSubtitleInternal(_computeCreatorSubtitle());
     // Recompute subtitle — hideMessageContent may still be active even after

--- a/lib/helpers/helpers.dart
+++ b/lib/helpers/helpers.dart
@@ -17,4 +17,5 @@ export 'ui/oauth_helpers.dart';
 export 'ui/reaction_helpers.dart';
 export 'ui/theme_helpers.dart';
 export 'ui/dialog_helpers.dart';
+export 'ui/findmy_helpers.dart';
 export 'ui/ui_helpers.dart';

--- a/lib/helpers/ui/findmy_helpers.dart
+++ b/lib/helpers/ui/findmy_helpers.dart
@@ -1,0 +1,43 @@
+import 'package:bluebubbles/services/backend/settings/settings_service.dart';
+import 'package:latlong2/latlong.dart';
+
+/// Preset decoy centers spread across continents for redacted mode
+const _decoyCenters = <({double lat, double lng})>[
+  (lat: 40.7829, lng: -73.9654), // New York
+  (lat: 41.8781, lng: -87.6298), // Chicago
+  (lat: 64.1466, lng: -21.9426), // Reykjavik
+  (lat: -33.8688, lng: 151.2093), // Sydney
+  (lat: 19.4326, lng: -99.1332), // Mexico City
+  (lat: 35.6762, lng: 139.6503), // Tokyo
+  (lat: -23.5505, lng: -46.6333), // São Paulo
+  (lat: 28.6139, lng: 77.2090), // New Delhi
+  (lat: 52.3676, lng: 4.9041), // Amsterdam
+  (lat: -1.2921, lng: 36.8219), // Nairobi
+];
+
+/// Check for whether FindMy names and coordinates should be redacted or not
+bool shouldRedactFindMyContactInfo() =>
+    SettingsSvc.settings.redactedMode.value && SettingsSvc.settings.hideContactInfo.value;
+
+int _stableHash(String input) => input.codeUnits.fold(0, (h, c) => (h * 31 + c) & 0x7fffffff);
+
+/// Stable pseudo-random map point for [key]. Same key always maps to the same decoy location.
+LatLng redactedFindMyPoint(String key) {
+  final h1 = _stableHash(key);
+  final h2 = _stableHash('$key-jitter');
+  final center = _decoyCenters[h1 % _decoyCenters.length];
+  // ±0.05° scatter (~5 km) so markers sharing a preset don't stack exactly.
+  final latJitter = ((h2 % 1000) / 1000.0 - 0.5) * 0.1;
+  final lngJitter = (((h2 ~/ 1000) % 1000) / 1000.0 - 0.5) * 0.1;
+  return LatLng(center.lat + latJitter, center.lng + lngJitter);
+}
+
+/// Returns [redactedFindMyPoint] when contact info is hidden, otherwise the real coordinates.
+LatLng resolveFindMyMarkerPoint({
+  required String stableKey,
+  required double latitude,
+  required double longitude,
+}) {
+  if (shouldRedactFindMyContactInfo()) return redactedFindMyPoint(stableKey);
+  return LatLng(latitude, longitude);
+}

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -133,7 +133,9 @@ class NotificationsService {
     final isGroup = chat.isGroup;
     final guid = chat.guid;
     final contactName = message.handleRelation.target?.displayName ?? "Unknown";
-    final title = isGroup ? chat.getTitle() : contactName;
+    final title = isGroup
+        ? (ChatsSvc.getChatState(chat.guid)?.title.value ?? chat.getTitle())
+        : contactName;
     final text = hideContent ? "iMessage" : message.getNotificationText();
     final isReaction = !isNullOrEmpty(message.associatedMessageGuid);
 


### PR DESCRIPTION
This PR addresses two areas where user data slips through redacted mode:

### Custom Chat Display Names
If the user set a custom display name for a chat, redacted mode missed it.
- `redactContactInfo()` did not redact the ``displayName`` properly, only ``title``.
- Some UI used `ChatState.getTitle()`, which returns the raw unredacted title; `ChatState.title` is the correct place to access redacted titles.

`redactContactInfo()` and `unredactContactInfo()` now handle ``displayName``. Relevant places (search, notifications, etc.) were updated to use the redacted titles from `ChatState.title` 

### FindMy
FindMy was leaking Friends names, real map coordinates, and had some inconsistent redacting applied to location statuses.

- Real friend names in the bottomsheet list and popups are now redacted
- Added **findmy_helpers.dart** to handle redacting real coordinates.
It uses a list of preset location coordinates as bases and then applies a hashed jitter. This keeps location markers for the same ID stable and fully anonymous across the app.
- Other information ("Last updated ..." and "Live/Shallow Location" statuses) were redacted in some places but not others.
They are now consistently NOT redacted-- I felt this gives good debug information while not being overly heavy handed with redactions.

FindMy redaction uses the existing "Hide Contact Info" toggle under redacted mode, so no new settings are added.