### PR TITLE
Fix Settings Dropdown

### DIFF
--- a/lib/app/layouts/settings/widgets/content/settings_dropdown.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_dropdown.dart
@@ -70,38 +70,40 @@ class SettingsOptions<T extends Object> extends StatelessWidget {
     }
     return Container(
       color: Colors.transparent,
+      width: double.infinity,
       child: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        child: Wrap(
+          alignment: WrapAlignment.spaceBetween,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          runAlignment: WrapAlignment.spaceBetween,
+          runSpacing: 8.0,
+          spacing: 15.0,
           children: [
             if (leading != null)
               Padding(
                 padding: const EdgeInsets.only(left: 5.0, right: 10.0),
                 child: leading,
               ),
-            Expanded(
-              child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: context.theme.textTheme.bodyLarge,
-                    ),
-                    (subtitle != null)
-                        ? Padding(
-                            padding: const EdgeInsets.only(top: 3.0),
-                            child: Text(
-                              subtitle ?? "",
-                              style: context.theme.textTheme.bodySmall!
-                                  .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
-                            ),
-                          )
-                        : const SizedBox.shrink(),
-                  ]),
-            ),
-            const SizedBox(width: 15),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: context.theme.textTheme.bodyLarge,
+                ),
+                (subtitle != null)
+                    ? Padding(
+                        padding: const EdgeInsets.only(top: 3.0),
+                        child: Text(
+                          subtitle ?? "",
+                          style: context.theme.textTheme.bodySmall!
+                              .copyWith(color: context.theme.colorScheme.onSurfaceVariant),
+                        ),
+                      )
+                    : const SizedBox.shrink(),
+            ]),
             Builder(
               builder: (context) {
                 final widget = Container(

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -53,49 +53,47 @@ List<Widget> buildSettingItemList({
 }) {
   // return searchable items, headers, tiles, or sections
   return [
-    if (!kIsWeb && (!iOS || kIsDesktop))
-      SearchableSettingItem(
-        title: "Profile",
-        child: SettingsHeader(
-          height: 40,
-          iosSubtitle: iosSubtitle,
-          materialSubtitle: materialSubtitle,
-          text: "Profile",
-        ),
+    SearchableSettingItem(
+      title: "Profile",
+      child: SettingsHeader(
+        height: 40,
+        iosSubtitle: iosSubtitle,
+        materialSubtitle: materialSubtitle,
+        text: "Profile",
       ),
-    if (!kIsWeb && (!iOS || kIsDesktop))
-      SearchableSettingItem(
-        title: SettingsSvc.settings.redactedMode.value && SettingsSvc.settings.hideContactInfo.value
-            ? "User Name"
-            : SettingsSvc.settings.userName.value,
-        child: SettingsSection(
-          backgroundColor: tileColor,
-          children: [
-            SettingsTile(
-              backgroundColor: tileColor,
-              title: SettingsSvc.settings.redactedMode.value && SettingsSvc.settings.hideContactInfo.value
-                  ? "User Name"
-                  : SettingsSvc.settings.userName.value,
-              subtitle: "Tap to view more details",
-              onTap: () {
-                ns.pushAndRemoveSettingsUntil(
-                  context,
-                  const ProfilePanel(),
-                  (Route route) => route.isFirst,
-                );
-              },
-              leading: const ContactAvatarWidget(
-                handle: null,
-                borderThickness: 0.1,
-                editable: false,
-                fontSize: 22,
-                size: 50,
-              ),
-              trailing: const NextButton(),
+    ),
+    SearchableSettingItem(
+      title: SettingsSvc.settings.redactedMode.value && SettingsSvc.settings.hideContactInfo.value
+          ? "User Name"
+          : SettingsSvc.settings.userName.value,
+      child: SettingsSection(
+        backgroundColor: tileColor,
+        children: [
+          SettingsTile(
+            backgroundColor: tileColor,
+            title: SettingsSvc.settings.redactedMode.value && SettingsSvc.settings.hideContactInfo.value
+                ? "User Name"
+                : SettingsSvc.settings.userName.value,
+            subtitle: "Tap to view more details",
+            onTap: () {
+              ns.pushAndRemoveSettingsUntil(
+                context,
+                const ProfilePanel(),
+                (Route route) => route.isFirst,
+              );
+            },
+            leading: const ContactAvatarWidget(
+              handle: null,
+              borderThickness: 0.1,
+              editable: false,
+              fontSize: 22,
+              size: 50,
             ),
-          ],
-        ),
+            trailing: const NextButton(),
+          ),
+        ],
       ),
+    ),
     if (!kIsWeb)
       SearchableSettingItem(
         title: "Server & Message Management",


### PR DESCRIPTION
- The icloud account header is now unconditionally visible in settings
- Made the settings dropdown responsive so it wraps when there isn't enough space

<table>
<tr>
 <th>Before</th>
 <th>After</th>
</tr>
<tr>
<td>
<img width="239" height="727" alt="image" src="https://github.com/user-attachments/assets/36171314-d522-43bb-8069-2baf8b267852" />
</td>
 <td>
<img width="242" height="511" alt="image" src="https://github.com/user-attachments/assets/95782a73-82ca-4064-8761-acc385a53275" />
</td>
</tr>
</table>

- On a related note, we should probably redact this dropdown when redacted mode is enabled.