### PR TITLE
Improve Windows Build script

### DIFF
--- a/.github/workflows/desktop-builds.yml
+++ b/.github/workflows/desktop-builds.yml
@@ -10,6 +10,10 @@ on:
         description: "Run SignPath signing on this manual build (test the signing pipeline without a release tag)"
         type: boolean
         default: false
+      release_signing:
+        description: "Sign with the release cert instead of the test cert (implies sign). Artifacts are still not attached to any release."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -17,6 +21,9 @@ permissions:
 env:
   FLUTTER_VERSION: "3.44.6"
   FVM_VERSION: "4.1.2"
+  # Which SignPath policy/cert to use. Tags always sign for release; a manual run
+  # can opt in when a release build needs re-signing outside a tag push.
+  RELEASE_SIGNING: ${{ startsWith(github.ref, 'refs/tags/') || inputs.release_signing }}
 
 jobs:
   windows:
@@ -26,9 +33,6 @@ jobs:
     timeout-minutes: 60
     env:
       SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
-      # Must match the signing cert subject: release cert on tags, test cert on manual builds.
-      SIGNED_MSIX_PUBLISHER: "${{ startsWith(github.ref, 'refs/tags/') && 'CN=SignPath Foundation,O=SignPath Foundation,C=US,S=DE,L=Lewes' || 'CN=Test certificate for ''BlueBubbles [OSS]''' }}"
-      SIGNED_MSIX_IDENTITY: BlueBubbles.BlueBubbles
     steps:
       - name: Support long paths
         run: git config --system core.longpaths true
@@ -66,12 +70,12 @@ jobs:
         run: .\windows\build.ps1 -Phase Build
         shell: pwsh
 
-      # sign=true when: token present AND (release tag or manual sign=true).
+      # sign=true when: token present AND (release tag or manual sign/release_signing).
       - name: Determine signing
         id: gate
         shell: bash
         run: |
