### PR TITLE
feat: Jump to Message for Conversation Attachments

### DIFF
--- a/lib/app/layouts/conversation_details/conversation_details.dart
+++ b/lib/app/layouts/conversation_details/conversation_details.dart
@@ -46,7 +46,10 @@ class _ConversationDetailsState extends State<ConversationDetails> with WidgetsB
   void dispose() {
     if (ChatsSvc.activeChat != null) {
       ChatsSvc.setActiveToAlive();
-      cvc(ChatsSvc.activeChat!.chat).lastFocusedNode.requestFocus();
+      final controller = cvc(ChatsSvc.activeChat!.chat);
+      if (!controller.skipComposerFocusOnReturn) {
+        controller.lastFocusedNode.requestFocus();
+      }
     }
     super.dispose();
   }

--- a/lib/app/layouts/conversation_details/widgets/media_gallery_card.dart
+++ b/lib/app/layouts/conversation_details/widgets/media_gallery_card.dart
@@ -374,6 +374,8 @@ class _MediaGalleryCardState extends State<MediaGalleryCard> with AutomaticKeepA
           child = OtherFile(
             file: file,
             attachment: attachment,
+            showJumpToMessage: widget.showJumpToMessage,
+            galleryAttachments: widget.galleryAttachments,
           );
         }
       } else {

--- a/lib/app/layouts/conversation_details/widgets/media_gallery_card.dart
+++ b/lib/app/layouts/conversation_details/widgets/media_gallery_card.dart
@@ -9,6 +9,7 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart';
 import 'package:bluebubbles/app/components/circle_progress_bar.dart';
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
+import 'package:bluebubbles/app/state/chat_state_scope.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/cupertino.dart';
@@ -20,9 +21,17 @@ import 'package:universal_io/io.dart';
 import 'package:video_player/video_player.dart';
 
 class MediaGalleryCard extends StatefulWidget {
-  const MediaGalleryCard({super.key, required this.attachment, this.showSenderAvatar = true});
+  const MediaGalleryCard({
+    super.key,
+    required this.attachment,
+    this.showSenderAvatar = true,
+    this.showJumpToMessage = false,
+    this.galleryAttachments,
+  });
   final Attachment attachment;
   final bool showSenderAvatar;
+  final bool showJumpToMessage;
+  final List<Attachment>? galleryAttachments;
 
   @override
   State<MediaGalleryCard> createState() => _MediaGalleryCardState();
@@ -152,9 +161,19 @@ class _MediaGalleryCardState extends State<MediaGalleryCard> with AutomaticKeepA
               opacity: 0.3,
               child: file.path != null
                   ? (attachment.mimeType?.startsWith("image") ?? false)
-                      ? ImageDisplay(attachment: attachment, file: file)
+                      ? ImageDisplay(
+                          attachment: attachment,
+                          file: file,
+                          showJumpToMessage: widget.showJumpToMessage,
+                          galleryAttachments: widget.galleryAttachments,
+                        )
                       : (attachment.mimeType?.startsWith("video") ?? false) && videoPreviewPath != null
-                          ? ImageDisplay(attachment: attachment, imagePath: videoPreviewPath)
+                          ? ImageDisplay(
+                              attachment: attachment,
+                              imagePath: videoPreviewPath,
+                              showJumpToMessage: widget.showJumpToMessage,
+                              galleryAttachments: widget.galleryAttachments,
+                            )
                           : const SizedBox.shrink()
                   : const SizedBox.shrink(),
             ),
@@ -323,6 +342,8 @@ class _MediaGalleryCardState extends State<MediaGalleryCard> with AutomaticKeepA
             file: file,
             showSenderAvatar: widget.showSenderAvatar,
             onPressChanged: _setPressed,
+            showJumpToMessage: widget.showJumpToMessage,
+            galleryAttachments: widget.galleryAttachments,
           );
           addPadding = false;
         } else if ((attachment.mimeType?.startsWith("video") ?? false) && !kIsDesktop && !kIsWeb) {
@@ -332,7 +353,9 @@ class _MediaGalleryCardState extends State<MediaGalleryCard> with AutomaticKeepA
                 imagePath: videoPreviewPath,
                 duration: duration,
                 showSenderAvatar: widget.showSenderAvatar,
-                onPressChanged: _setPressed);
+                onPressChanged: _setPressed,
+                showJumpToMessage: widget.showJumpToMessage,
+                galleryAttachments: widget.galleryAttachments);
             addPadding = false;
           } else if (videoPreviewFailed) {
             child = Text(
@@ -385,6 +408,8 @@ class ImageDisplay extends StatefulWidget {
     this.duration,
     this.showSenderAvatar = true,
     this.onPressChanged,
+    this.showJumpToMessage = false,
+    this.galleryAttachments,
   });
 
   final Attachment attachment;
@@ -393,6 +418,8 @@ class ImageDisplay extends StatefulWidget {
   final Duration? duration;
   final bool showSenderAvatar;
   final ValueChanged<bool>? onPressChanged;
+  final bool showJumpToMessage;
+  final List<Attachment>? galleryAttachments;
 
   @override
   State<ImageDisplay> createState() => _ImageDisplayState();
@@ -409,14 +436,18 @@ class _ImageDisplayState extends State<ImageDisplay> {
   @override
   Widget build(BuildContext context) {
     final double cardSize = NavigationSvc.width(context) / max(2, NavigationSvc.width(context) ~/ 200);
+    final currentChat = ChatStateScope.maybeChatOf(context);
 
     return OpenContainer(
       transitionDuration: Durations.medium4,
       closedShape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(M3EShapes.lg))),
       openBuilder: (_, closeContainer) {
         return ConversationFullscreenHolder(
+          currentChat: currentChat,
           attachment: attachment,
           showInteractions: true,
+          showJumpToMessage: widget.showJumpToMessage,
+          galleryAttachments: widget.galleryAttachments,
         );
       },
       closedBuilder: (_, openContainer) {

--- a/lib/app/layouts/conversation_details/widgets/sections/documents/documents_section.dart
+++ b/lib/app/layouts/conversation_details/widgets/sections/documents/documents_section.dart
@@ -168,7 +168,11 @@ class _DocumentsSectionState extends State<DocumentsSection> with ThemeHelpers {
                 childAspectRatio: 1.75,
               ),
               delegate: SliverChildBuilderDelegate(
-                (context, int index) => MediaGalleryCard(attachment: _displayedDocs[index]),
+                (context, int index) => MediaGalleryCard(
+                  attachment: _displayedDocs[index],
+                  showJumpToMessage: true,
+                  galleryAttachments: _displayedDocs,
+                ),
                 childCount: _visibleCount,
               ),
             ),

--- a/lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart
+++ b/lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart
@@ -135,6 +135,8 @@ class _MediaGridSectionState extends State<MediaGridSection> with ThemeHelpers {
               children: [
                 MediaGalleryCard(
                   attachment: attachment,
+                  showJumpToMessage: true,
+                  galleryAttachments: _filteredMedia,
                 ),
                 if (isSelected)
                   Container(

--- a/lib/app/layouts/conversation_view/pages/conversation_view.dart
+++ b/lib/app/layouts/conversation_view/pages/conversation_view.dart
@@ -58,6 +58,7 @@ class ConversationViewState extends State<ConversationView> with ThemeHelpers<Co
       controller.focusNode.unfocus();
       controller.subjectFocusNode.unfocus();
     } else if (SettingsSvc.settings.swipeToOpenKeyboard.value && details.delta.dy < 0 && !controller.keyboardOpen) {
+      controller.releaseComposerFocusSuppression();
       controller.focusNode.requestFocus();
     }
   }

--- a/lib/app/layouts/conversation_view/widgets/header/material_header.dart
+++ b/lib/app/layouts/conversation_view/widgets/header/material_header.dart
@@ -282,14 +282,24 @@ class _ChatIconAndTitleState extends CustomState<_ChatIconAndTitle, void, Conver
               if (samsung &&
                   (controller.chat.isGroup ||
                       (!controller.chat.getTitle().isPhoneNumber && !controller.chat.getTitle().isEmail)))
-                Text(
-                  controller.chat.isGroup
-                      ? "${controller.chat.handles.length} recipients"
-                      : controller.chat.handles[0].address,
-                  style: context.theme.textTheme.labelLarge!.apply(color: context.theme.colorScheme.outline),
-                  maxLines: 1,
-                  overflow: TextOverflow.fade,
-                ),
+                controller.chat.isGroup
+                    ? Text(
+                        "${controller.chat.handles.length} recipients",
+                        style: context.theme.textTheme.labelLarge!.apply(color: context.theme.colorScheme.outline),
+                        maxLines: 1,
+                        overflow: TextOverflow.fade,
+                      )
+                    : Obx(() {
+                        if (chatState.participants.isEmpty) return const SizedBox.shrink();
+                        final address = chatState.participants.first.formattedAddress.value;
+                        if (address == null) return const SizedBox.shrink();
+                        return Text(
+                          address,
+                          style: context.theme.textTheme.labelLarge!.apply(color: context.theme.colorScheme.outline),
+                          maxLines: 1,
+                          overflow: TextOverflow.fade,
+                        );
+                      }),
             ],
           ),
         ),

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart
@@ -301,7 +301,11 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
           ),
           itemCount: _attachments.length,
           itemBuilder: (context, index) {
-            return MediaGalleryCard(attachment: _attachments[index], showSenderAvatar: false);
+            return MediaGalleryCard(
+              attachment: _attachments[index],
+              showSenderAvatar: false,
+              galleryAttachments: _attachments,
+            );
           },
         ),
       ),

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/other_file.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/other_file.dart
@@ -88,9 +88,13 @@ class OtherFile extends StatelessWidget {
     super.key,
     required this.attachment,
     required this.file,
+    this.showJumpToMessage = false,
+    this.galleryAttachments,
   });
   final Attachment attachment;
   final PlatformFile file;
