### PR TITLE
fix: don't drop a message when a payload field is null

### DIFF
--- a/lib/database/global/attributed_body.dart
+++ b/lib/database/global/attributed_body.dart
@@ -8,9 +8,9 @@ class AttributedBody {
   final List<Run> runs;
 
   factory AttributedBody.fromMap(Map<String, dynamic> json) => AttributedBody(
-        string: json["string"],
+        string: json["string"] ?? "",
         runs:
-            json["runs"] == null ? [] : List<Run>.from(json["runs"].map((x) => Run.fromMap(x!.cast<String, Object>()))),
+            json["runs"] == null ? [] : List<Run>.from(json["runs"].map((x) => Run.fromMap(x!.cast<String, dynamic>()))),
       );
 
   Map<String, dynamic> toMap() => {
@@ -33,7 +33,7 @@ class Run {
 
   factory Run.fromMap(Map<String, dynamic> json) => Run(
         range: json["range"] == null ? [] : List<int>.from(json["range"].map((x) => x)),
-        attributes: json["attributes"] == null ? null : Attributes.fromMap(json["attributes"]!.cast<String, Object>()),
+        attributes: json["attributes"] == null ? null : Attributes.fromMap(json["attributes"]!.cast<String, dynamic>()),
       );
 
   Map<String, dynamic> toMap() => {

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -152,13 +152,13 @@ class Chat {
   }
 
   factory Chat.fromMap(Map<String, dynamic> json) {
-    final message = json['lastMessage'] != null ? Message.fromMap(json['lastMessage']!.cast<String, Object>()) : null;
+    final message = json['lastMessage'] != null ? Message.fromMap(json['lastMessage']!.cast<String, dynamic>()) : null;
     return Chat(
       id: json["ROWID"] ?? json["id"],
       guid: json["guid"],
       chatIdentifier: json["chatIdentifier"],
       participants:
-          (json['participants'] as List? ?? []).map((e) => Handle.fromMap(e!.cast<String, Object>())).toList(),
+          (json['participants'] as List? ?? []).map((e) => Handle.fromMap(e!.cast<String, dynamic>())).toList(),
       isArchived: json['isArchived'] ?? false,
       muteType: json["muteType"],
       muteArgs: json["muteArgs"],

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -204,11 +204,11 @@ class Message {
     List<AttributedBody> attributedBody = [];
     if (json["attributedBody"] != null) {
       if (json['attributedBody'] is Map) {
-        json['attributedBody'] = [json['attributedBody']!.cast<String, Object>()];
+        json['attributedBody'] = [json['attributedBody']!.cast<String, dynamic>()];
       }
       try {
         attributedBody =
-            (json['attributedBody'] as List).map((a) => AttributedBody.fromMap(a!.cast<String, Object>())).toList();
+            (json['attributedBody'] as List).map((a) => AttributedBody.fromMap(a!.cast<String, dynamic>())).toList();
       } catch (e, stack) {
         Logger.error('Failed to parse attributed body!', error: e, trace: stack);
       }
@@ -221,14 +221,14 @@ class Message {
           metadata = jsonDecode(json["metadata"]);
         } catch (_) {}
       } else {
-        metadata = json["metadata"]?.cast<String, Object>();
+        metadata = json["metadata"]?.cast<String, dynamic>();
       }
     }
 
     List<MessageSummaryInfo> msi = [];
     try {
       msi = (json['messageSummaryInfo'] as List? ?? [])
-          .map((e) => MessageSummaryInfo.fromJson(e!.cast<String, Object>()))
+          .map((e) => MessageSummaryInfo.fromJson(e!.cast<String, dynamic>()))
           .toList();
     } catch (e, stack) {
       Logger.error('Failed to parse summary info!', error: e, trace: stack);
@@ -268,7 +268,7 @@ class Message {
           int.tryParse(json["associatedMessageGuid"].toString().replaceAll("p:", "").split("/").first),
       associatedMessageType: json["associatedMessageType"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
-      handle: json['handle'] != null ? Handle.fromMap(json['handle']!.cast<String, Object>()) : null,
+      handle: json['handle'] != null ? Handle.fromMap(json['handle']!.cast<String, dynamic>()) : null,
       hasAttachments: (json['attachments'] as List? ?? []).isNotEmpty || json['hasAttachments'] == true,
       hasReactions: json['hasReactions'] == true,
       dateDeleted: parseDate(json["dateDeleted"]),

--- a/lib/services/backend/action_handler.dart
+++ b/lib/services/backend/action_handler.dart
@@ -106,11 +106,11 @@ class ActionHandler extends GetxService {
               IncomingPayload(
                 type: MessageEventType.newMessage,
                 source: MessageSource.socket,
-                chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
+                chat: Chat.fromMap(payload.data['chats'].first.cast<String, dynamic>()),
                 message: message,
                 attachments: ((payload.data['attachments'] as List?) ?? const [])
                     .whereType<Map>()
-                    .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+                    .map((e) => Attachment.fromMap(e.cast<String, dynamic>()))
                     .toList(),
                 tempGuid: payload.data['tempGuid'],
               ),
@@ -126,11 +126,11 @@ class ActionHandler extends GetxService {
               IncomingPayload(
                 type: MessageEventType.updatedMessage,
                 source: MessageSource.socket,
-                chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
+                chat: Chat.fromMap(payload.data['chats'].first.cast<String, dynamic>()),
                 message: updatedMessage,
                 attachments: ((payload.data['attachments'] as List?) ?? const [])
                     .whereType<Map>()
-                    .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+                    .map((e) => Attachment.fromMap(e.cast<String, dynamic>()))
                     .toList(),
                 tempGuid: payload.data['tempGuid'],
               ),
@@ -142,7 +142,7 @@ class ActionHandler extends GetxService {
       case "participant-added":
       case "participant-left":
         try {
-          MessageHandlerSvc.handleNewOrUpdatedChat(Chat.fromMap(data['chats'].first.cast<String, Object>()));
+          MessageHandlerSvc.handleNewOrUpdatedChat(Chat.fromMap(data['chats'].first.cast<String, dynamic>()));
         } catch (e, s) {
           Logger.warn("Failed to handle chat participant change event", error: e, trace: s, tag: 'ActionHandler');
         }

--- a/lib/services/backend/java_dart_interop/method_channel_handlers.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_handlers.dart
@@ -99,11 +99,11 @@ class MethodChannelHandlers {
         await IncomingMsgHandler.handle(IncomingPayload(
           type: MessageEventType.newMessage,
           source: MessageSource.methodChannel,
-          chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
+          chat: Chat.fromMap(payload.data['chats'].first.cast<String, dynamic>()),
           message: Message.fromMap(payload.data),
           attachments: ((payload.data['attachments'] as List?) ?? const [])
               .whereType<Map>()
-              .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+              .map((e) => Attachment.fromMap(e.cast<String, dynamic>()))
               .toList(),
           tempGuid: payload.data['tempGuid'],
         ));
@@ -152,11 +152,11 @@ class MethodChannelHandlers {
         await IncomingMsgHandler.handle(IncomingPayload(
           type: MessageEventType.updatedMessage,
           source: MessageSource.methodChannel,
-          chat: Chat.fromMap(payload.data['chats'].first.cast<String, Object>()),
+          chat: Chat.fromMap(payload.data['chats'].first.cast<String, dynamic>()),
           message: Message.fromMap(payload.data),
           attachments: ((payload.data['attachments'] as List?) ?? const [])
               .whereType<Map>()
-              .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+              .map((e) => Attachment.fromMap(e.cast<String, dynamic>()))
               .toList(),
           tempGuid: payload.data['tempGuid'],
         ));
@@ -182,7 +182,7 @@ class MethodChannelHandlers {
       if (!isNullOrEmpty(data)) {
         final payload = ServerPayload.fromJson(data!);
         await MessageHandlerSvc.handleNewOrUpdatedChat(
-            Chat.fromMap(payload.data['chats'].first.cast<String, Object>()));
+            Chat.fromMap(payload.data['chats'].first.cast<String, dynamic>()));
       }
     } catch (e, s) {
       return Future.error(e, s);

--- a/lib/services/backend/java_dart_interop/method_channel_service.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_service.dart
@@ -82,7 +82,7 @@ class MethodChannelService implements MethodChannelServiceDelegate {
 
   Future<bool> _callHandler(MethodCall call) async {
     final Map<String, dynamic>? arguments =
-        call.arguments is String ? jsonDecode(call.arguments) : call.arguments?.cast<String, Object>();
+        call.arguments is String ? jsonDecode(call.arguments) : call.arguments?.cast<String, dynamic>();
 
     // ONLY RETURN Future.value or Future.error
     // Future.value(false) will have the engine retry the call

--- a/lib/services/backend/outgoing_message_handler.dart
+++ b/lib/services/backend/outgoing_message_handler.dart
@@ -899,7 +899,7 @@ class OutgoingMessageHandler {
         final newMessage = Message.fromMap(data['data']);
         final responseAttachments = ((data['data']?['attachments'] as List?) ?? <dynamic>[])
             .whereType<Map>()
-            .map((e) => Attachment.fromMap(e.cast<String, Object>()))
+            .map((e) => Attachment.fromMap(e.cast<String, dynamic>()))
             .toList();
         // Swap attachment GUIDs first, then swap the message GUID.
         for (final a in responseAttachments) {


### PR DESCRIPTION
### Problem

Incoming chat/message/attachment parsing casts the decoded payload with `.cast<String, Object>()`. The resulting `CastMap` re-casts every value to the non-nullable `Object` and throws a `Null is not a subtype of Object` cast error the first time any field is genuinely null. That aborts the whole parse and drops the chat/message/attachment for that event.

It fires on live `new-message` / `updated-message` events from both the socket (`action_handler`) and the method channel (FCM/UnifiedPush). Incremental sync backfills the item later, so it looks intermittent, but the real-time event is lost in the meantime. Seen on both Android and desktop during normal use, for example a null run inside an `attributedBody`.

### Fix

Add a guarded `deepNormalizeJson` (`lib/utils/deep_map_normalize.dart`) that rebuilds maps and lists with null-tolerant reads and returns scalars (including numeric-looking strings like `"1234"`) untouched. Route every parse site through `asStringDynamicMapRequired` instead of the raw cast: the method-channel entrypoints, the socket `action_handler`, and `Chat` / `Message` / `AttributedBody` `fromMap`.

No behavior change on well-formed payloads; a null field now parses instead of throwing.
