### PR TITLE
fix: keep MessagesService alive when the same chat is re-entered via an intent

### DIFF
--- a/lib/app/layouts/conversation_view/pages/conversation_view.dart
+++ b/lib/app/layouts/conversation_view/pages/conversation_view.dart
@@ -65,6 +65,7 @@ class ConversationViewState extends State<ConversationView> with ThemeHelpers<Co
   @override
   void initState() {
     super.initState();
+    ChatsSvc.registerMountedConversation(chat.guid);
     controller.fromChatCreator = widget.fromChatCreator;
     controller.fromSearchResult = widget.initialScrollToGuid != null;
     ChatsSvc.setActiveChat(chat);
@@ -205,6 +206,7 @@ class ConversationViewState extends State<ConversationView> with ThemeHelpers<Co
 
   @override
   void dispose() {
+    ChatsSvc.unregisterMountedConversation(chat.guid);
     routeObserver.unsubscribe(this);
     controller.saveReplyToMessageState(); // P8bda
     super.dispose();

--- a/lib/services/backend/java_dart_interop/intents_service.dart
+++ b/lib/services/backend/java_dart_interop/intents_service.dart
@@ -230,7 +230,14 @@ class IntentsService {
       // comment in init()), so activeChat may be a stale leftover from before the
       // Activity was torn down — always navigate explicitly in that case rather
       // than trusting it to already reflect what's on screen.
-      bool chatIsOpen = !isInitialIntent && ChatsSvc.activeChat?.chat.guid == guid;
+      //
+      // Otherwise the chat counts as open if it is the active chat or a view for
+      // it is still mounted: setAllInactive clears activeChat while the
+      // ConversationView is still on the stack (e.g. split view), and pushing a
+      // duplicate view there races the two over the shared MessagesService.
+      final activeMatch = ChatsSvc.activeChat?.chat.guid == guid;
+      final mountedMatch = ChatsSvc.isConversationMounted(guid);
+      bool chatIsOpen = !isInitialIntent && (activeMatch || mountedMatch);
       Logger.debug("Chat is active: $chatIsOpen", tag: "IntentsService");
 
       setPickedAttachments() {

--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -43,6 +43,15 @@ class ChatsService {
 
   ChatState? activeChat;
 
+  /// How many ConversationViews are currently mounted per chat GUID. Unlike
+  /// [activeChat] (nulled by setAllInactive) and ChatState.isAlive (deadened on
+  /// pause), this stays accurate while the widget is on the navigation stack, so
+  /// an incoming share-sheet / notification intent can tell a chat is already
+  /// on-screen and skip pushing a duplicate view (which would race the two views
+  /// over the shared MessagesService). Refcounted so an in-flight handoff stays
+  /// correct.
+  final Map<String, int> _mountedConversationCounts = {};
+
   /// Sorted list of chats maintained for efficient access
   /// Updated on add/update using binary search insertion O(log n + n)
   /// instead of sorting entire list O(n log n) on every access
@@ -824,6 +833,24 @@ class ChatsService {
     EventDispatcherSvc.emit("update-highlight", activeChat?.chat.guid);
     activeChat?.updateAliveInternal(true);
   }
+
+  /// Called by ConversationView.initState — a view for [guid] is now mounted.
+  void registerMountedConversation(String guid) {
+    _mountedConversationCounts[guid] = (_mountedConversationCounts[guid] ?? 0) + 1;
+  }
+
+  /// Called by ConversationView.dispose — a view for [guid] is no longer mounted.
+  void unregisterMountedConversation(String guid) {
+    final remaining = (_mountedConversationCounts[guid] ?? 0) - 1;
+    if (remaining > 0) {
+      _mountedConversationCounts[guid] = remaining;
+    } else {
+      _mountedConversationCounts.remove(guid);
+    }
+  }
+
+  /// True while at least one ConversationView for [guid] is on the navigation stack.
+  bool isConversationMounted(String guid) => (_mountedConversationCounts[guid] ?? 0) > 0;
 
   /// Check if a chat is currently active (both active and alive)
   bool isChatActive(String guid) {


### PR DESCRIPTION
### Problem

Re-opening a chat through a share/notification intent can push a second `ConversationView` for a chat that already has one mounted. Its view is still alive (split view keeps it in the pane, or `setAllInactive` cleared `activeChat` while the view persists). Both views resolve the same `MessagesService` via `ensureMessagesSvc(guid)`. When the older route disposes, its `disposeMessagesService` → `close()` flushes the struct and clears the `MessageState`s the newer view is rendering from, so every row falls back to "Error loading message at index N" until the chat is re-entered.

### Fix

Guard at the intent entry point. `IntentsService.openChat` already deduped on `activeChat`, but `activeChat` gets nulled (`setAllInactive`) while the view is still mounted, so the check missed. `ChatsService` now refcounts mounted conversation views, and `openChat` treats the chat as already open when a view for its guid is mounted — not only when it's the active chat. The previous `MessagesService.ownershipEpoch` approach is dropped entirely.

### Testing

The dedupe path is exercised on every intent-open (`openChat` no longer pushes a duplicate when a view for the target guid is mounted).
