### PR TITLE
fix: don't rewind a chat's latest-message pointer to an older message

### DIFF
--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -1319,9 +1319,29 @@ class ChatsService {
   /// Update chat latest message and subtitle in response to a new or updated message.
   /// Called by IncomingMessageHandler and SyncService to keep ChatState as the single
   /// source of truth for the conversation tile subtitle.
-  void updateChatLatestMessage(String chatGuid, Message message) {
+  ///
+  /// Only moves the latest-message pointer forward in time — sync can report an
+  /// older delta message as a chat's latest, which would rewind its sort order.
+  /// The 2s tolerance allows a temp->real GUID swap. [allowOlder] opts out for the
+  /// post-deletion recompute, which must fall back to an older surviving message.
+  void updateChatLatestMessage(String chatGuid, Message message, {bool allowOlder = false}) {
     final state = getChatState(chatGuid);
     if (state == null) return;
+
+    if (!allowOlder) {
+      final current = state.latestMessage.value;
+      final currentDate = current?.dateCreated;
+      final incomingDate = message.dateCreated;
+      const staleTolerance = Duration(seconds: 2);
+      if (current != null &&
+          current.guid != message.guid &&
+          currentDate != null &&
+          currentDate.millisecondsSinceEpoch > 0 &&
+          incomingDate != null &&
+          incomingDate.isBefore(currentDate.subtract(staleTolerance))) {
+        return;
+      }
+    }
 
     state.updateLatestMessageInternal(message);
     final redacted = SettingsSvc.settings.redactedMode.value;

--- a/lib/services/ui/message/messages_service.dart
+++ b/lib/services/ui/message/messages_service.dart
@@ -1262,7 +1262,9 @@ class MessagesService extends GetxController {
     if (chat == null) return;
     final latest = Chat.getMessages(chat, limit: 1);
     if (latest.isNotEmpty) {
-      ChatsSvc.updateChatLatestMessage(tag, latest.first);
+      // The newest message was just deleted, so the surviving latest is older
+      // than the current pointer — allow the downgrade here specifically.
+      ChatsSvc.updateChatLatestMessage(tag, latest.first, allowOlder: true);
     }
   }
 


### PR DESCRIPTION
**What**

`updateChatLatestMessage` set `ChatState.latestMessage` unconditionally, so an older message could replace a newer one and rewind a chat's position in the list.

**How it shows up**

Incremental sync reports the newest message *in its delta* per chat and passes it here. When that delta message is an edit, a read-receipt, or a backfill on a days-old message, it overwrites the chat's actual-newest message as "latest", so the chat sorts by the old date and drops down the list even though it has newer messages. On a busy chat it repeats on every resume-sync, so an actively-used chat keeps falling out of view.

Observed: a chat surfaced at the top on a message dated today, then a sync pass fed it a message dated 11 days earlier and it dropped ~15 positions; the next new message brought it back, and the following sync knocked it down again.

**Fix**

Only advance the pointer forward in time. `MessagesService` already does exactly this at its own load call site (the `offset == 0` freshness guard, "loading older pages must never overwrite a newer latest"); this centralises the same rule so every caller, including sync, is covered. A 2s tolerance keeps a temp->real GUID swap from being treated as older. `allowOlder` opts out for the post-deletion recompute, which must fall back to an older surviving message.

Verified on Android and Linux.