+  final bool showJumpToMessage;
+  final List<Attachment>? galleryAttachments;
 
   @override
   Widget build(BuildContext context) {
@@ -104,6 +108,8 @@ class OtherFile extends StatelessWidget {
                 currentChat: currentChat,
                 attachment: attachment,
                 showInteractions: true,
+                showJumpToMessage: showJumpToMessage,
+                galleryAttachments: galleryAttachments,
               ),
             ),
           );

--- a/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
@@ -459,7 +459,9 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
 
   @override
   Widget build(BuildContext context) {
-    return Obx(() => Padding(
+    return Listener(
+      onPointerDown: (_) => controller.releaseComposerFocusSuppression(),
+      child: Obx(() => Padding(
           padding: EdgeInsets.only(
             bottom: showAttachmentPicker ? 0 : 10.0,
             top: 10.0,
@@ -539,6 +541,7 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
               ),
             ],
           ),
-        ));
+        )),
+    );
   }
 }

--- a/lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart
+++ b/lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart
@@ -202,7 +202,7 @@ class ConversationFullscreenHolderState extends State<ConversationFullscreenHold
     final handle = message.handleRelation.target;
     if (handle == null) return "From Unknown";
     final handleState = HandleSvc.getOrCreateHandleState(handle);
-    return "From ${handleState.displayName.value ?? handle.displayName}";
+    return "From ${handleState.displayName.value ?? "Unknown"}";
   }
 
   PreferredSizeWidget? _buildJumpToMessageBar(BuildContext context) {

--- a/lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart
+++ b/lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart
@@ -1,3 +1,5 @@
+import 'package:bluebubbles/app/components/bb_chip.dart';
+import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
 import 'package:bluebubbles/app/components/circle_progress_bar.dart';
 import 'package:bluebubbles/app/layouts/fullscreen_media/fullscreen_image.dart';
 import 'package:bluebubbles/app/layouts/fullscreen_media/fullscreen_video.dart';
@@ -28,7 +30,8 @@ class ConversationFullscreenHolder extends StatefulWidget {
       this.initialAttachmentGuid,
       this.replyMessage,
       this.replyPartIndex,
-      this.galleryAttachments});
+      this.galleryAttachments,
+      this.showJumpToMessage = false});
 
   final Chat? currentChat;
   final Attachment attachment;
