### PR TITLE
fix: harden path handling, Tasker intent receiver, and error-log redaction

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -76,10 +76,12 @@
             </intent-filter>
         </receiver>
 
+        <!-- Keep exported="false": only MainActivity broadcasts this, via an
+             explicit Intent. Exporting lets any app restart the socket service. -->
         <receiver
             android:name=".services.foreground.ForegroundServiceBroadcastReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="restartservice" />
             </intent-filter>
@@ -145,11 +147,13 @@
             </intent-filter>
         </service>
 
+        <!-- Keep exported="false": every start/stop site uses an explicit in-app
+             Intent. Exporting lets any app start or stop the socket service. -->
         <service
             android:name=".services.foreground.SocketIOForegroundService"
             android:foregroundServiceType="remoteMessaging"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="false" />
 
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/ExternalIntentReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/ExternalIntentReceiver.kt
@@ -7,9 +7,24 @@ import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.utils.PersistentLog
 import com.bluebubbles.messaging.utils.Utils
 import io.flutter.plugin.common.MethodChannel
+import java.security.MessageDigest
 
 /// Receives intents from other apps. This is primarily used for Tasker integration.
+///
+/// SECURITY: this receiver is exported with no permission, so any app installed on
+/// the device can send it intents. Treat every extra as hostile input.
 class ExternalIntentReceiver: BroadcastReceiver() {
+
+    companion object {
+        private const val TASKER_PACKAGE = "net.dinglisch.android.taskerm"
+
+        /// Constant-time string compare. `==` short-circuits at the first differing
+        /// byte, which any app can time to guess the password one byte at a time.
+        /// Length still leaks (isEqual returns early on it); contents don't.
+        internal fun constantTimeEquals(a: String, b: String): Boolean =
+            MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))
+    }
+
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context == null || intent == null) return
 
@@ -21,21 +36,33 @@ class ExternalIntentReceiver: BroadcastReceiver() {
                 val prefs = context.getSharedPreferences("FlutterSharedPreferences", 0)
                 val storedPassword = prefs.getString("guidAuthKey", "")
 
-                if (password == storedPassword) {
-                    Utils.getServerUrl(context, object : MethodChannel.Result {
-                        override fun success(result: Any?) {
-                            PersistentLog.d(context, Constants.logTag, "Got URL: $result - sending to Tasker...")
-                            val intent = Intent()
-                            intent.setAction("net.dinglisch.android.taskerm.BB_SERVER_URL")
-                            intent.putExtra("url", result.toString())
-                            intent.putExtra("id", identifier)
-                            context.sendBroadcast(intent)
-                        }
-
-                        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {}
-                        override fun notImplemented() {}
-                    })
+                // guidAuthKey defaults to "" before setup, so an empty password must
+                // never authenticate.
+                if (password.isNullOrEmpty() || storedPassword.isNullOrEmpty()) {
+                    PersistentLog.d(context, Constants.logTag, "Rejected GET_SERVER_URL: missing password")
+                    return
                 }
+                if (!constantTimeEquals(password, storedPassword)) {
+                    PersistentLog.d(context, Constants.logTag, "Rejected GET_SERVER_URL: bad password")
+                    return
+                }
+
+                Utils.getServerUrl(context, object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        PersistentLog.d(context, Constants.logTag, "Got server URL - sending to Tasker...")
+                        val reply = Intent()
+                        reply.setAction("net.dinglisch.android.taskerm.BB_SERVER_URL")
+                        reply.putExtra("url", result.toString())
+                        reply.putExtra("id", identifier)
+                        // Must stay package-targeted: an untargeted broadcast exposes
+                        // the server URL to any app listening for this action.
+                        reply.setPackage(TASKER_PACKAGE)
+                        context.sendBroadcast(reply)
+                    }
+
+                    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {}
+                    override fun notImplemented() {}
+                })
             }
         }
     }

