### PR TITLE
fix: don't crash sending a reaction — temp reaction has no temp GUID (regression introduced by PR #3074)

### DIFF
--- a/lib/services/backend/outgoing_message_handler.dart
+++ b/lib/services/backend/outgoing_message_handler.dart
@@ -218,8 +218,11 @@ class OutgoingMessageHandler {
   /// `(ok: false, ...)` once a terminal failure has been finalized (the caller
   /// should stop).
   Future<({bool ok, dynamic result})> _prepItemWithRetry(OutgoingQueueItem item) async {
-    // Every call site generates the temp GUID before queueing, so it is set.
-    final guid = item.message.guid!;
+    // Most call sites generate the temp GUID before queueing, but reactions
+    // queue a temp Message with no GUID yet. Fall back to '' so the retry guard
+    // and failure-finalize below stay safe (findOne('') matches nothing, i.e.
+    // "not yet saved").
+    final guid = item.message.guid ?? '';
     Object? lastError;
     StackTrace? lastStack;
     int attempts = 0;


### PR DESCRIPTION
### Problem

The prep-retry refactor from #3074 reads `item.message.guid!` in `_prepItemWithRetry`, assuming (per its own comment) that every queued item has a temp GUID. Since reactions don't, `sendTapback` (`message_popup_holder.dart`) queues an `OutgoingReaction` whose temp `Message` is built without one. So sending any in-app tapback (love/like/dislike/laugh/emphasize/question, picker or double-tap) throws `Null check operator used on a null value` at `outgoing_message_handler.dart:222` and the reaction is silently dropped. Happens on Android and desktop.

### Fix

Fall back to `''` (the pre-refactor behavior) so the retry guard and failure-finalize stay safe — `Message.findOne(guid: '')` matches nothing, i.e. "not yet saved".

### Testing

Long-press an incoming message → tap any tapback. Before: nothing happens + a `Null check operator` exception in the log. After: the reaction sends. Verified on Android and desktop.