@@ -42,6 +45,9 @@ class ConversationFullscreenHolder extends StatefulWidget {
   /// When non-null, the fullscreen carousel is limited to these attachments
   /// instead of all images in the chat. Used when opening from a gallery card.
   final List<Attachment>? galleryAttachments;
+
+  /// When true, shows a header chip to jump back to the source message.
+  final bool showJumpToMessage;
 
   @override
   ConversationFullscreenHolderState createState() => ConversationFullscreenHolderState();
@@ -79,6 +85,166 @@ class ConversationFullscreenHolderState extends State<ConversationFullscreenHold
   bool get _isVideoAttachment => attachment.mimeStart == "video";
   late bool showAppBar = kIsDesktop || kIsWeb || !_isVideoAttachment;
   bool get _canReply => widget.replyMessage != null && widget.replyPartIndex != null && widget.currentChat != null;
+
+  Message? _messageForAttachment(Attachment attachment) {
+    if (attachment.message.hasValue) {
+      return attachment.message.target;
+    }
+    final svc = messageService;
+    if (svc != null && attachment.guid != null) {
+      for (final message in svc.struct.messages) {
+        if (message.dbAttachments.any((a) => a.guid == attachment.guid)) {
+          return message;
+        }
+      }
+    }
+    return null;
+  }
+
+  Message? get _currentMessage => _messageForAttachment(attachments[currentIndex]);
+
+  bool _canJumpFor(Attachment attachment) {
+    if (!widget.showJumpToMessage || kIsWeb || !widget.showInteractions) return false;
+    final message = _messageForAttachment(attachment);
+    if (message?.guid == null) return false;
+    final chatGuid = widget.currentChat?.guid ?? message!.chat.target?.guid;
+    if (chatGuid == null) return false;
+    return maybeFindMessagesSvc(chatGuid) != null;
+  }
+
+  bool get _canJumpToMessage => _canJumpFor(attachments[currentIndex]);
+
+  void _jumpToSourceMessage() {
+    final message = _currentMessage;
+    final guid = message?.guid;
+    final chatGuid = widget.currentChat?.guid ?? message?.chat.target?.guid;
+    if (guid == null || chatGuid == null) return;
+
+    final service = maybeFindMessagesSvc(chatGuid);
+    if (service == null) return;
+
+    // Capture before popping — this widget's context is disposed after the first pop.
+    final navigator = Navigator.of(context);
+    final useTabletNestedNav = Get.keys.containsKey(2) && NavigationSvc.isTabletMode(context);
+
+    // Close fullscreen first.
+    navigator.pop();
+
+    if (useTabletNestedNav) {
+      // Nested right-pane navigator doesn't fire RouteAware, so showingSubRoute stays
+      // false. Pop Details / Attachments via Get.back(id: 2) instead.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _popTabletOverlaysThenJump(guid: guid, service: service);
+      });
+      return;
+    }
+
+    // Phone: pop one route per frame so ConversationView's RouteAware can clear
+    // showingSubRoute before we decide whether another pop is needed.
+    void popUntilConversation() {
+      final ctrl = Get.isRegistered<ConversationViewController>(tag: chatGuid)
+          ? Get.find<ConversationViewController>(tag: chatGuid)
+          : null;
+      if (ctrl?.showingSubRoute == true && navigator.canPop()) {
+        navigator.pop();
+        WidgetsBinding.instance.addPostFrameCallback((_) => popUntilConversation());
+        return;
+      }
+      service.jumpToMessage(guid);
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => popUntilConversation());
+  }
+
+  /// Tablet right-pane stack is typically: initial → ConversationView → Details → (Attachments?).
+  /// ConversationView and Attachments are both GetPageRoute; Details is a ThemeSwitcher page route.
+  /// Pop overlays only — never the conversation (the GetPageRoute that sits above `initial`).
+  void _popTabletOverlaysThenJump({required String guid, required MessagesService service}) {
+    void step({int popsDone = 0}) {
+      if (popsDone >= 2) {
+        service.jumpToMessage(guid);
+        return;
+      }
+
+      final nav = Get.global(2).currentState;
+      if (nav == null || !nav.canPop()) {
+        service.jumpToMessage(guid);
+        return;
+      }
+
+      Route<dynamic>? top;
+      nav.popUntil((route) {
+        top = route;
+        return true; // Inspect only; do not pop.
+      });
+
+      final isDetailsRoute = top is MaterialPageRoute || top is PageRouteBuilder;
+      final isGetPageRoute = top is GetPageRoute;
+
+      // Details (always pop). Attachments is a GetPageRoute still above CV — pop only as
+      // the first overlay. A later GetPageRoute is ConversationView; leave it alone.
+      final shouldPop = isDetailsRoute || (isGetPageRoute && popsDone == 0);
+      if (!shouldPop) {
+        service.jumpToMessage(guid);
+        return;
+      }
+
+      Get.back(id: 2);
+      WidgetsBinding.instance.addPostFrameCallback((_) => step(popsDone: popsDone + 1));
+    }
+
+    step();
+  }
+
+  String get _jumpChipLabel {
+    final message = _currentMessage!;
+    if (message.isFromMe!) return "From You";
+    final handle = message.handleRelation.target;
+    if (handle == null) return "From Unknown";
+    final handleState = HandleSvc.getOrCreateHandleState(handle);
+    return "From ${handleState.displayName.value ?? handle.displayName}";
+  }
+
+  PreferredSizeWidget? _buildJumpToMessageBar(BuildContext context) {
+    if (!_canJumpToMessage) return null;
+
+    return PreferredSize(
+      // Material chip metrics (avatar + bodyMedium line-height) can slightly exceed 36;
+      // keep headroom so we don't trip fractional RenderFlex overflows.
+      preferredSize: const Size.fromHeight(40),
+      child: Align(
+        alignment: Alignment.center,
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Theme(
+            data: context.theme.copyWith(
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              visualDensity: VisualDensity.compact,
+            ),
+            child: BBChip(
+              avatar: CircleAvatar(
+                backgroundColor: context.theme.colorScheme.primaryContainer,
+                radius: 12,
+                child: ContactAvatarWidget(
+                  handle: _currentMessage!.isFromMe! ? null : _currentMessage!.handleRelation.target,
+                  size: 24,
+                  editable: false,
+                  scaleSize: false,
+                  borderThickness: 0,
+                ),
+              ),
+              label: Text(
+                _jumpChipLabel,
+                style: context.theme.textTheme.bodyMedium?.copyWith(height: 1.2),
+                overflow: TextOverflow.ellipsis,
+              ),
+              onPressed: _jumpToSourceMessage,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   @override
   void initState() {
@@ -153,6 +319,7 @@ class ConversationFullscreenHolderState extends State<ConversationFullscreenHold
                       : "${currentIndex + 1} of ${attachments.length}",
                   titleStyle:
                       context.theme.textTheme.titleLarge!.copyWith(color: context.theme.colorScheme.onSurfaceVariant),
+                  bottom: _buildJumpToMessageBar(context),
                   iconTheme: IconThemeData(color: context.theme.colorScheme.primary),
                   actions: [
                     if (_canReply)
@@ -233,184 +400,219 @@ class ConversationFullscreenHolderState extends State<ConversationFullscreenHold
                   _videoSwipeVelocityTracker = null;
                   _videoSwipeDragDx = 0;
                 },
-                child: PageView.builder(
-                physics: physics ??
-                    (attachments.length == 1 ? const NeverScrollableScrollPhysics() : ThemeSwitcher.getScrollPhysics()),
-                reverse: SettingsSvc.settings.fullscreenViewerSwipeDir.value == SwipeDirection.RIGHT,
-                itemCount: attachments.length,
-                onPageChanged: (int val) {
-                  widget.videoController?.player.pause();
-                  setState(() {
-                    currentIndex = val;
-                    // Reset a zoom-lock (NeverScrollableScrollPhysics) set by the page we're
-                    // leaving — FullscreenImage's PhotoView reports its own scale state via
-                    // updatePhysics, but `physics` lives on this shared holder, not per-page.
-                    // Without this reset, landing on a video (which never calls updatePhysics)
-                    // after a zoomed image permanently locks the PageView from then on.
-                    physics = null;
-                  });
-                },
-                controller: controller,
-                itemBuilder: (BuildContext context, int index) {
-                  final attachment = attachments[index];
-                  dynamic content = AttachmentsSvc.getContent(attachment,
-                      path: attachment.guid == null ? attachment.transferName : null);
-                  final key = attachment.guid ?? attachment.transferName ?? randomString(8);
-
-                  if (content is PlatformFile) {
-                    if (attachment.mimeStart == "image") {
-                      return FullscreenImage(
-                        key: Key(key),
-                        attachment: attachment,
-                        file: content,
-                        showInteractions: widget.showInteractions,
-                        updatePhysics: (ScrollPhysics p) {
-                          if (physics != p) {
-                            setState(() {
-                              physics = p;
-                            });
-                          }
-                        },
-                        onOverlayToggle: (show) {
-                          if (showAppBar != show) {
-                            setState(() {
-                              showAppBar = show;
-                            });
-                          }
-                        },
-                      );
-                    } else if (attachment.mimeStart == "video") {
-                      return FullscreenVideo(
-                        key: Key(key),
-                        file: content,
-                        attachment: attachment,
-                        showInteractions: widget.showInteractions,
-                        videoController: widget.videoController,
-                        mute: widget.mute,
-                        onOverlayToggle: (show) {
-                          if (showAppBar != show) {
-                            setState(() {
-                              showAppBar = show;
-                            });
-                          }
-                        },
-                      );
-                    } else {
-                      return const SizedBox.shrink();
-                    }
-                  } else if (content is Attachment) {
-                    final Attachment _content = content;
-                    return InkWell(
-                      onTap: () {
+                child: Stack(
+                  children: [
+                    PageView.builder(
+                      physics: physics ??
+                          (attachments.length == 1
+                              ? const NeverScrollableScrollPhysics()
+                              : ThemeSwitcher.getScrollPhysics()),
+                      reverse: SettingsSvc.settings.fullscreenViewerSwipeDir.value == SwipeDirection.RIGHT,
+                      itemCount: attachments.length,
+                      onPageChanged: (int val) {
+                        widget.videoController?.player.pause();
                         setState(() {
-                          content = AttachmentDownloader.startDownload(content, onComplete: (file) {
-                            setState(() {
-                              content = file;
-                            });
-                          });
+                          currentIndex = val;
+                          // Reset a zoom-lock (NeverScrollableScrollPhysics) set by the page we're
+                          // leaving — FullscreenImage's PhotoView reports its own scale state via
+                          // updatePhysics, but `physics` lives on this shared holder, not per-page.
+                          // Without this reset, landing on a video (which never calls updatePhysics)
+                          // after a zoomed image permanently locks the PageView from then on.
+                          physics = null;
                         });
                       },
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: <Widget>[
-                          SizedBox(
-                            height: 40,
-                            width: 40,
-                            child: Center(
-                                child: Icon(iOS ? CupertinoIcons.cloud_download : Icons.cloud_download_outlined,
-                                    size: 30)),
-                          ),
-                          const SizedBox(height: 5),
-                          Text(
-                            (_content.mimeType ?? ""),
-                            style: context.theme.textTheme.bodyLarge!
-                                .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 10),
-                          Text(
-                            _content.getFriendlySize(),
-                            style: context.theme.textTheme.bodyMedium!
-                                .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
-                            maxLines: 1,
-                          ),
-                        ],
-                      ),
-                    );
-                  } else if (content is AttachmentDownloadController) {
-                    final AttachmentDownloadController _content = content;
-                    return InkWell(
-                      onTap: () {
-                        final AttachmentDownloadController _content = content;
-                        if (_content.state.value != AttachmentDownloadState.error) return;
-                        Get.delete<AttachmentDownloadController>(tag: _content.attachment.guid);
-                        content = AttachmentDownloader.startDownload(_content.attachment, onComplete: (file) {
-                          setState(() {
-                            content = file;
-                          });
-                        });
-                      },
-                      child: Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Obx(() {
-                          final isError = _content.state.value == AttachmentDownloadState.error;
-                          final isProcessing = _content.state.value == AttachmentDownloadState.processing;
-                          final isQueued = _content.state.value == AttachmentDownloadState.queued;
+                      controller: controller,
+                      itemBuilder: (BuildContext context, int index) {
+                        final attachment = attachments[index];
+                        dynamic content = AttachmentsSvc.getContent(attachment,
+                            path: attachment.guid == null ? attachment.transferName : null);
+                        final key = attachment.guid ?? attachment.transferName ?? randomString(8);
 
-                          return Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: <Widget>[
-                              SizedBox(
-                                height: 40,
-                                width: 40,
-                                child: Center(
-                                  child: isError
-                                      ? Icon(iOS ? CupertinoIcons.arrow_clockwise : Icons.refresh, size: 30)
-                                      : isProcessing
-                                          ? (iOS
-                                              ? const CupertinoActivityIndicator(radius: 14)
-                                              : const CircularProgressIndicator())
-                                          : isQueued
-                                              ? Icon(iOS ? CupertinoIcons.clock : Icons.schedule, size: 30)
-                                              : CircleProgressBar(
-                                                  value: _content.progress.value?.toDouble() ?? 0,
-                                                  backgroundColor: context.theme.colorScheme.outline,
-                                                  foregroundColor: context.theme.colorScheme.onSurfaceVariant,
-                                                ),
+                        if (content is PlatformFile) {
+                          final canJump = _canJumpFor(attachment);
+                          if (attachment.mimeStart == "image") {
+                            return FullscreenImage(
+                              key: Key(key),
+                              attachment: attachment,
+                              file: content,
+                              showInteractions: widget.showInteractions,
+                              updatePhysics: (ScrollPhysics p) {
+                                if (physics != p) {
+                                  setState(() {
+                                    physics = p;
+                                  });
+                                }
+                              },
+                              onOverlayToggle: (show) {
+                                if (showAppBar != show) {
+                                  setState(() {
+                                    showAppBar = show;
+                                  });
+                                }
+                              },
+                              onJumpToMessage: canJump ? _jumpToSourceMessage : null,
+                            );
+                          } else if (attachment.mimeStart == "video") {
+                            return FullscreenVideo(
+                              key: Key(key),
+                              file: content,
+                              attachment: attachment,
+                              showInteractions: widget.showInteractions,
+                              videoController: widget.videoController,
+                              mute: widget.mute,
+                              onOverlayToggle: (show) {
+                                if (showAppBar != show) {
+                                  setState(() {
+                                    showAppBar = show;
+                                  });
+                                }
+                              },
+                              onJumpToMessage: canJump ? _jumpToSourceMessage : null,
+                            );
+                          } else {
+                            return const SizedBox.shrink();
+                          }
+                        } else if (content is Attachment) {
+                          final Attachment _content = content;
+                          return InkWell(
+                            onTap: () {
+                              setState(() {
+                                content = AttachmentDownloader.startDownload(content, onComplete: (file) {
+                                  setState(() {
+                                    content = file;
+                                  });
+                                });
+                              });
+                            },
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                SizedBox(
+                                  height: 40,
+                                  width: 40,
+                                  child: Center(
+                                      child: Icon(iOS ? CupertinoIcons.cloud_download : Icons.cloud_download_outlined,
+                                          size: 30)),
                                 ),
-                              ),
-                              isError ? const SizedBox(height: 10) : const SizedBox(height: 5),
+                                const SizedBox(height: 5),
+                                Text(
+                                  (_content.mimeType ?? ""),
+                                  style: context.theme.textTheme.bodyLarge!
+                                      .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                const SizedBox(height: 10),
+                                Text(
+                                  _content.getFriendlySize(),
+                                  style: context.theme.textTheme.bodyMedium!
+                                      .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
+                                  maxLines: 1,
+                                ),
+                              ],
+                            ),
+                          );
+                        } else if (content is AttachmentDownloadController) {
+                          final AttachmentDownloadController _content = content;
+                          return InkWell(
+                            onTap: () {
+                              final AttachmentDownloadController _content = content;
+                              if (_content.state.value != AttachmentDownloadState.error) return;
+                              Get.delete<AttachmentDownloadController>(tag: _content.attachment.guid);
+                              content = AttachmentDownloader.startDownload(_content.attachment, onComplete: (file) {
+                                setState(() {
+                                  content = file;
+                                });
+                              });
+                            },
+                            child: Padding(
+                              padding: const EdgeInsets.all(20.0),
+                              child: Obx(() {
+                                final isError = _content.state.value == AttachmentDownloadState.error;
+                                final isProcessing = _content.state.value == AttachmentDownloadState.processing;
+                                final isQueued = _content.state.value == AttachmentDownloadState.queued;
+
+                                return Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: <Widget>[
+                                    SizedBox(
+                                      height: 40,
+                                      width: 40,
+                                      child: Center(
+                                        child: isError
+                                            ? Icon(iOS ? CupertinoIcons.arrow_clockwise : Icons.refresh, size: 30)
+                                            : isProcessing
+                                                ? (iOS
+                                                    ? const CupertinoActivityIndicator(radius: 14)
+                                                    : const CircularProgressIndicator())
+                                                : isQueued
+                                                    ? Icon(iOS ? CupertinoIcons.clock : Icons.schedule, size: 30)
+                                                    : CircleProgressBar(
+                                                        value: _content.progress.value?.toDouble() ?? 0,
+                                                        backgroundColor: context.theme.colorScheme.outline,
+                                                        foregroundColor: context.theme.colorScheme.onSurfaceVariant,
+                                                      ),
+                                      ),
+                                    ),
+                                    isError ? const SizedBox(height: 10) : const SizedBox(height: 5),
+                                    Text(
+                                      isError
+                                          ? "Failed to download!"
+                                          : isProcessing
+                                              ? "Processing"
+                                              : isQueued
+                                                  ? "Queued"
+                                                  : (_content.attachment.mimeType ?? ""),
+                                      style: context.theme.textTheme.bodyLarge!
+                                          .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                    )
+                                  ],
+                                );
+                              }),
+                            ),
+                          );
+                        } else {
+                          return Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
                               Text(
-                                isError
-                                    ? "Failed to download!"
-                                    : isProcessing
-                                        ? "Processing"
-                                        : isQueued
-                                            ? "Queued"
-                                            : (_content.attachment.mimeType ?? ""),
-                                style: context.theme.textTheme.bodyLarge!
-                                    .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              )
+                                "Error loading attachment",
+                                style: context.theme.textTheme.bodyLarge,
+                              ),
                             ],
                           );
-                        }),
-                      ),
-                    );
-                  } else {
-                    return Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          "Error loading attachment",
-                          style: context.theme.textTheme.bodyLarge,
+                        }
+                      },
+                    ),
+                    if (material && _canJumpToMessage)
+                      Positioned(
+                        right: 16,
+                        bottom: 16,
+                        child: IgnorePointer(
+                          ignoring: !showAppBar,
+                          child: AnimatedOpacity(
+                            opacity: showAppBar ? 1.0 : 0.0,
+                            duration: const Duration(milliseconds: 200),
+                            child: SafeArea(
+                              top: false,
+                              child: FilledButton(
+                                onPressed: _jumpToSourceMessage,
+                                style: FilledButton.styleFrom(
+                                  backgroundColor: context.theme.colorScheme.primary,
+                                  foregroundColor: context.theme.colorScheme.onPrimary,
+                                  shape: const StadiumBorder(),
+                                  minimumSize: const Size(0, 48),
+                                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                                ),
+                                child: const Text("See in chat"),
+                              ),
+                            ),
+                          ),
                         ),
-                      ],
-                    );
-                  }
-                },
+                      ),
+                  ],
                 ),
               ),
             ),