--- a/lib/database/io/attachment.dart
+++ b/lib/database/io/attachment.dart
@@ -231,15 +231,23 @@ class Attachment {
 
   String get directory => "$baseDirectory/$guid";
 
+  /// SECURITY: flattens a server-supplied [transferName] to one inert path segment,
+  /// so `../../..` can't escape [directory]. Narrow on purpose — legitimate names
+  /// (including `my..file.txt`) are unchanged, so existing files still resolve.
+  static String sanitizeFileName(String name, {String replacement = '_'}) {
+    final flattened = name.replaceAll('/', replacement);
+    if (flattened.isEmpty || flattened == '.' || flattened == '..') return 'attachment';
+    return flattened;
+  }
+
   String get path {
+    final safeName = sanitizeFileName("$transferName");
     switch (Platform.operatingSystem) {
       case "windows":
-        return "$directory/${"$transferName".replaceAll(RegExp(r'[<>:"/\|?*]'), "_")}";
-      case "linux":
-      case "macos":
-        return "$directory/${"$transferName".replaceAll(RegExp(r'/'), "_")}";
+        // `\` is also a separator here, and the rest are illegal in a filename.
+        return "$directory/${safeName.replaceAll(RegExp(r'[<>:"\\|?*]'), "_")}";
       default:
-        return "$directory/$transferName";
+        return "$directory/$safeName";
     }
   }
 

--- a/lib/services/network/http_overrides.dart
+++ b/lib/services/network/http_overrides.dart
@@ -4,6 +4,11 @@ import 'package:universal_io/io.dart';
 
 /// Shared certificate validation logic for both HTTP and WebSocket connections
 /// Returns true if the certificate should be accepted (override bad cert), false otherwise
+///
+/// SECURITY / TODO: this accepts *any* failed certificate (self-signed, expired,
+/// wrong CA) as long as the host matches the configured server, so a MITM on that
+/// host is not detectable. Needs cert pinning or an explicit opt-in setting —
+/// coming back to this. See ENGINEERING-STANDARDS.md §9.6.
 bool shouldAcceptCertificate(X509Certificate cert, String host, int port) {
   String serverUrl = sanitizeServerAddress() ?? "";
 

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -368,8 +368,10 @@ class ApiInterceptor extends Interceptor {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
-    // Get params without sensitive info
-    final params = err.requestOptions.queryParameters;
+    // Get params without sensitive info. Must be a copy — queryParameters is the
+    // live map on the request, so removing from it in place strips the auth key
+    // off the request itself.
+    final params = Map<String, dynamic>.from(err.requestOptions.queryParameters);
     params.remove("guid");
     params.remove("password");
 


### PR DESCRIPTION
## Summary

- **Path traversal**: `Attachment.path` interpolated the server-supplied `transferName` directly into a filesystem path. The Windows and Linux/macOS branches stripped path separators; the `default:` branch — Android and iOS, the platforms most users are on — applied no sanitization at all, so a `transferName` of `../../../../shared_prefs/...` would resolve outside the attachments directory. Added `Attachment.sanitizeFileName()`, applied on every platform. Deliberately narrow (only `/`, `.`, and `..` are touched) so legitimate filenames hash to the same path as before and already-downloaded attachments aren't orphaned.
- **Tasker intent receiver** (`ExternalIntentReceiver`): this receiver is exported with no permission, so any app on the device can send it intents.
  - The password comparison used Kotlin's `==`, which short-circuits at the first differing byte — a timing oracle any app could probe by repeating the broadcast. Switched to `MessageDigest.isEqual`.
  - `guidAuthKey` defaults to `""` before setup; the comparison now rejects an empty password/stored-key outright rather than letting `password=""` match.
  - The Tasker reply used an untargeted `sendBroadcast`, putting the server URL on a bus any installed app could listen on — including one whose password guess was rejected. Now `setPackage`-targeted at Tasker.
- Two components were exported with no need to be: `SocketIOForegroundService` and `ForegroundServiceBroadcastReceiver`. Every start/stop site uses an explicit same-app `Intent`, which doesn't require exporting; exporting let any installed app start or stop the socket service. Set `exported="false"` on both.
- **Log redaction side effect**: `ApiInterceptor.onError` stripped `"guid"` and `"password"` before logging a failed request, but did so by calling `.remove()` directly on `err.requestOptions.queryParameters` — the live map on the request — which stripped the auth key off the actual request being reported, not just the log line. Now redacts a copy.

## Test plan

- [x] `flutter analyze`: 302 pre-existing info-level lints, zero errors, zero warnings, before and after
- [x] Verified `sanitizeFileName` preserves ordinary filenames byte-for-byte (including ones containing dots) while neutralizing `..`/`.`/empty and flattening path separators
- [ ] Manual test of the Tasker `GET_SERVER_URL` intent against a real Tasker install
- [ ] Manual test that the foreground service still starts/stops correctly with `exported="false"` on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)