### PR TITLE
Desktop 2.0.0.0

### DIFF
--- a/flatpak/app.bluebubbles.BlueBubbles.metainfo.xml
+++ b/flatpak/app.bluebubbles.BlueBubbles.metainfo.xml
@@ -44,28 +44,79 @@
   <launchable type="desktop-id">app.bluebubbles.BlueBubbles.desktop</launchable>
   <screenshots>
     <screenshot type="default" xml:lang="en">
-      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v1.15.4%2B73-desktop/flatpak/screenshots/Ios%20Skin.png</image>
+      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v2.0.0%2B89/flatpak/screenshots/Ios%20Skin.png</image>
       <caption>Chat with friends and family</caption>
     </screenshot>
     <screenshot xml:lang="en">
-      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v1.15.4%2B73-desktop/flatpak/screenshots/Dark.png</image>
+      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v2.0.0%2B89/flatpak/screenshots/Dark.png</image>
       <caption>Dark Mode</caption>
     </screenshot>
     <screenshot xml:lang="en">
-      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v1.15.4%2B73-desktop/flatpak/screenshots/Settings.png</image>
+      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v2.0.0%2B89/flatpak/screenshots/Settings.png</image>
       <caption>Extensive Customization</caption>
     </screenshot>
     <screenshot xml:lang="en">
-      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v1.15.4%2B73-desktop/flatpak/screenshots/Material%20Skin.png</image>
+      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v2.0.0%2B89/flatpak/screenshots/Material%20Skin.png</image>
       <caption>Material Skin</caption>
     </screenshot>
     <screenshot xml:lang="en">
-      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v1.15.4%2B73-desktop/flatpak/screenshots/Samsung%20Skin.png</image>
+      <image>https://raw.githubusercontent.com/BlueBubblesApp/bluebubbles-app/refs/tags/v2.0.0%2B89/flatpak/screenshots/Samsung%20Skin.png</image>
       <caption>Samsung Skin</caption>
     </screenshot>
   </screenshots>
 
   <releases>
+    <release date="2026-07-23" version="2.0.0.0">
+      <url type="details">https://github.com/BlueBubblesApp/bluebubbles-app/releases/tag/v2.0.0%2B89</url>
+      <description>
+        <p>The Big Stuff</p>
+        <ul>
+          <li>Major Performance Improvements</li>
+          <li>Custom Groups &amp; Chat Filtering</li>
+          <li>Theme Studio (Revamped Advanced Theming)</li>
+          <li>Improved New Chat Creator</li>
+          <li>Improved Share Sheet/Menu</li>
+          <li>Skin-Specific Dialogs</li>
+          <li>Improved Attachment Explorer in the Conversation Details Page</li>
+          <li>Send a Quick Reaction via a Notification Button</li>
+          <li>Chat-Specific Custom Theming</li>
+          <li>Chat-Specific Custom Backgrounds</li>
+          <li>Live Photo Support</li>
+          <li>Digital Pass Support</li>
+          <li>Revamped Server Management Page</li>
+          <li>Image Gallery for Messages with Multiple Images</li>
+          <li>New splash screen so the app shows something while it loads</li>
+          <li>Option to fully hide the title bar</li>
+          <li>Open images in your system's native image viewer</li>
+        </ul>
+        <p>The Small Stuff</p>
+        <ul>
+          <li>Improved invisible ink consistency to prevent leaks</li>
+          <li>Improved page &amp; UI consistency</li>
+          <li>Nickname support &amp; default</li>
+          <li>Settings Backup/Restore now supports pinned chats &amp; custom groups</li>
+          <li>Improved Attachments UI &amp; Full Screen Viewer</li>
+          <li>Redesigned Scheduled Messages Page</li>
+          <li>iMessage Statistics Page</li>
+          <li>Improved Redacted Mode</li>
+          <li>Improve camera quality</li>
+          <li>Improved video playback quality</li>
+          <li>Improved connection status bar</li>
+          <li>Improved notification reliability</li>
+          <li>Improved contact syncing &amp; matching</li>
+          <li>View and restore recently deleted chats</li>
+          <li>Cancel a message while it is still sending</li>
+          <li>Additional Material You preset themes with improved previews</li>
+          <li>New settings for image preview quality and maximum concurrent downloads</li>
+          <li>Improved error pages, error reporting, and crash guards</li>
+          <li>System GIF paste and clipboard history support</li>
+          <li>Fixes launch at startup and opening file locations under Flatpak</li>
+          <li>Fixes clipboard handling on Linux</li>
+          <li>The window now unminimizes when opening a chat from a notification</li>
+          <li>Fixes the window failing to close on Linux</li>
+        </ul>
+      </description>
+    </release>
     <release date="2026-07-19" version="1.15.104.0" type="development" />
     <release date="2026-07-18" version="1.15.103.0" type="development" />
     <release date="2026-06-12" version="1.15.102.0" type="development" />