--- a/lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart
+++ b/lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart
@@ -123,6 +123,11 @@ class ConversationFullscreenHolderState extends State<ConversationFullscreenHold
     final service = maybeFindMessagesSvc(chatGuid);
     if (service == null) return;
 
+    final ctrl = Get.isRegistered<ConversationViewController>(tag: chatGuid)
+        ? Get.find<ConversationViewController>(tag: chatGuid)
+        : null;
+    ctrl?.suppressComposerFocus();
+
     // Capture before popping — this widget's context is disposed after the first pop.
     final navigator = Navigator.of(context);
     final useTabletNestedNav = Get.keys.containsKey(2) && NavigationSvc.isTabletMode(context);
@@ -142,9 +147,6 @@ class ConversationFullscreenHolderState extends State<ConversationFullscreenHold
     // Phone: pop one route per frame so ConversationView's RouteAware can clear
     // showingSubRoute before we decide whether another pop is needed.
     void popUntilConversation() {
-      final ctrl = Get.isRegistered<ConversationViewController>(tag: chatGuid)
-          ? Get.find<ConversationViewController>(tag: chatGuid)
-          : null;
       if (ctrl?.showingSubRoute == true && navigator.canPop()) {
         navigator.pop();
         WidgetsBinding.instance.addPostFrameCallback((_) => popUntilConversation());

--- a/lib/app/layouts/fullscreen_media/fullscreen_image.dart
+++ b/lib/app/layouts/fullscreen_media/fullscreen_image.dart
@@ -202,6 +202,30 @@ class _FullscreenImageState extends State<FullscreenImage>
     );
   }
 
