### PR TITLE
Fix warm cache on windows

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,63 @@
+name: Setup Flutter
+description: Install fvm + the pinned Flutter SDK, resolve dependencies, and cache both.
+
+inputs:
+  flutter-version:
+    description: Flutter SDK version to install via fvm.
+    required: true
+  fvm-version:
+    description: fvm version to activate.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Dart
+      uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+
+    - name: Install fvm
+      run: dart pub global activate fvm "${{ inputs.fvm-version }}"
+      shell: bash
+
+    # Split restore/save: actions/cache only writes when the whole job succeeds, so a
+    # later analyze, compile or signing failure would discard a freshly downloaded SDK
+    # and pub cache. Each save below runs as soon as its directory is populated instead.
+    - name: Restore Flutter SDK (fvm)
+      id: cache-fvm
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: ~/fvm
+        key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ inputs.flutter-version }}
+
+    - name: Restore pub packages
+      id: cache-pub
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: ~/.pub-cache
+        key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
+
+    # `dart pub global run fvm:main` rather than the `fvm` shim: the shim isn't callable
+    # from Git Bash on the Windows runner, and this form works on all three platforms.
+    - name: Select Flutter version
+      run: dart pub global run fvm:main use "${{ inputs.flutter-version }}" --force
+      shell: bash
+
+    # No explicit status check, so the saves inherit the implicit success() — they never
+    # persist a half-populated directory left behind by a step that failed.
+    - name: Save Flutter SDK (fvm)
+      if: steps.cache-fvm.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: ~/fvm
+        key: ${{ steps.cache-fvm.outputs.cache-primary-key }}
+
+    - name: Pub get
+      run: dart pub global run fvm:main flutter pub get --enforce-lockfile
+      shell: bash
+
+    - name: Save pub packages
+      if: steps.cache-pub.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: ~/.pub-cache
+        key: ${{ steps.cache-pub.outputs.cache-primary-key }}

--- a/.github/workflows/desktop-builds.yml
+++ b/.github/workflows/desktop-builds.yml
@@ -35,26 +35,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-
-      - name: Install fvm
-        run: dart pub global activate fvm "$FVM_VERSION"
-        shell: bash
-
-      # Keyed on the Flutter version so the SDK is only re-downloaded when the
-      # version actually changes — not on every build-script edit.
-      - name: Cache Flutter SDK (fvm)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      # Also resolves dependencies, so build.ps1's own pub get below is a no-op.
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ~/fvm
-          key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ env.FLUTTER_VERSION }}
-
-      - name: Cache pub packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          fvm-version: ${{ env.FVM_VERSION }}
 
       - name: Write .env
         run: echo "KLIPY_API_KEY=${{ secrets.KLIPY_API_KEY }}" > .env
@@ -278,26 +264,12 @@ jobs:
             libayatana-appindicator3-dev \
             libnotify-dev
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-
-      - name: Install fvm
-        run: dart pub global activate fvm "$FVM_VERSION"
-        shell: bash
-
-      # Keyed on the Flutter version so the SDK is only re-downloaded when the
-      # version actually changes — not on every build-script edit.
-      - name: Cache Flutter SDK (fvm)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      # Also resolves dependencies, so build.sh's own pub get below is a no-op.
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ~/fvm
-          key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ env.FLUTTER_VERSION }}
-
-      - name: Cache pub packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          fvm-version: ${{ env.FVM_VERSION }}
 
       - name: Write .env
         run: echo "KLIPY_API_KEY=${{ secrets.KLIPY_API_KEY }}" > .env

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   # Warm the SDK/pub caches in master's scope (see warm-cache job below).
   push:
-    branches: [master]
+    branches: [master, jjoelj-patch-1]
   workflow_dispatch:
 
 # Cancel superseded runs when a PR is pushed again.
@@ -63,11 +63,11 @@ jobs:
           key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
 
       - name: Select Flutter version