-          if [ -n "$SIGNPATH_API_TOKEN" ] && { [[ "$GITHUB_REF" == refs/tags/* ]] || [ "${{ inputs.sign }}" = "true" ]; }; then
+          if [ -n "$SIGNPATH_API_TOKEN" ] && { [ "$RELEASE_SIGNING" = "true" ] || [ "${{ inputs.sign }}" = "true" ]; }; then
             echo "sign=true" >> "$GITHUB_OUTPUT"
           else
             echo "sign=false" >> "$GITHUB_OUTPUT"
@@ -103,7 +107,7 @@ jobs:
           api-token: ${{ env.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ startsWith(github.ref, 'refs/tags/') && 'release-signing' || 'test-signing' }}
+          signing-policy-slug: ${{ env.RELEASE_SIGNING == 'true' && 'release-signing' || 'test-signing' }}
           artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIG_APP }}
           github-artifact-id: ${{ steps.upload-payload.outputs.artifact-id }}
           wait-for-completion: true
@@ -121,6 +125,10 @@ jobs:
         shell: pwsh
         env:
           PACKAGE_MSIX: ${{ steps.sign-payload.outcome == 'success' }}
+          # Must match the signing cert subject: release cert when signing for release, else test cert.
+          # MakeAppx requires ", " (comma-space) between RDNs — bare commas fail with 0x80080204.
+          SIGNED_MSIX_PUBLISHER: "${{ env.RELEASE_SIGNING == 'true' && 'CN=SignPath Foundation, O=SignPath Foundation, C=US, S=DE, L=Lewes' || 'CN=Test certificate for ''BlueBubbles [OSS]''' }}"
+          SIGNED_MSIX_IDENTITY: BlueBubbles.BlueBubbles
 
       - name: Upload unsigned installer artifact
         id: upload-installer
@@ -163,7 +171,7 @@ jobs:
           api-token: ${{ env.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
-          signing-policy-slug: ${{ startsWith(github.ref, 'refs/tags/') && 'release-signing' || 'test-signing' }}
+          signing-policy-slug: ${{ env.RELEASE_SIGNING == 'true' && 'release-signing' || 'test-signing' }}
           artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIG_INSTALLER }}
           github-artifact-id: ${{ steps.upload-installer.outputs.artifact-id }}
           wait-for-completion: true
@@ -171,7 +179,7 @@ jobs:
 
       - name: Sign release msix (SignPath)
         id: sign-msix
-        if: ${{ steps.gate.outputs.sign == 'true' && steps.sign-payload.outcome == 'success' && startsWith(github.ref, 'refs/tags/') && steps.upload-msix.outputs.artifact-id != '' }}
+        if: ${{ steps.gate.outputs.sign == 'true' && steps.sign-payload.outcome == 'success' && env.RELEASE_SIGNING == 'true' && steps.upload-msix.outputs.artifact-id != '' }}
         continue-on-error: true
         uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd
         with:
@@ -186,7 +194,7 @@ jobs:
 
       - name: Sign test msix (SignPath)
         id: sign-msix-test
-        if: ${{ steps.gate.outputs.sign == 'true' && steps.sign-payload.outcome == 'success' && !startsWith(github.ref, 'refs/tags/') && steps.upload-msix.outputs.artifact-id != '' }}
+        if: ${{ steps.gate.outputs.sign == 'true' && steps.sign-payload.outcome == 'success' && env.RELEASE_SIGNING != 'true' && steps.upload-msix.outputs.artifact-id != '' }}
         uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd
         with:
           api-token: ${{ env.SIGNPATH_API_TOKEN }}

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -18,6 +18,54 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Ctrl+C tears PowerShell down before `finally`/`trap` get a look in, and the fvm/flutter/dart
+# batch shims leave dart.exe, MSBuild and friends building away in the background. So take the
+# console signal in .NET instead — it fires on a separate thread while the build command is
+# still blocking the main one — kill the process tree from there, then exit.
+Add-Type -Name Ctrl -Namespace Build -MemberDefinition @'
+    [DllImport("kernel32.dll")] static extern uint GetConsoleProcessList(uint[] pids, uint count);
+    [DllImport("kernel32.dll")] static extern IntPtr GetStdHandle(int which);
+    [DllImport("kernel32.dll")] static extern bool GetConsoleMode(IntPtr handle, out uint mode);
+    [DllImport("kernel32.dll")] static extern bool SetConsoleMode(IntPtr handle, uint mode);
+
+    static uint _inMode, _outMode;
+    static System.Collections.Generic.List<int> _spare;   // us, plus whatever was here first
+
+    // Everything attached to this console: the set Windows warns about when you close the tab,
+    // and unlike a parent-PID walk it still finds a dart.exe whose cmd.exe shim already exited.
+    // ponytail: misses anything that made its own console — that doesn't hold the tab open either.
+    static System.Collections.Generic.List<int> Attached() {
+        var pids = new uint[256];
+        uint found = GetConsoleProcessList(pids, 256);
+        var list = new System.Collections.Generic.List<int>();
+        for (int i = 0; i < found && i < 256; i++) list.Add((int)pids[i]);
+        return list;
+    }
+
+    public static void KillTreeOnCtrlC() {
+        _spare = Attached();
+        GetConsoleMode(GetStdHandle(-10), out _inMode);
+        GetConsoleMode(GetStdHandle(-11), out _outMode);
+        System.Console.CancelKeyPress += delegate(object sender, System.ConsoleCancelEventArgs e) {
+            // e.Cancel stays false: kill what the build started, then let PowerShell handle the
+            // signal as usual. Killing this process too would take the terminal with it.
+            foreach (var pid in Attached()) {
+                if (_spare.Contains(pid)) continue;
+                try {
+                    var p = System.Diagnostics.Process.GetProcessById(pid);
+                    System.Console.Error.WriteLine("Stopping " + p.ProcessName + " (" + pid + ")");
+                    p.Kill();
+                } catch { }   // already gone, or not ours to touch
+            }
+            // A killed dart.exe never restores the console mode it changed
+            SetConsoleMode(GetStdHandle(-10), _inMode);
+            SetConsoleMode(GetStdHandle(-11), _outMode);
+            System.Console.Error.WriteLine("Build cancelled.");
+        };
+    }
+'@
+[Build.Ctrl]::KillTreeOnCtrlC()
+
 # Flutter version to build with; override with the FLUTTER_VERSION env var.
 $flutterVersion = if ($env:FLUTTER_VERSION) { $env:FLUTTER_VERSION } else { '3.44.6' }
 

--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -141,6 +141,8 @@ if ($Phase -ne 'Build') {
         )
         if ($env:SIGNED_MSIX_IDENTITY) { $msixArgs += @('--identity-name', $env:SIGNED_MSIX_IDENTITY) }
         Invoke-Checked $dartCmd run msix:create @msixArgs
+        # fvm swallows the child exit code, so Invoke-Checked can't see a msix failure.
+        if (-not (Test-Path 'windows\bluebubbles.msix')) { throw "msix:create did not produce windows\bluebubbles.msix — see the output above." }
     }
 
     # Compile the Inno Setup installer


### PR DESCRIPTION
- Support Ctrl-C properly to exit the Windows build script
- Raise on msix errors
- Support manually triggering release mode builds (won't attach to any release)