+  Widget _samsungBottomAction({
+    required IconData icon,
+    required String label,
+    required VoidCallback onPressed,
+  }) {
+    return InkWell(
+      onTap: onPressed,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: Colors.white, size: 28),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: context.theme.textTheme.labelMedium?.copyWith(color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -355,6 +379,44 @@ class _FullscreenImageState extends State<FullscreenImage>
                             ),
                             onPressed: () => refreshAttachment(),
                           ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            // Bottom actions bar (Samsung style)
+            if (widget.showInteractions && samsung)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: AnimatedOpacity(
+                  opacity: showOverlay ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 200),
+                  child: SafeArea(
+                    top: false,
+                    child: Container(
+                      height: 72,
+                      color: Colors.black,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          _samsungBottomAction(
+                            icon: Icons.file_download_outlined,
+                            label: 'Save',
+                            onPressed: () => AttachmentsSvc.saveToDisk(widget.file),
+                          ),
+                          if (!kIsWeb && !kIsDesktop)
+                            _samsungBottomAction(
+                              icon: Icons.share_outlined,
+                              label: 'Share',
+                              onPressed: () {
+                                if (widget.file.path != null) {
+                                  Share.files([widget.file.path!]);
+                                }
+                              },
+                            ),
                         ],
                       ),
                     ),

--- a/lib/app/layouts/fullscreen_media/fullscreen_image.dart
+++ b/lib/app/layouts/fullscreen_media/fullscreen_image.dart
@@ -25,6 +25,7 @@ class FullscreenImage extends StatefulWidget {
     required this.showInteractions,
     required this.updatePhysics,
     this.onOverlayToggle,
+    this.onJumpToMessage,
   });
 
   final PlatformFile file;
@@ -32,6 +33,7 @@ class FullscreenImage extends StatefulWidget {
   final bool showInteractions;
   final Function(ScrollPhysics) updatePhysics;
   final Function(bool)? onOverlayToggle;
+  final VoidCallback? onJumpToMessage;
 
   @override
   State<FullscreenImage> createState() => _FullscreenImageState();
@@ -155,6 +157,51 @@ class _FullscreenImageState extends State<FullscreenImage>
     );
   }
 
+  Widget _senderHeaderColumn({required bool jumpEnabled}) {
+    final column = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Obx(() {
+          final msg = message;
+          if (msg == null) return const SizedBox.shrink();
+          final name = (msg.isFromMe ?? false)
+              ? 'You'
+              : (msg.handleRelation.target != null
+                      ? HandleSvc.getOrCreateHandleState(msg.handleRelation.target!).displayName.value
+                      : null) ??
+                  'Unknown';
+          return Text(name, style: context.theme.textTheme.titleLarge!.copyWith(color: Colors.white));
+        }),
+        if (message?.dateCreated != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2.0),
+            child: Text(
+              samsung
+                  ? intl.DateFormat.jm().add_MMMd().format(message!.dateCreated!)
+                  : intl.DateFormat('EEE').add_jm().format(message!.dateCreated!),
+              style: context.theme.textTheme.bodyLarge!
+                  .copyWith(color: samsung ? Colors.grey : Colors.white),
+            ),
+          ),
+      ],
+    );
+
+    if (!jumpEnabled) return column;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: widget.onJumpToMessage,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          child: column,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -217,29 +264,8 @@ class _FullscreenImageState extends State<FullscreenImage>
                               if (widget.showInteractions)
                                 Padding(
                                   padding: const EdgeInsets.only(left: 5.0),
-                                  child: Column(
-                                    mainAxisSize: MainAxisSize.min,
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        (message?.isFromMe ?? false)
-                                            ? 'You'
-                                            : message?.handleRelation.target?.displayName ?? "Unknown",
-                                        style: context.theme.textTheme.titleLarge!.copyWith(color: Colors.white),
-                                      ),
-                                      if (message?.dateCreated != null)
-                                        Padding(
-                                          padding: const EdgeInsets.only(top: 2.0),
-                                          child: Text(
-                                            samsung
-                                                ? intl.DateFormat.jm().add_MMMd().format(message!.dateCreated!)
-                                                : intl.DateFormat('EEE').add_jm().format(message!.dateCreated!),
-                                            style: context.theme.textTheme.bodyLarge!.copyWith(
-                                              color: samsung ? Colors.grey : Colors.white,
-                                            ),
-                                          ),
-                                        ),
-                                    ],
+                                  child: _senderHeaderColumn(
+                                    jumpEnabled: samsung && widget.onJumpToMessage != null,
                                   ),
                                 ),
                             ],