--- a/lib/app/layouts/settings/pages/server/backup_restore_panel.dart
+++ b/lib/app/layouts/settings/pages/server/backup_restore_panel.dart
@@ -291,13 +291,13 @@ class _BackupRestorePanelState extends State<BackupRestorePanel> with ThemeHelpe
                                       "Are you sure you want to replace this backup with your current Settings?",
                                     ),
                                     onYes: () {
-                                      Navigator.of(_context).pop();
+                                      Navigator.of(_context, rootNavigator: true).pop();
                                       yes = true;
                                     },
                                   );
                                   if (!yes) return;
                                 } else {
-                                  Navigator.of(_context).pop();
+                                  Navigator.of(_context, rootNavigator: true).pop();
                                 }
                                 Map<String, dynamic> json = SettingsSvc.settings.toMap(includeAll: false);
                                 if (desc.isNotEmpty) {
@@ -332,23 +332,28 @@ class _BackupRestorePanelState extends State<BackupRestorePanel> with ThemeHelpe
                                   }
                                   final downloadsDir = await FilesystemSvc.downloadsDirectory;
                                   String filePath = join(downloadsDir, "BB-Settings-$name.json");
+                                  final String jsonString = jsonEncode(json);
                                   if (kIsDesktop) {
+                                    // Let the portal write the file: passing bytes lands it at the
+                                    // real chosen location (sandbox-safe) so reveal opens the right
+                                    // folder, instead of a separate write to a non-granted path.
                                     String? _filePath = await FilePicker.saveFile(
                                       initialDirectory: downloadsDir,
                                       dialogTitle: 'Choose a location to save this file',
                                       fileName: "BB-Settings-$name.json",
                                       type: FileType.custom,
                                       allowedExtensions: ["json"],
+                                      bytes: utf8.encode(jsonString),
                                     );
                                     if (_filePath == null) {
                                       return showSnackbar('Failed', 'You didn\'t select a file path!');
                                     }
                                     filePath = _filePath;
+                                  } else {
+                                    File file = File(filePath);
+                                    await file.create(recursive: true);
+                                    await file.writeAsString(jsonString);
                                   }