-        run: fvm use "$FLUTTER_VERSION" --force
+        run: dart pub global run fvm:main use "$FLUTTER_VERSION" --force
         shell: bash
 
       - name: Pub get
-        run: fvm flutter pub get --enforce-lockfile
+        run: dart pub global run fvm:main flutter pub get --enforce-lockfile
         shell: bash
 
   analyze:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,32 +43,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-
-      - name: Install fvm
-        run: dart pub global activate fvm "$FVM_VERSION"
-        shell: bash
-
-      - name: Cache Flutter SDK (fvm)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ~/fvm
-          key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ env.FLUTTER_VERSION }}
-
-      - name: Cache pub packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
-
-      - name: Select Flutter version
-        run: dart pub global run fvm:main use "$FLUTTER_VERSION" --force
-        shell: bash
-
-      - name: Pub get
-        run: dart pub global run fvm:main flutter pub get --enforce-lockfile
-        shell: bash
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          fvm-version: ${{ env.FVM_VERSION }}
 
   analyze:
     if: github.event_name != 'push'
@@ -78,30 +57,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-
-      - name: Install fvm
-        run: dart pub global activate fvm "$FVM_VERSION"
-        shell: bash
-
-      - name: Cache Flutter SDK (fvm)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ~/fvm
-          key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ env.FLUTTER_VERSION }}
-
-      - name: Cache pub packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
-
-      - name: Select Flutter version
-        run: fvm use "$FLUTTER_VERSION" --force
-
-      - name: Pub get
-        run: fvm flutter pub get --enforce-lockfile
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          fvm-version: ${{ env.FVM_VERSION }}
 
       - name: Write .env
         run: echo "KLIPY_API_KEY=" > .env
@@ -128,36 +88,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-
-      - name: Install fvm
-        run: dart pub global activate fvm "$FVM_VERSION"
-        shell: bash
-
-      - name: Cache Flutter SDK (fvm)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ~/fvm
-          key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ env.FLUTTER_VERSION }}
-
-      - name: Cache pub packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
-
-      - name: Select Flutter version
-        run: fvm use $env:FLUTTER_VERSION --force
-        shell: pwsh
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          fvm-version: ${{ env.FVM_VERSION }}
 
       - name: Write .env
         run: echo "KLIPY_API_KEY=" > .env
         shell: bash
-
-      - name: Pub get
-        run: fvm flutter pub get --enforce-lockfile
-        shell: pwsh
 
       # Compile only — no msix/installer packaging (that's the release workflow).
       # --no-pub: reuse the lockfile-enforced resolution from the Pub get step.
@@ -193,33 +132,14 @@ jobs:
             libayatana-appindicator3-dev \
             libnotify-dev
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
-
-      - name: Install fvm
-        run: dart pub global activate fvm "$FVM_VERSION"
-        shell: bash
-
-      - name: Cache Flutter SDK (fvm)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      - name: Setup Flutter
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ~/fvm
-          key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ env.FLUTTER_VERSION }}
-
-      - name: Cache pub packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}
-
-      - name: Select Flutter version
-        run: fvm use "$FLUTTER_VERSION" --force
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          fvm-version: ${{ env.FVM_VERSION }}
 
       - name: Write .env
         run: echo "KLIPY_API_KEY=" > .env
-
-      - name: Pub get
-        run: fvm flutter pub get --enforce-lockfile
 
       # Compile only — no tarball packaging (that's the release workflow).
       # --no-pub: reuse the lockfile-enforced resolution from the Pub get step.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   # Warm the SDK/pub caches in master's scope (see warm-cache job below).
   push:
-    branches: [master, jjoelj-patch-1]
+    branches: [master]
   workflow_dispatch:
 
 # Cancel superseded runs when a PR is pushed again.


### PR DESCRIPTION
Runs `fvm` with `dart pub global run fvm:main` to let it work on Windows.

This PR also moves the Flutter and Pub setup/cache into a separate action so it's easier to maintain and caches things even if the build fails