@@ -291,9 +317,7 @@ class _FullscreenImageState extends State<FullscreenImage>
                     child: Container(
                       height: 60,
                       decoration: BoxDecoration(
-                        color: samsung
-                            ? Colors.black
-                            : context.theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.9),
+                        color: context.theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.9),
                       ),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -301,7 +325,7 @@ class _FullscreenImageState extends State<FullscreenImage>
                           IconButton(
                             icon: Icon(
                               CupertinoIcons.cloud_download,
-                              color: samsung ? Colors.white : context.theme.colorScheme.primary,
+                              color: context.theme.colorScheme.primary,
                             ),
                             onPressed: () => AttachmentsSvc.saveToDisk(widget.file),
                           ),
@@ -309,7 +333,7 @@ class _FullscreenImageState extends State<FullscreenImage>
                             IconButton(
                               icon: Icon(
                                 CupertinoIcons.share,
-                                color: samsung ? Colors.white : context.theme.colorScheme.primary,
+                                color: context.theme.colorScheme.primary,
                               ),
                               onPressed: () {
                                 if (widget.file.path != null) {
@@ -320,14 +344,14 @@ class _FullscreenImageState extends State<FullscreenImage>
                           IconButton(
                             icon: Icon(
                               CupertinoIcons.info,
-                              color: samsung ? Colors.white : context.theme.colorScheme.primary,
+                              color: context.theme.colorScheme.primary,
                             ),
                             onPressed: () => showMetadataDialog(widget.attachment, context),
                           ),
                           IconButton(
                             icon: Icon(
                               CupertinoIcons.refresh,
-                              color: samsung ? Colors.white : context.theme.colorScheme.primary,
+                              color: context.theme.colorScheme.primary,
                             ),
                             onPressed: () => refreshAttachment(),
                           ),

--- a/lib/app/layouts/fullscreen_media/fullscreen_image.dart
+++ b/lib/app/layouts/fullscreen_media/fullscreen_image.dart
@@ -158,45 +158,55 @@ class _FullscreenImageState extends State<FullscreenImage>
   }
 
   Widget _senderHeaderColumn({required bool jumpEnabled}) {
-    final column = Column(
+    final nameStyle = context.theme.textTheme.titleLarge!.copyWith(color: Colors.white);
+    final msg = message;
+    Widget name;
+    if (msg == null) {
+      name = const SizedBox.shrink();
+    } else if (msg.isFromMe ?? false) {
+      name = Text('You', style: nameStyle);
+    } else {
+      final handle = msg.handleRelation.target;
+      name = handle == null
+          ? Text('Unknown', style: nameStyle)
+          : Obx(() {
+              final displayName = HandleSvc.getOrCreateHandleState(handle).displayName.value ?? 'Unknown';
+              return Text(displayName, style: nameStyle);
+            });
+    }
+
+    return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Obx(() {
-          final msg = message;
-          if (msg == null) return const SizedBox.shrink();
-          final name = (msg.isFromMe ?? false)
-              ? 'You'
-              : (msg.handleRelation.target != null
-                      ? HandleSvc.getOrCreateHandleState(msg.handleRelation.target!).displayName.value
-                      : null) ??
-                  'Unknown';
-          return Text(name, style: context.theme.textTheme.titleLarge!.copyWith(color: Colors.white));
-        }),
+        name,
         if (message?.dateCreated != null)
           Padding(
             padding: const EdgeInsets.only(top: 2.0),
-            child: Text(
-              samsung
-                  ? intl.DateFormat.jm().add_MMMd().format(message!.dateCreated!)
-                  : intl.DateFormat('EEE').add_jm().format(message!.dateCreated!),
-              style: context.theme.textTheme.bodyLarge!
-                  .copyWith(color: samsung ? Colors.grey : Colors.white),
-            ),
+            child: _senderTimestamp(jumpEnabled: jumpEnabled),
           ),
       ],
     );
+  }
 
-    if (!jumpEnabled) return column;
-
+  Widget _senderTimestamp({required bool jumpEnabled}) {
+    final color = samsung ? Colors.grey : Colors.white;
+    final date = samsung
+        ? intl.DateFormat.jm().add_MMMd().format(message!.dateCreated!)
+        : intl.DateFormat('EEE').add_jm().format(message!.dateCreated!);
+    final label = Text(
+      jumpEnabled ? '$date ›' : date,
+      style: context.theme.textTheme.bodyLarge!.copyWith(color: color),
+    );
+    if (!jumpEnabled) return label;
     return Material(
       color: Colors.transparent,
       child: InkWell(
         onTap: widget.onJumpToMessage,
         borderRadius: BorderRadius.circular(8),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-          child: column,
+          padding: const EdgeInsets.fromLTRB(0, 0, 4, 0),
+          child: label,
         ),
       ),
     );
@@ -267,31 +277,29 @@ class _FullscreenImageState extends State<FullscreenImage>
                     left: false,
                     right: false,
                     bottom: false,
-                    child: SizedBox(
-                      height: kIsDesktop ? 80 : 50,
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Padding(
-                                padding: const EdgeInsets.only(left: 5),
-                                child: CupertinoButton(
-                                  padding: const EdgeInsets.symmetric(horizontal: 5),
-                                  onPressed: () async {
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: const Icon(Icons.close, color: Colors.white),
-                                ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.only(left: 5),
+                              child: CupertinoButton(
+                                padding: const EdgeInsets.symmetric(horizontal: 5),
+                                onPressed: () async {
+                                  Navigator.of(context).pop();
+                                },
+                                child: const Icon(Icons.close, color: Colors.white),
                               ),
-                              if (widget.showInteractions)
-                                Padding(
-                                  padding: const EdgeInsets.only(left: 5.0),
+                            ),
+                            if (widget.showInteractions)
+                              Padding(
+                                padding: const EdgeInsets.only(left: 5.0),
                                   child: _senderHeaderColumn(
                                     jumpEnabled: samsung && widget.onJumpToMessage != null,
                                   ),
-                                ),
+                              ),
                             ],
                           ),
                           !widget.showInteractions
@@ -323,7 +331,6 @@ class _FullscreenImageState extends State<FullscreenImage>
                                 ),
                         ],
                       ),
-                    ),
                   ),
                 ),
               ),

--- a/lib/app/layouts/fullscreen_media/fullscreen_video.dart
+++ b/lib/app/layouts/fullscreen_media/fullscreen_video.dart
@@ -254,40 +254,54 @@ class _FullscreenVideoState extends State<FullscreenVideo> with AutomaticKeepAli
   }
 
   Widget _samsungJumpHeader() {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: widget.onJumpToMessage,
-        borderRadius: BorderRadius.circular(8),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Obx(() {
-                final msg = message;
-                if (msg == null) return const SizedBox.shrink();
-                final name = (msg.isFromMe ?? false)
-                    ? 'You'
-                    : (msg.handleRelation.target != null
-                            ? HandleSvc.getOrCreateHandleState(msg.handleRelation.target!).displayName.value
-                            : null) ??
-                        'Unknown';
-                return Text(name, style: context.theme.textTheme.titleLarge!.copyWith(color: Colors.white));
-              }),
-              if (message?.dateCreated != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 2.0),
-                  child: Text(
-                    intl.DateFormat.jm().add_MMMd().format(message!.dateCreated!),
-                    style: context.theme.textTheme.bodyLarge!.copyWith(color: Colors.grey),
-                  ),
-                ),
-            ],
+    final nameStyle = context.theme.textTheme.titleLarge!.copyWith(color: Colors.white);
+    final msg = message;
+    Widget name;
+    if (msg == null) {
+      name = const SizedBox.shrink();
+    } else if (msg.isFromMe ?? false) {
+      name = Text('You', style: nameStyle);
+    } else {
+      final handle = msg.handleRelation.target;
+      name = handle == null
+          ? Text('Unknown', style: nameStyle)
+          : Obx(() {
+              final displayName = HandleSvc.getOrCreateHandleState(handle).displayName.value ?? 'Unknown';
+              return Text(displayName, style: nameStyle);
+            });
+    }
+
+    final date = message?.dateCreated;
+    Widget? timestamp;
+    if (date != null) {
+      final label = Text(
+        '${intl.DateFormat.jm().add_MMMd().format(date)} ›',
+        style: context.theme.textTheme.bodyLarge!.copyWith(color: Colors.grey),
+      );
+      timestamp = Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: widget.onJumpToMessage,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(0, 0, 4, 0),
+            child: label,
           ),
         ),
