### PR TITLE
fix: harden UnifiedPush delivery against parse failures and oversized payloads

### DIFF
--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/UnifiedPushReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/UnifiedPushReceiver.kt
@@ -4,7 +4,8 @@ import com.bluebubbles.messaging.services.backend_ui_interop.DartWorkManager
 import com.bluebubbles.messaging.utils.PersistentLog
 import com.bluebubbles.messaging.utils.Utils
 import com.google.gson.Gson
-import com.google.gson.JsonElement
+import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
 
 import org.unifiedpush.android.connector.MessagingReceiver
@@ -44,41 +45,50 @@ class UnifiedPushReceiver : MessagingReceiver() {
         DartWorkManager.createWorker(context, "unifiedpush-settings", data) {}
     }
 
-    inline fun <reified T> Gson.fromJson(json: String) = fromJson<T>(json, object: TypeToken<T>() {}.type)
-
     override fun onMessage(context: Context, payload: ByteArray, instance: String) {
         val applicationContext = context.getApplicationContext()
         val msg = payload.toString(Charsets.UTF_8)
-        val gson: Gson = Gson()
-        val json: Map<String, JsonElement> = gson.fromJson(msg)
-        val type: String
+        PersistentLog.i(applicationContext, tag, "UnifiedPush payload received (${payload.size} bytes)")
+
         try {
-            type = json.get("type")?.getAsString() ?: return
-        } catch (e: UnsupportedOperationException) {
-            PersistentLog.d(applicationContext, tag, "Invalid message type")
-            return
-        }
+            // LONG_OR_DOUBLE so integer fields (ROWIDs, timestamps) aren't parsed as
+            // scientific-notation doubles that later corrupt the message payload.
+            val gson: Gson = GsonBuilder()
+                .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                .create()
+            @Suppress("UNCHECKED_CAST")
+            val parsed = gson.fromJson<HashMap<String, Any?>>(
+                msg,
+                object : TypeToken<HashMap<String, Any?>>() {}.type,
+            )
+            val type: String = parsed["type"]?.toString() ?: run {
+                PersistentLog.w(applicationContext, tag, "UnifiedPush payload missing type field (${payload.size} bytes)")
+                return
+            }
 
-        PersistentLog.i(applicationContext, tag, "Received new message of type $type from UnifiedPush...")
-        DartWorkManager.createWorker(applicationContext, type, HashMap(json)) {}
+            PersistentLog.i(applicationContext, tag, "Received new message of type $type from UnifiedPush (${payload.size} bytes)")
+            DartWorkManager.createWorker(applicationContext, type, parsed) {}
 
-        // check if the user configured "Send Events to Tasker"
-        val prefs = applicationContext.getSharedPreferences("FlutterSharedPreferences", 0)
-        if (prefs.getBoolean("sendEventsToTasker", false)) {
-            Utils.getServerUrl(applicationContext, object : MethodChannel.Result {
-                override fun success(result: Any?) {
-                    PersistentLog.w(applicationContext, tag, "Got URL: $result - sending to Tasker...")
-                    val intent = Intent()
-                    intent.setAction("net.dinglisch.android.taserm.BB_EVENT")
-                    intent.putExtra("url", result.toString())
-                    intent.putExtra("event", type)
-                    intent.putExtras(bundleOf(*json.toList().toTypedArray()))
-                    applicationContext.sendBroadcast(intent)
-                }
+            // check if the user configured "Send Events to Tasker"
+            val prefs = applicationContext.getSharedPreferences("FlutterSharedPreferences", 0)
+            if (prefs.getBoolean("sendEventsToTasker", false)) {
+                Utils.getServerUrl(applicationContext, object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        PersistentLog.w(applicationContext, tag, "Got URL: $result - sending to Tasker...")
+                        val intent = Intent()
+                        intent.setAction("net.dinglisch.android.taserm.BB_EVENT")
+                        intent.putExtra("url", result.toString())
+                        intent.putExtra("event", type)
+                        intent.putExtras(bundleOf(*parsed.toList().toTypedArray()))
+                        applicationContext.sendBroadcast(intent)
+                    }
 
-                override fun error(errorCode: String, errorMesage: String?, errorDetails: Any?) {}
-                override fun notImplemented() {}
-            })
+                    override fun error(errorCode: String, errorMesage: String?, errorDetails: Any?) {}
+                    override fun notImplemented() {}
+                })
+            }
+        } catch (e: Exception) {
+            PersistentLog.e(applicationContext, tag, "Failed to process UnifiedPush message (${payload.size} bytes)", e)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
@@ -10,6 +10,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import java.util.concurrent.TimeUnit
+import java.io.File
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.utils.PersistentLog
 import com.google.gson.GsonBuilder
@@ -19,6 +20,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 object DartWorkManager {
+    // WorkManager input data is capped at ~10 KB total; attachment pushes can exceed that,
+    // so spill oversized payloads to a cache file and pass a marker path instead.
+    private const val WORKER_DATA_MAX_BYTES = 9_000
+    const val DATA_FILE_MARKER = "@file:"
+
     /// [callback] receives whether the Dart work actually SUCCEEDED. Callers must not
     /// treat completion as success: WorkManager also reaches a finished state on FAILED
     /// and CANCELLED, which is exactly what happens when a cold engine boot fails while
@@ -29,6 +35,25 @@ object DartWorkManager {
         val gson = GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .create()
+        val json = gson.toJson(arguments)
+
+        val dataBuilder = Data.Builder().putString("method", method)
+        if (json.length <= WORKER_DATA_MAX_BYTES) {
+            dataBuilder.putString("data", json)
+        } else {
+            val payloadFile = File(
+                context.cacheDir,
+                "dart_worker_${System.currentTimeMillis()}_${method.hashCode()}.json",
+            )
+            payloadFile.writeText(json)
+            dataBuilder.putString("data", DATA_FILE_MARKER + payloadFile.absolutePath)
+            PersistentLog.w(
+                context,
+                Constants.logTag,
+                "Worker payload exceeds WorkManager limit; spilling ${json.length} bytes to ${payloadFile.absolutePath}",
+            )
+        }
+
         val work = OneTimeWorkRequest.Builder(DartWorker::class.java)
             .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             // Retries redeliver dropped events (e.g. notifications). Exponential from the
@@ -36,12 +61,19 @@ object DartWorkManager {
             // long enough to outlast a memory-pressure spike that makes cold engine boots
             // fail repeatedly, while the first retry still lands within seconds.
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
-            .setInputData(Data.Builder()
-                .putString("method", method)
-                .putString("data", gson.toJson(arguments).toString()).build())
+            .setInputData(dataBuilder.build())
             .addTag(Constants.dartWorkerTag)
             .build()
-        WorkManager.getInstance(context).enqueue(work)
+        try {
+            WorkManager.getInstance(context).enqueue(work)
+        } catch (e: Exception) {
+            PersistentLog.e(context, Constants.logTag, "Failed to enqueue worker for method $method (${json.length} bytes)", e)
+            val spilledPath = dataBuilder.build().getString("data")
+            if (spilledPath?.startsWith(DATA_FILE_MARKER) == true) {
+                File(spilledPath.removePrefix(DATA_FILE_MARKER)).delete()
+            }
+            return
+        }
 
         // Observe when the worker is finished and run the provided callback.
         // Everything runs on the main thread (LiveData requirement), and we must hold

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
@@ -11,6 +11,7 @@ import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.MainActivity
 import com.bluebubbles.messaging.R
 import com.bluebubbles.messaging.utils.PersistentLog
+import java.io.File
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.gson.GsonBuilder
@@ -82,9 +83,30 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
         }
     }
 
+    /// Large worker payloads are spilled to a cache file by DartWorkManager (WorkManager
+    /// caps input data at ~10 KB). Resolve the marker back to the JSON, deleting the file.
+    private fun resolveWorkerPayload(rawData: String): String? {
+        if (!rawData.startsWith(DartWorkManager.DATA_FILE_MARKER)) {
+            return rawData
+        }
+        val path = rawData.removePrefix(DartWorkManager.DATA_FILE_MARKER)
+        val payloadFile = File(path)
+        return try {
+            val json = payloadFile.readText()
+            PersistentLog.d(applicationContext, Constants.logTag, "Loaded ${json.length} byte worker payload from $path")
+            payloadFile.delete()
+            json
+        } catch (e: Exception) {
+            PersistentLog.e(applicationContext, Constants.logTag, "Failed to read worker payload file $path", e)
+            payloadFile.delete()
+            null
+        }
+    }
+
     override fun startWork(): ListenableFuture<Result> {
         val method = inputData.getString("method")!!
-        val data = inputData.getString("data")!!
+        val data = resolveWorkerPayload(inputData.getString("data")!!)
+            ?: return Futures.immediateFuture(Result.failure())
         val gson = GsonBuilder()
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .create()


### PR DESCRIPTION
### Problem

Two issues on the UnifiedPush push path:

1. `UnifiedPushReceiver.onMessage` parsed the payload with a plain `Gson()` and had no try/catch around the handler. Integer fields (ROWIDs, timestamps) could parse as doubles and be mangled, and a single malformed payload threw on a background thread and silently dropped the notification.

2. WorkManager caps a worker's input `Data` at about 10KB. A large push (for example an attachment message) threw when enqueuing the `DartWorker`, so that message was never delivered.

### Fix

1. Parse with `ToNumberPolicy.LONG_OR_DOUBLE` and wrap `onMessage` so a bad payload logs and returns instead of dropping the notification.

2. Spill payloads over 9KB to a cache file and pass a marker path in the worker `Data`; `DartWorker` resolves the marker back to the payload and deletes the file.
