### PR TITLE
fix: eliminate the background-isolate wedge failure class

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -312,9 +312,31 @@ class Database {
     }
   }
 
-  /// Wrapper for store.runInTransaction
+  /// Wrapper for store.runInTransaction.
+  ///
+  /// Write transactions are timed: ObjectBox allows one writer per store
+  /// process-wide and blocks the rest natively, so a slow holder (or a
+  /// starved waiter) freezes every other writer in the app. Logging the
+  /// call site of anything that spends >5s in here is the only way to name
+  /// the holder when a store-wide write wedge occurs.
   static R runInTransaction<R>(TxMode mode, R Function() fn) {
-    return store.runInTransaction(mode, fn);
+    if (mode != TxMode.write) {
+      return store.runInTransaction(mode, fn);
+    }
+    final sw = Stopwatch()..start();
+    try {
+      return store.runInTransaction(mode, fn);
+    } finally {
+      sw.stop();
+      if (sw.elapsed > const Duration(seconds: 5)) {
+        Logger.warn(
+          'Write transaction spent ${sw.elapsedMilliseconds}ms (wait + hold) — '
+          'possible write-lock contention. Call site:',
+          trace: StackTrace.current,
+          tag: 'DbTx',
+        );
+      }
+    }
   }
 
   static reset() {

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -64,25 +64,38 @@ class StartupTasks {
     return interopReady;
   }
 
-  static Future<void> _initCoreServices({required bool headless}) async {
+  /// [isolateHandoff]/[onStage]: background isolates receive platform-channel
+  /// values (paths, package info, a prefs snapshot) from the main engine at
+  /// spawn instead of calling channel plugins themselves — those calls were
+  /// observed to hang around pause transitions and leave the isolate
+  /// stillborn at init (2026-07-05/06 wedges). [onStage] reports init
+  /// progress back to the isolate manager so a stalled init names its stage.
+  static Future<void> _initCoreServices({
+    required bool headless,
+    Map<String, dynamic>? isolateHandoff,
+    void Function(String)? onStage,
+  }) async {
+    onStage?.call('core:filesystem');
     debugPrint("Registering FilesystemService...");
     GetIt.I.registerSingletonAsync<FilesystemService>(() async {
       final fsService = FilesystemService();
-      await fsService.init(headless: headless);
+      await fsService.init(headless: headless, handoff: isolateHandoff?['filesystem'] as Map<String, dynamic>?);
       return fsService;
     });
     await GetIt.I.isReady<FilesystemService>();
     debugPrint("FilesystemService ready");
 
+    onStage?.call('core:prefs');
     debugPrint("Registering SharedPreferencesService...");
     GetIt.I.registerSingletonAsync<SharedPreferencesService>(() async {
       final prefsService = SharedPreferencesService();
-      await prefsService.init();
+      await prefsService.init(snapshot: (isolateHandoff?['prefs'] as Map?)?.cast<String, Object>());
       return prefsService;
     });
     await GetIt.I.isReady<SharedPreferencesService>();
     debugPrint("SharedPreferencesService ready");
 
+    onStage?.call('core:settings');
     debugPrint("Registering SettingsService...");
     GetIt.I.registerSingletonAsync<SettingsService>(() async {
       final settingsService = SettingsService();
@@ -92,6 +105,7 @@ class StartupTasks {
     await GetIt.I.isReady<SettingsService>();
     debugPrint("SettingsService ready");
 
+    onStage?.call('core:logger');
     debugPrint("Registering BaseLogger...");
     GetIt.I.registerSingletonAsync<BaseLogger>(() async {
       final logService = BaseLogger();
@@ -253,9 +267,14 @@ class StartupTasks {
     unawaited(NetworkTasks.detectLocalhost().then((_) => SyncSvc.startIncrementalSync()));
   }
 
-  static Future<void> initGlobalIsolateServices(RootIsolateToken? rootIsolateToken) async {
+  static Future<void> initGlobalIsolateServices(
+    RootIsolateToken? rootIsolateToken, [
+    Map<String, dynamic>? handoff,
+    void Function(String)? onStage,
+  ]) async {
     debugPrint("Initializing isolate services...");
 
+    onStage?.call('messenger');
     BinaryMessenger? messenger;
     if (rootIsolateToken != null) {
       debugPrint("Initializing Background Isolate Binary Messenger");
@@ -263,30 +282,40 @@ class StartupTasks {
       messenger = BackgroundIsolateBinaryMessenger.instance;
     }
 
-    await _initCoreServices(headless: true);
+    await _initCoreServices(headless: true, isolateHandoff: handoff, onStage: onStage);
 
+    onStage?.call('interop-preregister');
     final globalInteropReady = _preRegisterInteropServices(
       headless: true,
       isBubble: false,
       binaryMessenger: messenger,
     );
 
+    onStage?.call('db');
     Logger.info("Initializing database...");
     await Database.init();
     Logger.info("Database initialized");
     globalInteropReady.complete();
 
+    onStage?.call('contacts-chats');
     await _initContactHandleChats(headless: true);
+    onStage?.call('http');
     await _initHttpService();
+    onStage?.call('interop-wait');
     await _waitForInterop(methodChannel: true);
 
     Logger.info("Global isolate services initialization complete");
   }
 
   /// Initialize only the services required for sync operations (lighter than full global isolate)
-  static Future<void> initSyncIsolateServices(RootIsolateToken? rootIsolateToken) async {
+  static Future<void> initSyncIsolateServices(
+    RootIsolateToken? rootIsolateToken, [
+    Map<String, dynamic>? handoff,
+    void Function(String)? onStage,
+  ]) async {
     debugPrint("Initializing sync isolate services...");
 
+    onStage?.call('messenger');
     BinaryMessenger? messenger;
     if (rootIsolateToken != null) {
       debugPrint("Initializing Background Isolate Binary Messenger");
@@ -294,20 +323,24 @@ class StartupTasks {
       messenger = BackgroundIsolateBinaryMessenger.instance;
     }
 
-    await _initCoreServices(headless: true);
+    await _initCoreServices(headless: true, isolateHandoff: handoff, onStage: onStage);
 
+    onStage?.call('interop-preregister');
     final syncInteropReady = _preRegisterInteropServices(
       headless: true,
       isBubble: false,
       binaryMessenger: messenger,
     );
 
+    onStage?.call('db');
     Logger.info("Initializing database...");
     await Database.init();
     Logger.info("Database initialized");
     syncInteropReady.complete();
 
+    onStage?.call('contacts-chats');
     await _initContactHandleChats(headless: true);
+    onStage?.call('http');
     await _initHttpService();
     Logger.info("HttpService ready");
 

--- a/lib/services/backend/filesystem/filesystem_service.dart
+++ b/lib/services/backend/filesystem/filesystem_service.dart
@@ -127,7 +127,25 @@ class FilesystemService {
     return path;
   }
 
-  Future<void> init({bool headless = false}) async {
+  /// [handoff] is the background-isolate path: path_provider and package_info
+  /// are platform-channel plugins, and channel calls from inside an isolate
+  /// were observed to hang around pause transitions, leaving the isolate
+  /// stillborn at init (2026-07-05/06 wedges). The main engine hands the
+  /// already-resolved values over at isolate spawn instead.
+  Future<void> init({bool headless = false, Map<String, dynamic>? handoff}) async {
+    if (handoff != null) {
+      appDocDir = Directory(handoff['appDocPath'] as String);
+      _sysTemp = Directory(handoff['sysTempPath'] as String);
+      final pi = handoff['packageInfo'] as Map<String, dynamic>;
+      packageInfo = PackageInfo(
+        appName: pi['appName'] as String,
+        packageName: pi['packageName'] as String,
+        version: pi['version'] as String,
+        buildNumber: pi['buildNumber'] as String,
+        buildSignature: pi['buildSignature'] as String? ?? '',
+      );
+      return;
+    }
     if (!kIsWeb) {
       //ignore: unnecessary_cast, we need this as a workaround
       appDocDir = (kIsDesktop ? await getApplicationSupportDirectory() : await getApplicationDocumentsDirectory());
@@ -155,6 +173,20 @@ class FilesystemService {
       androidInfo = await DeviceInfoPlugin().androidInfo;
     }
   }
+
+  /// Serializable snapshot of the platform-channel-derived values, for the
+  /// isolate spawn handoff (see [init]'s `handoff` parameter).
+  Map<String, dynamic> buildHandoff() => {
+        'appDocPath': appDocDir.path,
+        'sysTempPath': _sysTemp.path,
+        'packageInfo': {
+          'appName': packageInfo.appName,
+          'packageName': packageInfo.packageName,
+          'version': packageInfo.version,
+          'buildNumber': packageInfo.buildNumber,
+          'buildSignature': packageInfo.buildSignature,
+        },
+      };
 
   void checkFont() async {
     if (!kIsWeb) {

--- a/lib/services/backend/interfaces/chat_interface.dart
+++ b/lib/services/backend/interfaces/chat_interface.dart
@@ -1,6 +1,7 @@
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/env.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/backend/actions/chat_actions.dart';
 import 'package:bluebubbles/models/models.dart' show MessageSaveResult;
 import 'package:bluebubbles/services/services.dart';
@@ -14,16 +15,13 @@ class ChatInterface {
     required int chatId,
     required String chatGuid,
   }) async {
-    final data = {
-      'chatId': chatId,
-      'chatGuid': chatGuid,
-    };
-
-    if (isIsolate) {
-      return await ChatActions.clearNotificationForChat(data);
-    } else if (!LifecycleSvc.isBubble) {
-      return await GetIt.I<GlobalIsolate>().send<void>(IsolateRequestType.clearNotificationForChat, input: data);
-    }
+    // This is purely a method-channel call to Kotlin (no DB work) — round-
+    // tripping it through the GlobalIsolate only added a platform-channel
+    // call from inside the isolate, the exact class of call observed to hang
+    // around pause transitions (2026-07-06 wedge). Invoke it directly.
+    if (kIsDesktop || kIsWeb) return;
+    if (!isIsolate && LifecycleSvc.isBubble) return;
+    await MethodChannelSvc.actions.deleteNotification(notificationId: chatId, tag: 'new_message');
   }
 
   static Future<void> markAllChatsRead({

--- a/lib/services/backend/interfaces/prefs_interface.dart
+++ b/lib/services/backend/interfaces/prefs_interface.dart
@@ -5,31 +5,26 @@ import 'package:bluebubbles/services/isolates/global_isolate.dart';
 import 'package:bluebubbles/services/backend/settings/settings_service.dart';
 
 class PrefsInterface {
+  // Reply-state persistence is SharedPreferences, not ObjectBox — there is no
+  // reason to marshal it through the GlobalIsolate, and doing so is hazardous:
+  // prefs writes are platform-channel write-throughs, and channel calls made
+  // from inside the isolate were observed to hang around pause transitions
+  // (2026-07-06 wedge: saveReplyToMessageState froze a healthy isolate and
+  // every request behind it). Always run these on the calling engine.
   static Future<void> saveReplyToMessageState(String chatGuid, String? messageGuid, int? messagePart) async {
     final data = {
       'chatGuid': chatGuid,
       'messageGuid': messageGuid,
       'messagePart': messagePart,
     };
-
-    if (isIsolate) {
-      return await PrefsActions.saveReplyToMessageState(data);
-    } else {
-      return await GetIt.I<GlobalIsolate>().send<void>(IsolateRequestType.saveReplyToMessageState, input: data);
-    }
+    return await PrefsActions.saveReplyToMessageState(data);
   }
 
   static Future<Map<String, dynamic>?> loadReplyToMessageState(String chatGuid) async {
     final data = {
       'chatGuid': chatGuid,
     };
-
-    if (isIsolate) {
-      return PrefsActions.loadReplyToMessageState(data);
-    } else {
-      return await GetIt.I<GlobalIsolate>()
-          .send<Map<String, dynamic>?>(IsolateRequestType.loadReplyToMessageState, input: data);
-    }
+    return PrefsActions.loadReplyToMessageState(data);
   }
 
   static Future<void> syncAllSettings({Map<String, dynamic>? settings}) async {

--- a/lib/services/backend/notifications/notifications_service.dart
+++ b/lib/services/backend/notifications/notifications_service.dart
@@ -642,6 +642,49 @@ class NotificationsService {
     }
   }
 
+  /// Shown when the isolate watchdog detects a store-wide database write
+  /// wedge (two watchdog fires in quick succession): isolate restarts can't
+  /// release a write lock held elsewhere in the process — only a full app
+  /// restart can. Without this, the app looks alive but silently saves
+  /// nothing until the user figures that out on their own.
+  Future<void> createDatabaseStuckNotification() async {
+    const title = "BlueBubbles needs a restart";
+    const text =
+        "The message database hit a write deadlock — new messages can't be saved until the app is fully restarted.";
+    const notifId = -4;
+
+    if (kIsDesktop) {
+      final toast = LocalNotification(
+        type: LocalNotificationType.text02,
+        title: title,
+        body: text,
+      );
+      toast.onClick = () async {
+        await windowManager.show();
+      };
+      await toast.show();
+    } else {
+      final notifs = await flnp.getActiveNotifications();
+      if (notifs.firstWhereOrNull((n) => n.id == notifId) != null) return;
+
+      await flnp.show(
+        id: notifId,
+        title: title,
+        body: text,
+        notificationDetails: NotificationDetails(
+          android: AndroidNotificationDetails(ERROR_CHANNEL, 'Errors',
+              channelDescription: 'Displays message send failures, connection failures, and more',
+              priority: Priority.max,
+              importance: Importance.max,
+              color: HexColor("4990de"),
+              ongoing: false,
+              onlyAlertOnce: true,
+              styleInformation: const BigTextStyleInformation('')),
+        ),
+      );
+    }
+  }
+
   Future<void> createFailedToSend(Chat chat, {bool scheduled = false}) async {
     final title = 'Failed to send${scheduled ? " scheduled" : ""} message';
     final subtitle = scheduled ? 'Tap to open scheduled messages list' : 'Tap to see more details or retry';

--- a/lib/services/backend/settings/shared_preferences_service.dart
+++ b/lib/services/backend/settings/shared_preferences_service.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences/util/legacy_to_async_migration_util.dart';
 import 'package:shared_preferences_android/shared_preferences_android.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 import 'package:universal_io/io.dart';
 import 'package:bluebubbles/services/backend/settings/actions/shared_preferences_admin_actions.dart';
 import 'package:bluebubbles/services/backend/settings/actions/shared_preferences_database_actions.dart';
@@ -51,20 +53,31 @@ class SharedPreferencesService {
         )
       : const SharedPreferencesOptions();
 
-  Future<void> init({bool headless = false}) async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(
-      legacySharedPreferencesInstance: prefs,
-      sharedPreferencesAsyncOptions: _options,
-      migrationCompletedKey: 'migrationCompleted',
-    );
+  /// [snapshot] is the isolate path: background isolates must NOT touch the
+  /// platform-channel prefs backends (getInstance / the legacy→async migration /
+  /// the DataStore copy) — those calls were observed to hang around pause
+  /// transitions, leaving the isolate stillborn at init with every queued
+  /// request frozen behind it. The main engine hands a full key/value snapshot
+  /// to the isolate at spawn and the whole prefs stack runs in-memory there.
+  /// Isolate-side writes are intentionally non-persistent.
+  Future<void> init({bool headless = false, Map<String, Object>? snapshot}) async {
+    if (snapshot != null) {
+      SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.withData(snapshot);
+    } else {
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      await migrateLegacySharedPreferencesToSharedPreferencesAsyncIfNecessary(
+        legacySharedPreferencesInstance: prefs,
+        sharedPreferencesAsyncOptions: _options,
+        migrationCompletedKey: 'migrationCompleted',
+      );
 
-    // Values written while the async API was DataStore-backed exist only in
-    // DataStore and would vanish when switching back to the XML store. Copy
-    // them over once. Runs AFTER the legacy migration above so the (newer)
-    // DataStore values win over any stale legacy values it re-imported.
-    if (!kIsWeb && Platform.isAndroid) {
-      await _migrateDataStoreToSharedPreferences();
+      // Values written while the async API was DataStore-backed exist only in
+      // DataStore and would vanish when switching back to the XML store. Copy
+      // them over once. Runs AFTER the legacy migration above so the (newer)
+      // DataStore values win over any stale legacy values it re-imported.
+      if (!kIsWeb && Platform.isAndroid) {
+        await _migrateDataStoreToSharedPreferences();
+      }
     }
 
     i = await SharedPreferencesWithCache.create(

--- a/lib/services/isolates/global_isolate.dart
+++ b/lib/services/isolates/global_isolate.dart
@@ -4,8 +4,12 @@ import 'dart:ui';
 
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:bluebubbles/helpers/backend/startup_tasks.dart';
+import 'package:bluebubbles/services/backend/filesystem/filesystem_service.dart';
+import 'package:bluebubbles/services/backend/notifications/notifications_service.dart';
+import 'package:bluebubbles/services/backend/settings/shared_preferences_service.dart';
 import 'package:bluebubbles/services/isolates/isolate_actions.dart';
 import 'package:bluebubbles/services/isolates/isolate_event.dart';
+import 'package:get_it/get_it.dart';
 import 'package:uuid/uuid.dart';
 
 /// A base isolate manager for handling background tasks
@@ -32,7 +36,23 @@ class GlobalIsolate {
   /// Timer for tracking isolate inactivity
   Timer? _idleTimer;
 
-  /// Timeout duration for individual task requests
+  /// Last time the request watchdog fired. Two fires close together mean the
+  /// wedge is store-wide (a leaked/blocked write lock outside this isolate) —
+  /// restarting isolates won't clear it, only a full app restart will.
+  DateTime? _lastWatchdogFire;
+
+  /// Latest init-stage report from the spawned isolate. 'done' = init
+  /// completed and the request listener is live; anything else at watchdog
+  /// time means the generation was stillborn at that init stage.
+  String? _lastInitStage;
+
+  /// Watchdog timeout for individual task requests. When a request exceeds
+  /// this, the isolate is presumed wedged (alive but stuck — e.g. a blocked
+  /// DB transaction): the request errors, all other pending requests are
+  /// failed, and the isolate is killed so the next operation restarts it
+  /// fresh. Without this, one hung action silently freezes every
+  /// isolate-dependent feature (sends, message loads) until the process dies.
+  /// [Duration.zero] disables the watchdog.
   final Duration taskTimeout;
 
   /// Timeout duration for isolate startup
@@ -64,7 +84,7 @@ class GlobalIsolate {
   String get isolateDebugName => 'GlobalIsolate';
 
   GlobalIsolate({
-    this.taskTimeout = Duration.zero,
+    this.taskTimeout = const Duration(minutes: 2),
     this.startupTimeout = const Duration(seconds: 30),
     this.idleTimeout = const Duration(minutes: 5),
   });
@@ -140,9 +160,19 @@ class GlobalIsolate {
       // action map via the defaultActionMap parameter inside the spawned isolate,
       // which avoids any cross-isolate serialisation of function closures/typedefs.
       final rootToken = RootIsolateToken.instance;
+      // Hand the isolate everything it would otherwise fetch via platform
+      // channels — see buildIsolateHandoff(). Best-effort: a null handoff
+      // falls back to the old (channel-calling) init path.
+      Map<String, dynamic>? handoff;
+      try {
+        handoff = buildIsolateHandoff();
+      } catch (e) {
+        Logger.warn('$isolateDebugName: failed to build isolate handoff, falling back to platform channels: $e');
+      }
+      _lastInitStage = 'spawning';
       _isolate = await Isolate.spawn(
         getIsolateEntryPoint as void Function(List<dynamic>),
-        [_receivePort!.sendPort, rootToken],
+        [_receivePort!.sendPort, rootToken, handoff],
         debugName: isolateDebugName,
         onExit: _exitPort!.sendPort,
         onError: _errorPort!.sendPort,
@@ -209,7 +239,17 @@ class GlobalIsolate {
 
     // Unregister the named port when stopping
     IsolateNameServer.removePortNameMapping(isolatePortName);
-    _isolate?.kill(priority: Isolate.immediate);
+    // Ask the isolate to exit cooperatively instead of Isolate.kill():
+    // kill() cannot interrupt a thread blocked in a native call (e.g. an
+    // ObjectBox write-lock wait). Killing a blocked WAITER leaves a zombie
+    // that can later ACQUIRE the write lock and then die mid-transaction —
+    // permanently leaking the store's process-wide write mutex. The shutdown
+    // message is processed whenever the isolate unblocks; until then it is
+    // simply abandoned (ports closed, references dropped) and a fresh
+    // isolate takes over on the next operation.
+    try {
+      _sendPort?.send({'__shutdown__': true});
+    } catch (_) {}
     _receivePort?.close();
     _receivePort = null;
     _exitPort?.close();
@@ -348,21 +388,56 @@ class GlobalIsolate {
     final requestId = const Uuid().v4();
     final completer = Completer<T>();
 
-    // Set up timeout if not disabled (zero duration means no timeout)
+    // Watchdog: if not disabled (zero duration means no watchdog), a request
+    // exceeding the timeout marks the whole isolate as wedged, not just the
+    // one request — an alive-but-stuck isolate otherwise hangs every caller
+    // forever (there is no other detection: _verifyIsolateAlive only checks
+    // handles, and the idle timer refuses to fire while requests are pending).
     Timer? timer;
-    if ((customTimeout ?? taskTimeout) != Duration.zero) {
-      timer = Timer(customTimeout ?? taskTimeout, () {
+    final effectiveTimeout = customTimeout ?? taskTimeout;
+    if (effectiveTimeout != Duration.zero) {
+      timer = Timer(effectiveTimeout, () {
         if (_pendingRequests.containsKey(requestId)) {
           final requestInfo = _pendingRequests.remove(requestId)!;
+          final nowTs = DateTime.now();
+          final stuckTypes = _pendingRequests.values
+              .map((r) => '${r.type.name}(+${nowTs.difference(r.issuedAt).inSeconds}s)')
+              .join(', ');
+          Logger.error(
+            '$isolateDebugName watchdog: [${type.name}] exceeded ${effectiveTimeout.inSeconds}s — '
+            'isolate presumed wedged (init stage: ${_lastInitStage ?? 'unknown'}). '
+            'Restarting it and failing ${_pendingRequests.length} other pending '
+            'request(s)${stuckTypes.isEmpty ? '' : ' [$stuckTypes]'}. '
+            'If this repeats back-to-back, the blockage is outside this isolate.',
+          );
           if (!requestInfo.completer.isCompleted) {
-            requestInfo.completer.completeError('Request timeout after ${customTimeout ?? taskTimeout}');
+            requestInfo.completer.completeError(
+              '$isolateDebugName watchdog: ${type.name} timed out after ${effectiveTimeout.inSeconds}s '
+              '(isolate wedged; restarted)',
+            );
           }
-          _maybeStopAfterDrain();
+          // Two fires close together = the fresh isolate wedged too, so the
+          // blockage is store-wide (write lock held outside this isolate).
+          // Isolate restarts cannot clear that — tell the user to restart.
+          final now = DateTime.now();
+          final isRepeat = _lastWatchdogFire != null && now.difference(_lastWatchdogFire!) < const Duration(minutes: 10);
+          _lastWatchdogFire = now;
+          if (isRepeat) {
+            Logger.error(
+              '$isolateDebugName watchdog fired twice within 10 minutes — store-wide write wedge; '
+              'only a full app restart releases the write lock.',
+            );
+            unawaited(_notifyDatabaseStuck());
+          }
+          // Abandon the wedged isolate. stop() error-completes the remaining
+          // pending requests, asks the isolate to exit cooperatively (no
+          // kill — see stop()), and the next operation spawns a fresh one.
+          stop();
         }
       });
     }
 
-    _pendingRequests[requestId] = _RequestInfo(completer: completer, timer: timer, type: type);
+    _pendingRequests[requestId] = _RequestInfo(completer: completer, timer: timer, type: type, issuedAt: DateTime.now());
 
     // Reset idle shutdown when new work is queued.
     _scheduleIdleShutdown();
@@ -397,6 +472,18 @@ class GlobalIsolate {
     }
 
     if (message is Map<String, dynamic>) {
+      // Init-stage progress reports, logged on the main engine so they are
+      // flush-safe even if the isolate itself never gets to write its log.
+      // Debug level keeps baseline logs quiet; the watchdog's ERROR line
+      // carries _lastInitStage regardless, so a wedge still names its stage
+      // at any log level.
+      final initStage = message['__init_stage__'];
+      if (initStage is String) {
+        _lastInitStage = initStage;
+        Logger.debug('$isolateDebugName init stage: $initStage');
+        return;
+      }
+
       // Check if this is an event message
       if (message.containsKey('event')) {
         try {
@@ -453,6 +540,38 @@ class GlobalIsolate {
           Logger.error('Error in event listener for ${eventMessage.type.name}: $e', trace: stack);
         }
       }
+    }
+  }
+
+  /// Values the isolate needs that would otherwise require platform-channel
+  /// plugin calls from inside the isolate (path_provider, package_info,
+  /// shared_preferences). Channel calls from isolates were observed to hang
+  /// around pause transitions — stillborn init generations and frozen
+  /// prefs write-throughs (2026-07-05/06 wedges) — so the main engine
+  /// resolves everything up front and hands it over at spawn.
+  Map<String, dynamic> buildIsolateHandoff() {
+    // ignore: deprecated_member_use_from_same_package
+    final prefs = GetIt.I<SharedPreferencesService>().i;
+    final prefsSnapshot = <String, Object>{};
+    for (final key in prefs.keys) {
+      final value = prefs.get(key);
+      if (value != null) prefsSnapshot[key] = value;
+    }
+    return {
+      'filesystem': GetIt.I<FilesystemService>().buildHandoff(),
+      'prefs': prefsSnapshot,
+    };
+  }
+
+  /// Surfaces a "restart the app" notification when the watchdog detects a
+  /// store-wide write wedge. Best-effort — never throws.
+  Future<void> _notifyDatabaseStuck() async {
+    try {
+      if (GetIt.I.isRegistered<NotificationsService>()) {
+        await GetIt.I<NotificationsService>().createDatabaseStuckNotification();
+      }
+    } catch (e) {
+      Logger.warn('Failed to show database-stuck notification: $e');
     }
   }
 
@@ -559,11 +678,12 @@ class GlobalIsolate {
   /// Accepts a custom initialization function to allow specialized isolates to load different services
   static Future<void> sharedIsolateEntryPoint(
     List<dynamic> args,
-    Future<void> Function(RootIsolateToken?) initServices,
+    Future<void> Function(RootIsolateToken?, Map<String, dynamic>?, void Function(String)?) initServices,
     Map<IsolateRequestType, IsolateAction> defaultActionMap,
   ) async {
     final SendPort sendPort = args[0];
     final RootIsolateToken? rootIsolateToken = args.length > 1 ? args[1] : null;
+    final Map<String, dynamic>? handoff = args.length > 2 ? (args[2] as Map?)?.cast<String, dynamic>() : null;
     // Use the action map supplied directly by the entry point (defaultActionMap).
     // This intentionally ignores args[2] — the action map is never passed across the
     // isolate boundary because serialising generic Map<K, typedef> values is fragile
@@ -582,9 +702,31 @@ class GlobalIsolate {
     final receivePort = ReceivePort();
     sendPort.send(receivePort.sendPort);
 
-    await initServices(rootIsolateToken);
+    // Init progress reports are logged by the MANAGER (main engine), which is
+    // flush-safe — a generation that stalls during init names its stage even
+    // though its own log buffer never gets written.
+    void reportStage(String stage) {
+      try {
+        sendPort.send({'__init_stage__': stage});
+      } catch (_) {}
+    }
+
+    await initServices(rootIsolateToken, handoff, reportStage);
+    reportStage('done');
 
     receivePort.listen((message) async {
+      // Cooperative shutdown (sent by the manager instead of Isolate.kill so a
+      // natively-blocked isolate finishes its in-flight call before exiting).
+      if (message is Map && message['__shutdown__'] == true) {
+        // Flush buffered log writes first — Isolate.exit() discards anything
+        // still queued in the logger (this is how the wedged generations
+        // vanished from the 2026-07-06 log file).
+        try {
+          await GetIt.I<BaseLogger>().dispose().timeout(const Duration(seconds: 2));
+        } catch (_) {}
+        receivePort.close();
+        Isolate.exit();
+      }
       if (message is! Map<String, dynamic>) return;
 
       final isolateRequest = IsolateRequest.fromMap(message);
@@ -732,8 +874,10 @@ class _RequestInfo<T> {
   final Completer<T> completer;
   final Timer? timer;
   final IsolateRequestType type;
+  final DateTime issuedAt;
 
-  _RequestInfo({required this.completer, this.timer, required this.type});
+  _RequestInfo({required this.completer, this.timer, required this.type, DateTime? issuedAt})
+      : issuedAt = issuedAt ?? DateTime.now();
 }
 
 /// A standard request format for isolate communication

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2760,7 +2760,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
@@ -3072,26 +3072,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   throttling:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,6 +150,7 @@ dependencies:
   share_plus: ^12.0.1 # sharing files not supported on Linux, doesn't work properly on Windows
   shared_preferences: ^2.5.3
   shared_preferences_android: ^2.4.10 # direct dep: Android backend options (keep native-readable SharedPreferences store)
+  shared_preferences_platform_interface: ^2.4.2 # direct dep: InMemorySharedPreferencesAsync for the isolate prefs snapshot (no channel calls)
   shimmer: ^3.0.0
   simple_animations: ^5.1.0
   skeletonizer: ^2.1.3


### PR DESCRIPTION
### Context

This is the underlying fix behind #3074. The gap in that thread was to find the root cause rather than just fail-visibly on retries. This is it.

### Root cause

Forensics across three on-device wedges (debug + server logs) converged on one failure class: platform-channel calls made from inside background isolates stop completing around app-pause transitions. The isolate runs all DB work on a single-threaded event loop, so one hung channel call freezes every queued request behind it. Two presentations, both observed:
- warm isolate: a prefs write-through (reply-state persistence, an awaited `SharedPreferences.setString`) hangs and jams the loop;
- fresh isolate: init itself hangs on one of four channel round-trips (`path_provider`, legacy `getInstance`, the legacy->async migration, `SharedPreferencesWithCache.create`), leaving the generation stale with reads and writes piling up unserved (which is why even pure in-memory reads looked "wedged", they never started).

### Fix

- Isolate spawn hands over everything the isolate used to fetch via channels: resolved filesystem paths and package info (a `FilesystemService` handoff), plus a full prefs key/value snapshot that backs an `InMemorySharedPreferencesAsync` platform instance. The whole prefs stack then runs in-memory inside isolates with zero channel calls, all existing call sites unchanged, falling back to the old channel path if the handoff fails. This is why it adds `shared_preferences_platform_interface` as a direct dep. It's layered on top of your current native-readable SharedPreferences backend, so the main engine is untouched.
- Reply-state persistence (pure prefs) and `clearNotificationForChat` (a pure method-channel call, no DB work) no longer round-trip through the isolate at all.

### Recovery + diagnostics

- A watchdog restarts a wedged isolate instead of letting it freeze the app. Init reports per-stage progress so a stalled generation names its exact stage, and cooperative shutdown flushes the isolate log buffer before `Isolate.exit` (wedged generations previously vanished from the log).
- Write-lock escalation: two watchdog fires in quick succession indicate a store-wide DB write deadlock an isolate restart can't clear (only a full app restart can), surfaced with a "needs a restart" notification instead of silently saving nothing.

### Notes

- Primarily an Android background-isolate problem, but the changes are platform agnostic. The desktop branch of the new notification uses `local_notifier` to match the current desktop path.
- Squashed from four commits on a fork. I can split the channel-elimination from the watchdog/recovery if you'd rather review them separately.

### Testing

Validated over a multi-day period on desktop and Android. The three wedge signatures have not recurred since.