-      ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        name,
+        if (timestamp != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2.0),
+            child: timestamp,
+          ),
+      ],
     );
   }
 
@@ -446,29 +460,26 @@ class _FullscreenVideoState extends State<FullscreenVideo> with AutomaticKeepAli
                                 left: false,
                                 right: false,
                                 bottom: false,
-                                child: SizedBox(
-                                  height: kIsDesktop ? 80 : 50,
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    children: [
-                                      Padding(
-                                        padding: const EdgeInsets.only(left: 5),
-                                        child: CupertinoButton(
-                                          padding: const EdgeInsets.symmetric(horizontal: 5),
-                                          onPressed: () => Navigator.of(context).pop(),
-                                          child: const Icon(
-                                            Icons.close,
-                                            color: Colors.white,
-                                          ),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  children: [
+                                    Padding(
+                                      padding: const EdgeInsets.only(left: 5),
+                                      child: CupertinoButton(
+                                        padding: const EdgeInsets.symmetric(horizontal: 5),
+                                        onPressed: () => Navigator.of(context).pop(),
+                                        child: const Icon(
+                                          Icons.close,
+                                          color: Colors.white,
                                         ),
                                       ),
-                                      if (_showSamsungJumpHeader)
-                                        Padding(
-                                          padding: const EdgeInsets.only(left: 5.0),
-                                          child: _samsungJumpHeader(),
-                                        ),
-                                    ],
-                                  ),
+                                    ),
+                                    if (_showSamsungJumpHeader)
+                                      Padding(
+                                        padding: const EdgeInsets.only(left: 5.0),
+                                        child: _samsungJumpHeader(),
+                                      ),
+                                  ],
                                 ),
                               ),
                             ),

--- a/lib/app/layouts/fullscreen_media/fullscreen_video.dart
+++ b/lib/app/layouts/fullscreen_media/fullscreen_video.dart
@@ -421,55 +421,62 @@ class _FullscreenVideoState extends State<FullscreenVideo> with AutomaticKeepAli
                 // On the iOS skin, closing is handled by whichever holder wraps this
                 // widget (ConversationFullscreenHolder's "Done" app bar, or
                 // SingleAttachmentFullscreenViewer's own), driven by `onOverlayToggle`.
+                // Positioned so this Stack's `alignment: Alignment.center` (needed to
+                // center the video) doesn't pull the bar into the middle of the screen.
                 if (!iOS)
