### PR TITLE
fix: self-heal images left undecodable by an interrupted download

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/attachment/image_viewer.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/image_viewer.dart
@@ -37,6 +37,61 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
   PlatformFile get file => widget.file;
   ConversationViewController? get controller => widget.controller;
 
+  // One-shot guard for auto-healing an undecodable image. A process crash
+  // mid-download can leave a truncated file that was never marked downloaded
+  // (isDownloaded != true); existsOnDisk-based gating then trusts the poisoned
+  // bytes and the image fails to decode forever. When that happens we
+  // re-download once. A file that WAS fully downloaded but still won't decode
+  // is left for a manual retry (no auto-loop).
+  bool _autoHealedDecode = false;
+
+  // Re-downloads the attachment and, on completion, evicts Flutter's cached
+  // (failed) decode for its path so the fresh bytes are re-read in place.
+  // Without the eviction the stale cache entry keeps rendering the error until
+  // the chat is re-entered. Setting the guard first prevents the auto-heal path
+  // from re-firing while the re-download (which flips isDownloaded false) runs.
+  void _healAttachment() {
+    if (attachment.guid?.isEmpty ?? true) return;
+    _autoHealedDecode = true;
+    AttachmentsSvc.redownloadAttachment(
+      attachment,
+      onComplete: (_) async {
+        if (!mounted) return;
+        try {
+          await FileImage(File(attachment.path)).evict();
+          await FileImage(File(attachment.convertedPath)).evict();
+        } catch (_) {}
+        if (mounted) setState(() {});
+      },
+    );
+  }
+
+  Widget _buildImageDecodeError(BuildContext context) {
+    if (!_autoHealedDecode && attachment.isDownloaded != true && (attachment.guid?.isNotEmpty ?? false)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _healAttachment());
+    }
+    return Center(
+      heightFactor: 1,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 5.0),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(
+              child: Text("Failed to display image", style: context.theme.textTheme.bodyLarge),
+            ),
+            const SizedBox(width: 4.0),
+            IconButton(
+              tooltip: "Retry download",
+              icon: Icon(CupertinoIcons.arrow_clockwise, color: context.theme.colorScheme.primary),
+              onPressed: _healAttachment,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   // Implement required getter for LivePhotoMixin
   @override
   Attachment get livePhotoAttachment => attachment;
@@ -154,46 +209,8 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
               }
               return child;
             },
-            errorBuilder: (context, object, stacktrace) => Center(
-                  heightFactor: 1,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 2.0, vertical: 5.0),
-                    child: Row(children: [
-                      Text("Failed to display image", style: context.theme.textTheme.bodyLarge),
-                      const SizedBox(width: 2.0),
-                      IconButton(
-                          onPressed: () {
-                            showBBDialog(
-                              context: context,
-                              title: "Image Stacktrace",
-                              content: SizedBox(
-                                width: NavigationSvc.width(context) * 3 / 5,
-                                height: context.height * 1 / 4,
-                                child: Container(
-                                  padding: const EdgeInsets.all(10.0),
-                                  decoration: BoxDecoration(
-                                      color: context.theme.colorScheme.surface,
-                                      borderRadius: const BorderRadius.all(Radius.circular(10))),
-                                  child: SingleChildScrollView(
-                                    child: SelectableText(
-                                      stacktrace.toString(),
-                                      style: context.theme.textTheme.bodyLarge,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              actions: [
-                                BBDialogAction(
-                                  text: "Close",
-                                  onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-                                ),
-                              ],
-                            );
-                          },
-                          icon: const Icon(CupertinoIcons.info_circle))
-                    ]),
-                  ),
-                ));
+            errorBuilder: (context, object, stacktrace) =>
+                _buildImageDecodeError(context));
       }
     } else {
       // Calculate the proper height/width for the attachment to use only for the
@@ -276,11 +293,8 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
               );
             }
 
-            // Conversion failed or not needed
-            return Center(
-              heightFactor: 1,
-              child: Text("Failed to display image", style: context.theme.textTheme.bodyLarge),
-            );
+            // Conversion failed or not needed — heal a crash-truncated file.
+            return _buildImageDecodeError(context);
           },
         ),
       );

--- a/lib/services/network/downloads_service.dart
+++ b/lib/services/network/downloads_service.dart
@@ -289,6 +289,24 @@ class AttachmentDownloadController extends GetxController {
       bytes: kIsWeb ? bytes : null,
     );
 
+    // Integrity guard: a completed transfer that produced 0 bytes is a failed
+    // download. Without this it gets marked downloaded and trusted forever
+    // (existsOnDisk gating), showing "Failed to display image" permanently.
+    // A partial/truncated file that still fails to decode is healed at display
+    // time by ImageViewer's auto re-download. (No size==totalBytes check here:
+    // GIFs are re-encoded and `original=false` can return a converted file, so
+    // size legitimately differs from totalBytes.)
+    if (!kIsWeb && (file.value?.size ?? 0) == 0) {
+      Logger.warn("Attachment ${attachment.guid} downloaded 0 bytes — not marking downloaded, will retry",
+          tag: "Downloads");
+      try {
+        await File(attachment.path).delete();
+      } catch (_) {}
+      state.value = AttachmentDownloadState.error;
+      AttachmentDownloader._removeFromQueue(this);
+      return;
+    }
+
     // Mark attachment as downloaded and save to database
     attachment.isDownloaded = true;
     await attachment.saveAsync(attachment.message.target);


### PR DESCRIPTION
### Problem

If the app is killed mid-download (e.g. an OOM decoding a large incoming image during boot), the file on disk is left truncated and was never marked `isDownloaded`. The display gate trusts any on-disk file, so the poisoned bytes hit the decoder, the image fails, and it shows "Failed to display image" **permanently** — auto re-download never fires because a file already exists. (Confirmed local-only: the same image rendered fine on another client that downloaded it cleanly.) A second path to the same state: a transfer that completes with 0 bytes gets marked downloaded and trusted forever.

### Fix

- `image_viewer.dart`: treat decode failure as the integrity signal. On the error builder, if the attachment isn't marked `isDownloaded`, re-download once (one-shot guard prevents a loop), then evict Flutter's cached failed `FileImage` decode so the fresh bytes render in place without re-entering the chat. A file that *was* fully downloaded but still won't decode keeps a manual retry button.
- `downloads_service.dart`: don't mark a 0-byte transfer as downloaded — delete it and set the error state so it retries.

Deliberately **not** a `size == totalBytes` check: GIFs are re-encoded client-side and `original=false` can return a converted file, so size legitimately differs from `totalBytes`.

### Note

This replaces the previous error-state "info" button (which opened a dialog showing the decode stacktrace) with a "retry download" button. We can keep the stacktrace affordance alongside it if you'd prefer.

### Testing

Validated over a multi-day testing period (desktop + Android): a poisoned image that previously showed the error forever now re-downloads and renders on the next frame.