-                                  File file = File(filePath);
-                                  await file.create(recursive: true);
-                                  String jsonString = jsonEncode(json);
-                                  await file.writeAsString(jsonString);
                                   showSnackbar(
                                     "Success",
                                     "Settings exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
@@ -746,21 +751,26 @@ class _BackupRestorePanelState extends State<BackupRestorePanel> with ThemeHelpe
                                 final downloadsDir = await FilesystemSvc.downloadsDirectory;
                                 String filePath = join(downloadsDir, themeFilename);
                                 if (kIsDesktop) {
+                                  // Let the portal write the file: passing bytes lands it at the
+                                  // real chosen location (sandbox-safe) so reveal opens the right
+                                  // folder, instead of a separate write to a non-granted path.
                                   String? _filePath = await FilePicker.saveFile(
                                     initialDirectory: downloadsDir,
                                     dialogTitle: 'Choose a location to save this file',
                                     fileName: themeFilename,
                                     type: FileType.custom,
                                     allowedExtensions: ["json"],
+                                    bytes: utf8.encode(jsonStr),
                                   );
                                   if (_filePath == null) {
                                     return showSnackbar('Failed', 'You didn\'t select a file path!');
                                   }
                                   filePath = _filePath;
+                                } else {
+                                  File file = File(filePath);
+                                  await file.create(recursive: true);
+                                  await file.writeAsString(jsonStr);
                                 }
-                                File file = File(filePath);
-                                await file.create(recursive: true);
-                                await file.writeAsString(jsonStr);
                                 showSnackbar(
                                   "Success",
                                   "Theming exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -271,66 +271,22 @@ class AttachmentsService extends GetxService {
 
       if (savePath == null) {
         return showSnackbar('Error', 'You didn\'t select a file path!');
-      } else if (await File(savePath).exists()) {
-        await showBBDialog(
-          context: Get.context!,
-          barrierDismissible: false,
-          title: "Confirm save",
-          body: "This file already exists.\nAre you sure you want to overwrite it?",
-          actions: <BBDialogAction>[
-            BBDialogAction(
-              text: "No",
-              onPressed: () => Navigator.of(Get.context!, rootNavigator: true).pop(),
-            ),
-            BBDialogAction(
-              text: "Yes",
-              isDefault: true,
-              onPressed: () async {
-                if (file.path != null) {
-                  await File(file.path!).copy(savePath);
-                } else {
-                  await File(savePath).writeAsBytes(file.bytes!);
-                }
-                Navigator.of(Get.context!, rootNavigator: true).pop();
-                showSnackbar(
-                  'Success',
-                  'Saved attachment to $savePath!',
-                  durationMs: 3000,
-                  button: TextButton(
-                    style: TextButton.styleFrom(
-                      backgroundColor: Get.theme.colorScheme.surfaceVariant,
-                    ),
-                    onPressed: () {
-                      launchUrl(Uri.file(savePath));
-                    },
-                    child: Text("OPEN FILE", style: TextStyle(color: Get.theme.colorScheme.onSurfaceVariant)),
-                  ),
-                );
-              },
-            ),
-          ],
-        );
-      } else {
-        if (file.path != null) {
-          await File(file.path!).copy(savePath);
-        } else {
-          await File(savePath).writeAsBytes(file.bytes!);
-        }
-        showSnackbar(
-          'Success',
-          'Saved attachment to $savePath!',
-          durationMs: 3000,
-          button: TextButton(
-            style: TextButton.styleFrom(
-              backgroundColor: Get.theme.colorScheme.surfaceVariant,
-            ),
-            onPressed: () {
-              launchUrl(Uri.file(savePath));
-            },
-            child: Text("OPEN FILE", style: TextStyle(color: Get.theme.colorScheme.onSurfaceVariant)),
-          ),
-        );
       }
+
+      showSnackbar(
+        'Success',
+        'Saved attachment to $savePath!',
+        durationMs: 3000,
+        button: TextButton(
+          style: TextButton.styleFrom(
+            backgroundColor: Get.theme.colorScheme.surfaceVariant,
+          ),
+          onPressed: () {
+            launchUrl(Uri.file(savePath));
+          },
+          child: Text("OPEN FILE", style: TextStyle(color: Get.theme.colorScheme.onSurfaceVariant)),
+        ),
+      );
     } else {
       String? savePath;
 

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -10,7 +10,7 @@ import 'package:universal_io/io.dart';
 /// host-side by URI string — no grant needed.
 Future<void> revealInFileManager(String path) async {
   if (Platform.isWindows) {
-    await Process.start('explorer', ['/select,$path']);
+    await Process.start('explorer', [dirname(path)]);
   } else if (Platform.isMacOS) {
     await Process.start('open', ['-R', path]);
   } else if (Platform.environment.containsKey('FLATPAK_ID')) {

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -33,7 +33,7 @@ fi
 # Inject version number into version.json
 tmp=$(mktemp)
 chmod 644 "$tmp"
-jq '.version = "1.15.104.0"' build/linux/$folder/release/bundle/data/flutter_assets/version.json > "$tmp" && mv "$tmp" build/linux/$folder/release/bundle/data/flutter_assets/version.json
+jq '.version = "2.0.0.0"' build/linux/$folder/release/bundle/data/flutter_assets/version.json > "$tmp" && mv "$tmp" build/linux/$folder/release/bundle/data/flutter_assets/version.json
 chmod +x build/linux/$folder/release/bundle/bluebubbles
 
 tar czvf bluebubbles-linux-"$arch".tar.gz -C build/linux/$folder/release/bundle .

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -396,12 +396,11 @@ packages:
   connectivity_plus:
     dependency: "direct main"
     description:
-      path: "packages/connectivity_plus/connectivity_plus"
-      ref: "2b614414ce95d920880765d07cbb9759699a4563"
-      resolved-ref: "2b614414ce95d920880765d07cbb9759699a4563"
-      url: "https://github.com/edde746/plus_plugins"
-    source: git
-    version: "7.1.1"
+      name: connectivity_plus
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -333,7 +333,7 @@ msix_config:
   display_name: BlueBubbles
   publisher_display_name: BlueBubbles
   identity_name: 23344BlueBubbles.BlueBubbles
-  msix_version: 1.15.104.0
+  msix_version: 2.0.0.0
   publisher: CN=BEC9154D-191E-4375-BF30-698BD4C141C4
   vs_generated_images_folder_path: windows/icons
   logo_path: assets/icon/icon.ico

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,11 +34,7 @@ dependencies:
   chunked_stream: ^1.4.2
   collection: ^1.19.0
   confetti: ^0.8.0
-  connectivity_plus:
-    git:
-      url: https://github.com/edde746/plus_plugins
-      ref: 2b614414ce95d920880765d07cbb9759699a4563
-      path: packages/connectivity_plus/connectivity_plus
+  connectivity_plus: ^7.3.0
   crop_your_image: ^2.0.0
   csslib: ^1.0.2
   cupertino_icons: ^1.0.8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: bluebubbles
 title: BlueBubbles
-version: 1.15.104.0
+version: 2.0.0.0
 summary: BlueBubbles client for Linux
 description: BlueBubbles is an open-source and cross-platform ecosystem of apps aimed to bring iMessage to Android, Windows, Linux, and more! With BlueBubbles, you'll be able to send messages, media, and much more to your friends and family.
 license: Apache-2.0
@@ -117,8 +117,8 @@ parts:
       - alsa-mixin
       - fmedia
     source:
-      - on amd64: https://github.com/BlueBubblesApp/bluebubbles-app/releases/download/v2.0.0%2Bdesktop.88-b.11/bluebubbles-linux-x86_64.tar.gz
-      - on arm64: https://github.com/BlueBubblesApp/bluebubbles-app/releases/download/v2.0.0%2Bdesktop.88-b.11/bluebubbles-linux-aarch64.tar.gz
+      - on amd64: https://github.com/BlueBubblesApp/bluebubbles-app/releases/download/v2.0.0%2B89/bluebubbles-linux-x86_64.tar.gz
+      - on arm64: https://github.com/BlueBubblesApp/bluebubbles-app/releases/download/v2.0.0%2B89/bluebubbles-linux-aarch64.tar.gz
     plugin: nil
     override-build: |
       set -eux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,6 @@ apps:
       - wayland
       - x11
       - unity7
-      - home
       - opengl
       - alsa
       - audio-playback

--- a/windows/bluebubbles_installer_script.iss
+++ b/windows/bluebubbles_installer_script.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "BlueBubbles"
-#define MyAppVersion "1.15.104.0"
+#define MyAppVersion "2.0.0.0"
 #define MyAppPublisher "BlueBubbles"
 #define MyAppURL "https://bluebubbles.app/"
 #define MyAppExeName "bluebubbles_app.exe"

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -59,8 +59,8 @@ IDI_APP_ICON            ICON                    "resources\\app_icon.ico"
 //
 // Version
 //
-#define VERSION_AS_NUMBER 1,15,104,0
-#define VERSION_AS_STRING "1.15.104.0"
+#define VERSION_AS_NUMBER 2,0,0,0
+#define VERSION_AS_STRING "2.0.0.0"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION VERSION_AS_NUMBER


### PR DESCRIPTION
- Version bumps in build scripts
- Adds flatpak changelog
- Updates `connectivity_plus`, no longer depends on a fork (the fix was merged upstream)
- Narrows snap file system permissions
- Adds portal support to linux file operations so they work in sandbox
- Fixes some route popping in backup/restore page

_NOTE:_ This assumes we will make the tag `v2.0.0+89`