-                  Obx(() {
-                    final visible = showPlayPauseOverlay.value || _hover.value;
-                    return MouseRegion(
-                      onEnter: (event) => _hover.value = true,
-                      onExit: (event) => _hover.value = false,
-                      child: AbsorbPointer(
-                        absorbing: !visible,
-                        child: AnimatedOpacity(
-                          opacity: visible ? 1.0 : 0.0,
-                          duration: const Duration(milliseconds: 125),
-                          child: Container(
-                            height: kIsDesktop ? 80 : 100.0,
-                            width: NavigationSvc.width(context),
-                            color: context.theme.colorScheme.shadow.withValues(alpha: samsung ? 1 : 0.65),
-                            child: SafeArea(
-                              left: false,
-                              right: false,
-                              bottom: false,
-                              child: SizedBox(
-                                height: kIsDesktop ? 80 : 50,
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.start,
-                                  children: [
-                                    Padding(
-                                      padding: const EdgeInsets.only(left: 5),
-                                      child: CupertinoButton(
-                                        padding: const EdgeInsets.symmetric(horizontal: 5),
-                                        onPressed: () => Navigator.of(context).pop(),
-                                        child: const Icon(
-                                          Icons.close,
-                                          color: Colors.white,
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    child: Obx(() {
+                      final visible = showPlayPauseOverlay.value || _hover.value;
+                      return MouseRegion(
+                        onEnter: (event) => _hover.value = true,
+                        onExit: (event) => _hover.value = false,
+                        child: AbsorbPointer(
+                          absorbing: !visible,
+                          child: AnimatedOpacity(
+                            opacity: visible ? 1.0 : 0.0,
+                            duration: const Duration(milliseconds: 125),
+                            child: Container(
+                              height: kIsDesktop ? 80 : 100.0,
+                              width: NavigationSvc.width(context),
+                              color: context.theme.colorScheme.shadow.withValues(alpha: samsung ? 1 : 0.65),
+                              child: SafeArea(
+                                left: false,
+                                right: false,
+                                bottom: false,
+                                child: SizedBox(
+                                  height: kIsDesktop ? 80 : 50,
+                                  child: Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: [
+                                      Padding(
+                                        padding: const EdgeInsets.only(left: 5),
+                                        child: CupertinoButton(
+                                          padding: const EdgeInsets.symmetric(horizontal: 5),
+                                          onPressed: () => Navigator.of(context).pop(),
+                                          child: const Icon(
+                                            Icons.close,
+                                            color: Colors.white,
+                                          ),
                                         ),
                                       ),
-                                    ),
-                                    if (_showSamsungJumpHeader)
-                                      Padding(
-                                        padding: const EdgeInsets.only(left: 5.0),
-                                        child: _samsungJumpHeader(),
-                                      ),
-                                  ],
+                                      if (_showSamsungJumpHeader)
+                                        Padding(
+                                          padding: const EdgeInsets.only(left: 5.0),
+                                          child: _samsungJumpHeader(),
+                                        ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                    );
-                  }),
+                      );
+                    }),
+                  ),
                 // Bottom action bar for iOS
                 if (iOS && widget.showInteractions)
                   Positioned(

--- a/lib/app/layouts/fullscreen_media/fullscreen_video.dart
+++ b/lib/app/layouts/fullscreen_media/fullscreen_video.dart
@@ -14,6 +14,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:intl/intl.dart' as intl;
 import 'package:media_kit_video/media_kit_video_controls/media_kit_video_controls.dart' as media_kit_video_controls;
 import 'package:universal_html/html.dart' as html;
 
@@ -26,6 +27,7 @@ class FullscreenVideo extends StatefulWidget {
     this.videoController,
     this.mute,
     this.onOverlayToggle,
+    this.onJumpToMessage,
   });
 
   final PlatformFile file;
@@ -35,6 +37,7 @@ class FullscreenVideo extends StatefulWidget {
   final VideoController? videoController;
   final RxBool? mute;
   final Function(bool)? onOverlayToggle;
+  final VoidCallback? onJumpToMessage;
 
   @override
   State<StatefulWidget> createState() => _FullscreenVideoState();
@@ -51,6 +54,11 @@ class _FullscreenVideoState extends State<FullscreenVideo> with AutomaticKeepAli
   final RxBool muted = SettingsSvc.settings.startVideosMutedFullscreen.value.obs;
   final RxBool showPlayPauseOverlay = true.obs;
   final RxDouble aspectRatio = 1.0.obs;
+
+  Attachment get attachment => widget.attachment;
+  Message? get message => attachment.message.target;
+
+  bool get _showSamsungJumpHeader => samsung && widget.onJumpToMessage != null;
 
   @override
   void initState() {
@@ -245,6 +253,44 @@ class _FullscreenVideoState extends State<FullscreenVideo> with AutomaticKeepAli
     });
   }
 
+  Widget _samsungJumpHeader() {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: widget.onJumpToMessage,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Obx(() {
+                final msg = message;
+                if (msg == null) return const SizedBox.shrink();
+                final name = (msg.isFromMe ?? false)
+                    ? 'You'
+                    : (msg.handleRelation.target != null
+                            ? HandleSvc.getOrCreateHandleState(msg.handleRelation.target!).displayName.value
+                            : null) ??
+                        'Unknown';
+                return Text(name, style: context.theme.textTheme.titleLarge!.copyWith(color: Colors.white));
+              }),
+              if (message?.dateCreated != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2.0),
+                  child: Text(
+                    intl.DateFormat.jm().add_MMMd().format(message!.dateCreated!),
+                    style: context.theme.textTheme.bodyLarge!.copyWith(color: Colors.grey),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   bool get wantKeepAlive => true;
 
@@ -410,6 +456,11 @@ class _FullscreenVideoState extends State<FullscreenVideo> with AutomaticKeepAli
                                         ),
                                       ),
                                     ),
+                                    if (_showSamsungJumpHeader)
+                                      Padding(
+                                        padding: const EdgeInsets.only(left: 5.0),
+                                        child: _samsungJumpHeader(),
+                                      ),
                                   ],
                                 ),
                               ),

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -33,6 +33,9 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   bool fromChatCreator = false;
   bool fromSearchResult = false;
   bool addedRecentPhotoReply = false;
+
+  /// When true, automatic composer focus is rejected until the user taps the field.
+  bool skipComposerFocusOnReturn = false;
   final AutoScrollController scrollController = AutoScrollController();
 
   ConversationViewController(this.chat, {String? tag_}) {
@@ -94,6 +97,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   set replyToMessage(MessageReplyContext? m) {
     _replyToMessage.value = m;
     if (m != null) {
+      releaseComposerFocusSuppression();
       lastFocusedNode.requestFocus();
     }
   }
@@ -185,15 +189,43 @@ class ConversationViewController extends StatefulController with GetSingleTicker
 
     focusNode.addListener(() {
       if (focusNode.hasFocus) {
+        if (skipComposerFocusOnReturn) {
+          _unfocusComposerAfterFrame();
+          return;
+        }
         _subjectWasLastFocused = false;
       }
     });
 
     subjectFocusNode.addListener(() {
       if (subjectFocusNode.hasFocus) {
+        if (skipComposerFocusOnReturn) {
+          _unfocusComposerAfterFrame();
+          return;
+        }
         _subjectWasLastFocused = true;
       }
     });
+  }
+
+  void suppressComposerFocus() {
+    skipComposerFocusOnReturn = true;
+    unfocusComposer();
+  }
+
+  void _unfocusComposerAfterFrame() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (skipComposerFocusOnReturn) unfocusComposer();
+    });
+  }
+
+  void unfocusComposer() {
+    focusNode.unfocus();
+    subjectFocusNode.unfocus();
+  }
+
+  void releaseComposerFocusSuppression() {
+    skipComposerFocusOnReturn = false;
   }
 
   @override


### PR DESCRIPTION
This PR adds jump-to-message for attachments opened from conversation details.

It uses the existing `jumpToMessage` function in `MessagesService`. The UI is only shown for attachments opened from the conversation details pages (Photos & Videos).

- `MediaGalleryCard`, `ConversationFullscreenHolder`, and `ImageDisplay` now take a `showJumpToMessage` prop.
- **iOS:** pill/chip in the fullscreen app bar with the sender’s details (“From You” / “From {name}”), similar to iMessage
- **Material:** “See in chat” overlay button, similar to Google Messages
- **Samsung:** the timestamp label in the fullscreen header (with a `›`) triggers the jump-to-message
- Jumping to a message suppresses focusing the composer / opening the keyboard while it scrolls to.

Tapping jump closes the fullscreen viewer (and conversation details on phone / the tablet right-pane overlays) and scrolls the conversation to the source message.

<table>
  <tr>
    <th align="center">iOS “From X” chip</th>
    <th align="center">Material “See in Chat”</th>
  </tr>
  <tr>
    <td width="50%" align="center">
      <img width="260px" alt="iOS From X chip" src="https://github.com/user-attachments/assets/33da7551-160f-4725-9e38-7196e2aa2ee5" />
    </td>
    <td width="50%" align="center">
      <img width="260px" alt="Material See in Chat" src="https://github.com/user-attachments/assets/086ca487-9cdd-4ce8-9fec-bf31969d671b" />
    </td>
  </tr>
  <tr>
    <th align="center">Samsung Timestamp Chevron</th>
    <th align="center">Jump to Message</th>
  </tr>
  <tr>
    <td width="50%" align="center">
      <img width="260px" alt="Samsung timestamp jump" src="https://github.com/user-attachments/assets/6d15e5b7-bbe1-4d2c-9140-04df52103d94" />
    </td>
    <td width="25%" align="center">
      <video width="25%" controls src="https://github.com/user-attachments/assets/d7565f01-aada-43f1-a806-86f7608a6f96"></video>
    </td>
  </tr>
</table>

#### Links, Locations, and Other Files Not Included
The other attachment types (Links, Locations, and Other Files) open externally, so there is nowhere to put jump-to-message UI. That is the only remaining gap.

A long-term wishlist item I have would be a long-press context menu, see the **Attachment Popups** demo in #2895.

<details>
<summary>Developer notes</summary>

The current `jumpToMessage` method loads *all* messages from the current cursor to the target contiguously. If the target is far away (hundreds or thousands of messages), that can take a long time. Conversation view depends on those messages being contiguous, so a window around the target was not an option here.

The feature still works; a proper fix would be refactoring Messages service to load non-contiguous windows. Search already loads isolated windows, but that path has its own issues (#2269).

</details>

## Additional bug fixes

- **Samsung fullscreen viewer:** Requested Save and Share actions on the image viewer (parity with Material)
- **Samsung fullscreen video:** header is pinned to the top of the screen instead of floating in the middle
- **Redacted mode:** Material fullscreen viewer no longer leaks contact names; Samsung conversation headers use `formattedAddress` instead of the raw handle address

----

<details>
<summary>Files Changed</summary>

`lib/app/layouts/conversation_details/conversation_details.dart` — skip refocusing the composer when returning from jump-to-message

`lib/app/layouts/conversation_details/widgets/media_gallery_card.dart` — add `showJumpToMessage` and pass it through to the fullscreen viewer

`lib/app/layouts/conversation_details/widgets/sections/documents/documents_section.dart` — enable jump-to-message on document gallery cards

`lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart` — enable jump-to-message on photo/video gallery cards

`lib/app/layouts/conversation_view/pages/conversation_view.dart` — release composer-focus suppression when swiping to open the keyboard

`lib/app/layouts/conversation_view/widgets/header/material_header.dart` — stop Samsung conversation headers from leaking raw addresses in redacted mode

`lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart` — release composer-focus suppression when the user taps the text field

`lib/app/layouts/fullscreen_media/conversation_fullscreen_holder.dart` — jump-to-message navigation plus iOS “From X” chip and Material “See in chat” button

`lib/app/layouts/fullscreen_media/fullscreen_image.dart` — Samsung timestamp jump target, plus Save and Share actions

`lib/app/layouts/fullscreen_media/fullscreen_video.dart` — Samsung timestamp jump target and pin the video header to the top of the screen

`lib/services/ui/chat/conversation_view_controller.dart` — add composer-focus suppression so jump-to-message does not open the keyboard

</details>