### PR TITLE
fix: message parts - use partIds and helpers instead of unstable indices (1/7)

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart
@@ -338,7 +338,7 @@ class _AttachmentHolderState extends State<AttachmentHolder> with ThemeHelpers {
     final bool isInReply = ReplyScope.maybeOf(context) != null;
     final bool isPass = attachment.isPkPass;
     final bool showTail =
-        !isInReply && !isPass && message.showTail(newerMessage) && part.part == controller.parts.length - 1;
+        !isInReply && !isPass && message.showTail(newerMessage) && controller.isTrailingMessagePart(part);
 
     // Resolve state once for the scope.  The AttachmentState object is updated
     // in-place by the service layer; no re-lookup is needed on reactive changes.

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart
@@ -30,13 +30,21 @@ class MessageImageGallery extends StatefulWidget {
     required this.partIndex,
     required this.isInReply,
     required this.fanDirection,
+    this.attachmentPartIndices,
     this.infiniteScroll = false,
     this.currentIndexNotifier,
     this.reactionsByAttachmentKey,
   });
 
   final List<Attachment> attachments;
+
+  /// Collapsed gallery message-part id
   final int partIndex;
+
+  /// Original message-part id for each attachment index when the gallery is
+  /// collapsed from multiple parts. Null when all attachments share [partIndex].
+  final List<int>? attachmentPartIndices;
+
   final bool isInReply;
   final GalleryFanDirection fanDirection;
   final bool infiniteScroll;
@@ -248,14 +256,18 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
     widget.currentIndexNotifier?.value = _currentIndex;
   }
 
-  Attachment _attachmentAtOffset(int offset) {
-    final index = (_currentIndex + offset) % _attachments.length;
-    return _attachments[index];
+  int _indexAtOffset(int offset) {
+    var index = (_currentIndex + offset) % _attachments.length;
+    if (index < 0) index += _attachments.length;
+    return index;
   }
 
-  MessagePart _partForAttachment(Attachment attachment) {
+  int _partIdForAttachment(int attachmentIndex) =>
+      widget.attachmentPartIndices?[attachmentIndex] ?? widget.partIndex;
+
+  MessagePart _partForAttachment(Attachment attachment, int attachmentIndex) {
     return MessagePart(
-      part: widget.partIndex,
+      part: _partIdForAttachment(attachmentIndex),
       attachments: [attachment],
       shouldRedact: false,
       text: null,
@@ -351,9 +363,10 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
 
     if (widget.infiniteScroll) {
       stackChildren.addAll(List.generate(_attachments.length, (i) {
-        final attachment = _attachmentAtOffset(i);
+        final attachmentIndex = _indexAtOffset(i);
         return _buildFanCard(
-          attachment: attachment,
+          attachment: _attachments[attachmentIndex],
+          attachmentIndex: attachmentIndex,
           slotIndex: i,
           baseCardWidth: baseCardWidth,
           baseCardHeight: baseCardHeight,
@@ -370,10 +383,11 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
       final visibleFuture = min(futureCount, _visibleFanSlots - 1);
 
       for (int p = visiblePast; p >= 1; p--) {
-        final attachment = _attachments[_currentIndex - p];
+        final attachmentIndex = _currentIndex - p;
         final slot = (p - 1).clamp(0, _maxPastCards - 1);
         stackChildren.add(_buildPastCard(
-          attachment: attachment,
+          attachment: _attachments[attachmentIndex],
+          attachmentIndex: attachmentIndex,
           slotIndex: slot,
           baseCardWidth: baseCardWidth,
           baseCardHeight: baseCardHeight,
@@ -383,9 +397,10 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
       }
 
       for (int f = visibleFuture; f >= 1; f--) {
-        final attachment = _attachments[_currentIndex + f];
+        final attachmentIndex = _currentIndex + f;
         stackChildren.add(_buildFanCard(
-          attachment: attachment,
+          attachment: _attachments[attachmentIndex],
+          attachmentIndex: attachmentIndex,
           slotIndex: f,
           baseCardWidth: baseCardWidth,
           baseCardHeight: baseCardHeight,
@@ -398,6 +413,7 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
 
       stackChildren.add(_buildFanCard(
         attachment: _attachments[_currentIndex],
+        attachmentIndex: _currentIndex,
         slotIndex: 0,
         baseCardWidth: baseCardWidth,
         baseCardHeight: baseCardHeight,
@@ -608,6 +624,7 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
 
   Widget _buildFanCard({
     required Attachment attachment,
+    required int attachmentIndex,
     required int slotIndex,
     required double baseCardWidth,
     required double baseCardHeight,
@@ -646,7 +663,7 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
               IgnorePointer(
                 ignoring: !isCurrent,
                 child: AttachmentHolder(
-                  message: _partForAttachment(attachment),
+                  message: _partForAttachment(attachment, attachmentIndex),
                   transparentBackground: true,
                   showCardShadow: true,
                   galleryAttachments: _attachments,
@@ -662,6 +679,7 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
 
   Widget _buildPastCard({
     required Attachment attachment,
+    required int attachmentIndex,
     required int slotIndex,
     required double baseCardWidth,
     required double baseCardHeight,
@@ -698,7 +716,7 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
               IgnorePointer(
                 ignoring: true,
                 child: AttachmentHolder(
-                  message: _partForAttachment(attachment),
+                  message: _partForAttachment(attachment, attachmentIndex),
                   transparentBackground: true,
                   showCardShadow: true,
                   galleryAttachments: _attachments,

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -158,24 +158,21 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
 
       final groupedAttachments = <Attachment>[...current.attachments];
       final groupedPartIndices = <int>[...List.filled(current.attachments.length, current.part)];
-      int lastPart = current.part;
       int j = i + 1;
       while (j < parts.length) {
         final next = parts[j];
         if (!next.isMediaOnlyPart) break;
         groupedAttachments.addAll(next.attachments);
         groupedPartIndices.addAll(List.filled(next.attachments.length, next.part));
-        lastPart = next.part;
         j++;
       }
 
       if (groupedAttachments.length > 1) {
         collapsed.add(MessagePart(
           attachments: groupedAttachments,
-          // Use the last grouped message-part id (not the first) so downstream
-          // "is this the last part of the message" checks (e.g. avatar, tail)
-          // still resolve correctly against controller.parts.length - 1.
-          part: lastPart,
+          // First raw id is the bubble's part id; attachmentPartIndices holds the
+          // full span. Trailing chrome uses MessageState.isTrailingMessagePart.
+          part: current.part,
           shouldRedact: current.shouldRedact,
           mentions: const [],
           edits: const [],
@@ -401,7 +398,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                     children: [
                                       // avatar, if needed
                                       if (message.showTail(newerMessage) &&
-                                          e.part == controller.parts.length - 1 &&
+                                          controller.isTrailingMessagePart(e) &&
                                           (showAvatar || SettingsSvc.settings.alwaysShowAvatars.value) &&
                                           !message.isFromMe! &&
                                           !message.isGroupEvent)
@@ -427,9 +424,10 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                           message.threadOriginatorGuid != null &&
                                                           olderMessage != null) ||
                                                       (index == messageParts.length - 1 &&
-                                                          service.struct
-                                                              .threads(message.guid!, e.part, returnOriginator: false)
-                                                              .isNotEmpty &&
+                                                          (e.attachmentPartIndices ?? [e.part]).any((id) => service
+                                                              .struct
+                                                              .threads(message.guid!, id, returnOriginator: false)
+                                                              .isNotEmpty) &&
                                                           newerMessage != null))
                                               ? ReplyLineDecoration(
                                                   isFromMe: message.isFromMe!,
@@ -472,7 +470,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                         if ((message.hasApplePayloadData ||
                                                                 message.isLegacyUrlPreview ||
                                                                 message.isInteractive ||
-                                                                (e.part == 0 &&
+                                                                (controller.isLeadingMessagePart(e) &&
                                                                     isNullOrEmpty(e.text) &&
                                                                     e.attachments.isNotEmpty)) &&
                                                             !isNullOrEmpty(message.subject))
@@ -484,10 +482,12 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                                 showTail: false,
                                                                 connectLower: iOS
                                                                     ? false
-                                                                    : (e.part != 0 &&
-                                                                            e.part != controller.parts.length - 1) ||
-                                                                        (e.part == 0 && controller.parts.length > 1),
-                                                                connectUpper: iOS ? false : e.part != 0,
+                                                                    : (!controller.isLeadingMessagePart(e) &&
+                                                                            !controller.isTrailingMessagePart(e)) ||
+                                                                        (controller.isLeadingMessagePart(e) &&
+                                                                            controller.parts.length > 1),
+                                                                connectUpper:
+                                                                    iOS ? false : !controller.isLeadingMessagePart(e),
                                                               ),
                                                               child: TextBubble(
                                                                 message: MessagePart(
@@ -517,7 +517,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                                   part: e.part,
                                                                   globalKey: keys.length > index ? keys[index] : null,
                                                                   showTail: message.showTail(newerMessage) &&
-                                                                      e.part == controller.parts.length - 1,
+                                                                      controller.isTrailingMessagePart(e),
                                                                   messageState: controller,
                                                                   child: MessagePopupHolder(
                                                                     key: keys.length > index ? keys[index] : null,
@@ -582,16 +582,19 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                                               isFromMe: message.isFromMe!,
                                                                               showTail: !e.isPkPass &&
                                                                                   message.showTail(newerMessage) &&
-                                                                                  e.part == controller.parts.length - 1,
+                                                                                  controller.isTrailingMessagePart(e),
                                                                               connectLower: iOS
                                                                                   ? false
-                                                                                  : (e.part != 0 &&
-                                                                                          e.part !=
-                                                                                              controller.parts.length -
-                                                                                                  1) ||
-                                                                                      (e.part == 0 &&
+                                                                                  : (!controller.isLeadingMessagePart(
+                                                                                          e) &&
+                                                                                      !controller.isTrailingMessagePart(
+                                                                                          e)) ||
+                                                                                      (controller.isLeadingMessagePart(
+                                                                                              e) &&
                                                                                           controller.parts.length > 1),
-                                                                              connectUpper: iOS ? false : e.part != 0,
+                                                                              connectUpper: iOS
+                                                                                  ? false
+                                                                                  : !controller.isLeadingMessagePart(e),
                                                                             ),
                                                                             child: inner,
                                                                           );

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -196,8 +196,9 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
     final alwaysShowAvatars = SettingsSvc.settings.alwaysShowAvatars.value;
     final avatarScale = SettingsSvc.settings.avatarScale.value;
 
-    Iterable<Message> reactionsForPart(int part, List<Message> reactions) {
-      return reactions.where((s) => (s.associatedMessagePart ?? 0) == part);
+    // Bubble-level reactions for [part], including any original ids in a collapsed gallery span.
+    Iterable<Message> reactionsForPart(MessagePart part, List<Message> reactions) {
+      return reactions.where((s) => part.coversPartId(s.associatedMessagePart ?? 0));
     }
 
     /// Layout tree

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -425,10 +425,13 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                           message.threadOriginatorGuid != null &&
                                                           olderMessage != null) ||
                                                       (index == messageParts.length - 1 &&
-                                                          (e.attachmentPartIndices ?? [e.part]).any((id) => service
-                                                              .struct
-                                                              .threads(message.guid!, id, returnOriginator: false)
-                                                              .isNotEmpty) &&
+                                                          service.struct
+                                                              .threadsForParts(
+                                                                message.guid!,
+                                                                e.attachmentPartIndices ?? [e.part],
+                                                                returnOriginator: false,
+                                                              )
+                                                              .isNotEmpty &&
                                                           newerMessage != null))
                                               ? ReplyLineDecoration(
                                                   isFromMe: message.isFromMe!,

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -415,7 +415,9 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                           message.threadOriginatorGuid != null &&
                                                           olderMessage != null) ||
                                                       (index == messageParts.length - 1 &&
-                                                          service.struct.threads(message.guid!, index).isNotEmpty &&
+                                                          service.struct
+                                                              .threads(message.guid!, e.part, returnOriginator: false)
+                                                              .isNotEmpty &&
                                                           newerMessage != null))
                                               ? ReplyLineDecoration(
                                                   isFromMe: message.isFromMe!,
@@ -500,7 +502,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                               children: [
                                                                 // actual message content
                                                                 BubbleEffects(
-                                                                  part: index,
+                                                                  part: e.part,
                                                                   globalKey: keys.length > index ? keys[index] : null,
                                                                   showTail: message.showTail(newerMessage) &&
                                                                       e.part == controller.parts.length - 1,
@@ -519,7 +521,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                                                       enabled: canSwipeToReply &&
                                                                           !isEditing(e.part) &&
                                                                           !(iOS && e.isMediaGallery),
-                                                                      partIndex: index,
+                                                                      partIndex: e.part,
                                                                       replyOffset: replyOffsets[index],
                                                                       cvController: widget.cvController,
                                                                       child: Builder(

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -172,9 +172,9 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
       if (groupedAttachments.length > 1) {
         collapsed.add(MessagePart(
           attachments: groupedAttachments,
-          // Use the last grouped raw part index (not the first) so downstream
+          // Use the last grouped message-part id (not the first) so downstream
           // "is this the last part of the message" checks (e.g. avatar, tail)
-          // still resolve correctly against controller.parts.length.
+          // still resolve correctly against controller.parts.length - 1.
           part: lastPart,
           shouldRedact: current.shouldRedact,
           mentions: const [],
@@ -232,7 +232,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
 
         // Read controller.parts reactively so Obx rebuilds when parts change
         final rawMessageParts = widget.isReplyThread && widget.replyPart != null
-            ? [controller.parts[widget.replyPart!]]
+            ? [controller.partById(widget.replyPart!)!]
             : controller.parts.toList();
         final messageParts = _collapseImageGalleryParts(rawMessageParts);
 

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -230,9 +230,21 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
         // ignore: unused_local_variable
         final _rxGuard = (controller.isSending.value, controller.hasError.value, controller.parts.length);
 
-        // Read controller.parts reactively so Obx rebuilds when parts change
-        final rawMessageParts = widget.isReplyThread && widget.replyPart != null
-            ? [controller.partById(widget.replyPart!)!]
+        // Read controller.parts reactively so Obx rebuilds when parts change.
+        // replyPart is a message-part id, not a list index. A miss must not fall
+        // through to the full parts list — that would show the whole message.
+        final targetingPart = widget.isReplyThread && widget.replyPart != null;
+        final matchedPart = targetingPart ? controller.partById(widget.replyPart!) : null;
+        final rawMessageParts = targetingPart
+            ? [
+                if (matchedPart != null)
+                  matchedPart
+                else
+                  MessagePart(
+                    part: widget.replyPart!,
+                    text: "This message is no longer available",
+                  ),
+              ]
             : controller.parts.toList();
         final messageParts = _collapseImageGalleryParts(rawMessageParts);
 

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
@@ -27,7 +27,7 @@ class ReactionObserver extends StatelessWidget {
   final List<MessagePart> messageParts;
   final MessagePart part;
   final String chatGuid;
-  final Iterable<Message> Function(int, List<Message>) reactionsForPart;
+  final Iterable<Message> Function(MessagePart, List<Message>) reactionsForPart;
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +39,7 @@ class ReactionObserver extends StatelessWidget {
       final reactions = associatedMessages
           .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
           .toList();
-      final reactionList = messageParts.length == 1 ? reactions : reactionsForPart(part.part, reactions).toList();
+      final reactionList = messageParts.length == 1 ? reactions : reactionsForPart(part, reactions).toList();
 
       return Positioned(
         top: -14,
@@ -75,7 +75,7 @@ class StickerObserver extends StatelessWidget {
       final allStickers = state.associatedMessages.where((e) => e.associatedMessageType == "sticker").toList();
       final stickersForPart = messageParts.length == 1
           ? allStickers
-          : allStickers.where((s) => (s.associatedMessagePart ?? 0) == part.part).toList();
+          : allStickers.where((s) => part.coversPartId(s.associatedMessagePart ?? 0)).toList();
 
       if (stickersForPart.isEmpty) return const SizedBox.shrink();
 
@@ -100,7 +100,7 @@ class ReactionSpacing extends StatelessWidget {
 
   final List<MessagePart> messageParts;
   final MessagePart part;
-  final Iterable<Message> Function(int, List<Message>) reactionsForPart;
+  final Iterable<Message> Function(MessagePart, List<Message>) reactionsForPart;
   final double minHeightWhenNoReactions;
 
   @override
@@ -113,12 +113,8 @@ class ReactionSpacing extends StatelessWidget {
           .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
           .cast<Message>()
           .toList();
-      // A gallery part can bundle several originally-separate message parts
-      // (see MessageHolder._collapseImageGalleryParts), so check every one
-      // of them rather than just part.part.
-      final relevantParts = part.attachmentPartIndices?.toSet() ?? {part.part};
-      final hasReaction = relevantParts.any((p) => reactionsForPart(p, reactions).isNotEmpty);
-      if ((messageParts.length == 1 && reactions.isNotEmpty) || hasReaction) {
+      // coversPartId covers collapsed gallery spans via attachmentPartIndices.
+      if ((messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part, reactions).isNotEmpty) {
         return const SizedBox(height: 12.5);
       }
 

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
@@ -22,7 +22,7 @@ class SamsungTimestampObserver extends StatelessWidget {
   final List<MessagePart> messageParts;
   final MessagePart part;
   final ConversationViewController cvController;
-  final Iterable<Message> Function(int, List<Message>) reactionsForPart;
+  final Iterable<Message> Function(MessagePart, List<Message>) reactionsForPart;
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +35,7 @@ class SamsungTimestampObserver extends StatelessWidget {
           .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
           .toList();
       return Padding(
-        padding: (messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part.part, reactions).isNotEmpty
+        padding: (messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part, reactions).isNotEmpty
             ? EdgeInsets.only(left: isFromMe ? 0 : 10, right: isFromMe ? 20 : 0)
             : const EdgeInsets.only(right: 10),
         child: MessageTimestamp(controller: ms, cvController: cvController),

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
@@ -84,12 +84,14 @@ class EditHistoryObserver extends StatelessWidget {
                                   isFromMe: message.isFromMe!,
                                   showTail: !part.isPkPass &&
                                       message.showTail(newerMessage) &&
-                                      part.part == ms.parts.length - 1,
+                                      ms.isTrailingMessagePart(part),
                                   connectLower: SettingsSvc.settings.skin.value == Skins.iOS
                                       ? false
-                                      : (part.part != 0 && part.part != ms.parts.length - 1) ||
-                                          (part.part == 0 && ms.parts.length > 1),
-                                  connectUpper: SettingsSvc.settings.skin.value == Skins.iOS ? false : part.part != 0,
+                                      : (!ms.isLeadingMessagePart(part) && !ms.isTrailingMessagePart(part)) ||
+                                          (ms.isLeadingMessagePart(part) && ms.parts.length > 1),
+                                  connectUpper: SettingsSvc.settings.skin.value == Skins.iOS
+                                      ? false
+                                      : !ms.isLeadingMessagePart(part),
                                 ),
                                 child: TextBubble(
                                   message: edit,

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_reactions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_reactions.dart
@@ -17,7 +17,7 @@ class MessageReactions extends StatelessWidget {
   final List<MessagePart> messageParts;
   final MessagePart part;
   final String chatGuid;
-  final Iterable<Message> Function(int, List<Message>) reactionsForPart;
+  final Iterable<Message> Function(MessagePart, List<Message>) reactionsForPart;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/layouts/conversation_view/widgets/message/misc/message_part_content.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/message_part_content.dart
@@ -82,6 +82,7 @@ class MessagePartContent extends StatelessWidget {
               return MessageImageGallery(
                 attachments: messagePart.attachments,
                 partIndex: messagePart.part,
+                attachmentPartIndices: messagePart.attachmentPartIndices,
                 isInReply: false,
                 fanDirection: message.isFromMe == true ? GalleryFanDirection.left : GalleryFanDirection.right,
                 currentIndexNotifier: galleryCurrentIndexNotifier,

--- a/lib/app/layouts/conversation_view/widgets/message/misc/message_properties.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/message_properties.dart
@@ -41,7 +41,15 @@ class _MessagePropertiesState extends State<MessageProperties> with ThemeHelpers
 
   List<TextSpan> getProperties() {
     final properties = <TextSpan>[];
-    final replyList = service.struct.threads(message.guid!, widget.part.part, returnOriginator: false);
+    // Galleries are per-attachment for replies (native iMessage). Skip the
+    // aggregate bubble-level count; open threads via per-card popup instead.
+    final replyList = widget.part.isMediaGallery
+        ? const <Message>[]
+        : service.struct.threadsForParts(
+            message.guid!,
+            widget.part.attachmentPartIndices ?? [widget.part.part],
+            returnOriginator: false,
+          );
     if (message.expressiveSendStyleId != null) {
       final effect =
           effectMap.entries.firstWhereOrNull((element) => element.value == message.expressiveSendStyleId)?.key ??

--- a/lib/app/layouts/conversation_view/widgets/message/misc/swipe_to_reply_wrapper.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/swipe_to_reply_wrapper.dart
@@ -17,13 +17,19 @@ class SwipeToReplyWrapper extends StatefulWidget {
     required this.replyOffset,
     required this.cvController,
     required this.child,
+    this.attachmentGuid,
   });
 
   final bool enabled;
+
+  /// Message-part id being replied to (not a collapsed list index).
   final int partIndex;
   final RxDouble replyOffset;
   final ConversationViewController cvController;
   final Widget child;
+
+  /// When set, reply preview / send target a specific attachment within the part.
+  final String? attachmentGuid;
 
   @override
   State<SwipeToReplyWrapper> createState() => _SwipeToReplyWrapperState();
@@ -69,7 +75,11 @@ class _SwipeToReplyWrapperState extends State<SwipeToReplyWrapper> {
 
         // Trigger reply if threshold reached
         if (widget.replyOffset.value.abs() >= SlideToReply.replyThreshold) {
-          widget.cvController.replyToMessage = MessageReplyContext(message, widget.partIndex);
+          widget.cvController.replyToMessage = MessageReplyContext(
+            message,
+            widget.partIndex,
+            attachmentGuid: widget.attachmentGuid,
+          );
         }
 
         widget.replyOffset.value = 0;

--- a/lib/app/layouts/conversation_view/widgets/message/misc/swipe_to_reply_wrapper.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/swipe_to_reply_wrapper.dart
@@ -22,7 +22,7 @@ class SwipeToReplyWrapper extends StatefulWidget {
 
   final bool enabled;
 
-  /// Message-part id being replied to (not a collapsed list index).
+  /// Message-part id being replied to
   final int partIndex;
   final RxDouble replyOffset;
   final ConversationViewController cvController;

--- a/lib/app/layouts/conversation_view/widgets/message/parts/message_part_wrapper.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/parts/message_part_wrapper.dart
@@ -76,7 +76,7 @@ class MessagePartWrapper extends StatelessWidget {
           messageState: controller,
           part: part.part,
           globalKey: globalKey,
-          showTail: !part.isPkPass && message.showTail(newerMessage) && part.part == controller.parts.length - 1,
+          showTail: !part.isPkPass && message.showTail(newerMessage) && controller.isTrailingMessagePart(part),
           child: MessagePopupHolder(
             key: globalKey,
             controller: controller,
@@ -187,12 +187,12 @@ class _MessageContentBubble extends StatelessWidget {
     return ClipPath(
       clipper: TailClipper(
         isFromMe: message.isFromMe!,
-        showTail: !part.isPkPass && message.showTail(newerMessage) && part.part == controller.parts.length - 1,
+        showTail: !part.isPkPass && message.showTail(newerMessage) && controller.isTrailingMessagePart(part),
         connectLower: SettingsSvc.settings.skin.value == Skins.iOS
             ? false
-            : (part.part != 0 && part.part != controller.parts.length - 1) ||
-                (part.part == 0 && controller.parts.length > 1),
-        connectUpper: SettingsSvc.settings.skin.value == Skins.iOS ? false : part.part != 0,
+            : (!controller.isLeadingMessagePart(part) && !controller.isTrailingMessagePart(part)) ||
+                (controller.isLeadingMessagePart(part) && controller.parts.length > 1),
+        connectUpper: SettingsSvc.settings.skin.value == Skins.iOS ? false : !controller.isLeadingMessagePart(part),
       ),
       child: Stack(
         alignment: Alignment.centerRight,

--- a/lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart
@@ -37,7 +37,7 @@ void showThread(MessagePopupActionContext ctx) {
     final mwc = ctx.service.getMessageStateIfExists(ctx.message.threadOriginatorGuid!);
     if (mwc == null) return ctx.showSnack("Error", "Failed to find thread!");
     showReplyThread(
-        ctx.context, mwc.message, mwc.parts[ctx.message.normalizedThreadPart], ctx.service, ctx.cvController);
+        ctx.context, mwc.message, mwc.partById(ctx.message.normalizedThreadPart)!, ctx.service, ctx.cvController);
   } else {
     showReplyThread(ctx.context, ctx.message, ctx.part, ctx.service, ctx.cvController);
   }

--- a/lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart
@@ -41,8 +41,9 @@ void showThread(MessagePopupActionContext ctx) {
   if (ctx.message.threadOriginatorGuid != null) {
     final mwc = ctx.service.getMessageStateIfExists(ctx.message.threadOriginatorGuid!);
     if (mwc == null) return ctx.showSnack("Error", "Failed to find thread!");
-    showReplyThread(
-        ctx.context, mwc.message, mwc.partById(ctx.message.normalizedThreadPart)!, ctx.service, ctx.cvController);
+    final originatorPart = mwc.partById(ctx.message.normalizedThreadPart);
+    if (originatorPart == null) return ctx.showSnack("Error", "Failed to find thread!");
+    showReplyThread(ctx.context, mwc.message, originatorPart, ctx.service, ctx.cvController);
   } else {
     showReplyThread(ctx.context, ctx.message, ctx.part, ctx.service, ctx.cvController);
   }

--- a/lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart
@@ -15,7 +15,12 @@ import 'package:flutter/widgets.dart';
 
 void reply(MessagePopupActionContext ctx) {
   ctx.popDetails();
-  ctx.cvController.replyToMessage = MessageReplyContext(ctx.message, ctx.part.part);
+  final part = ctx.part;
+  ctx.cvController.replyToMessage = MessageReplyContext(
+    ctx.message,
+    part.part,
+    attachmentGuid: part.attachments.length == 1 ? part.attachments.first.guid : null,
+  );
 }
 
 void openDm(MessagePopupActionContext ctx) {

--- a/lib/app/layouts/conversation_view/widgets/message/reply/CLAUDE.md
+++ b/lib/app/layouts/conversation_view/widgets/message/reply/CLAUDE.md
@@ -12,9 +12,9 @@ Displays reply threading: the quoted preview above a message and the thread conn
 
 ## How `ReplyBubble` Works
 
-- Reads `controller.messageState?.text` reactively so the quoted text updates if the original was edited.
+- Resolves the quoted part via `MessageState.partById` (message-part id, not list index).
 - Shows: sender name, content snippet (text or attachment icon), and a mini attachment thumbnail if applicable.
-- Tap → scrolls the conversation list to the original message (via `cvController.scrollToMessage(replyTo)`).
+- Tap → opens the reply thread for the resolved part (`showReplyThread`).
 
 ## Thread Lines (iOS)
 

--- a/lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart
@@ -32,13 +32,20 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
   late MessageState _ms;
   MessageState get controller => _ms;
 
-  MessagePart get part => controller.partById(widget.part)!;
+  /// Resolves [widget.part] as a message-part id. Null when the part is missing —
+  /// never substitutes another part.
+  MessagePart? get part => controller.partById(widget.part);
   Message get message => controller.message;
 
   @override
   void initState() {
     super.initState();
     _ms = MessageStateScope.readStateOnce(context);
+  }
+
+  void _openReplyThread(BuildContext context, String chatGuid, MessagePart? part) {
+    if (part == null) return;
+    showReplyThread(context, message, part, MessagesSvc(chatGuid), widget.cvController);
   }
 
   Color getBubbleColor() {
@@ -60,9 +67,21 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
   Widget build(BuildContext context) {
     final chatGuid = widget.cvController.chat.guid;
     final hasBackground = ChatStateScope.maybeOf(context)?.hasCustomWallpaper ?? false;
+    final resolvedPart = part;
     if (!iOS) {
-      final messageText = controller.text.value;
-      String text = Message(text: messageText, subject: controller.subject.value).getNotificationText();
+      String text;
+      if (resolvedPart == null) {
+        text = "Failed to parse thread parts!";
+      } else {
+        final previewMessage = Message(
+          text: resolvedPart.text,
+          subject: resolvedPart.subject,
+          hasAttachments: resolvedPart.attachments.isNotEmpty,
+        )
+          ..dbAttachments.addAll(resolvedPart.attachments)
+          ..mergeWith(message);
+        text = previewMessage.getNotificationText();
+      }
       return MouseRegion(
         cursor: MouseCursor.defer,
         child: ConstrainedBox(
@@ -71,9 +90,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
             minHeight: 30,
           ),
           child: GestureDetector(
-            onTap: () {
-              showReplyThread(context, message, part, MessagesSvc(chatGuid), widget.cvController);
-            },
+            onTap: () => _openReplyThread(context, chatGuid, resolvedPart),
             child: Container(
               padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 15),
               decoration: hasBackground
@@ -118,9 +135,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
             child: MouseRegion(
               cursor: MouseCursor.defer,
               child: GestureDetector(
-                onTap: () {
-                  showReplyThread(context, message, part, MessagesSvc(chatGuid), widget.cvController);
-                },
+                onTap: () => _openReplyThread(context, chatGuid, resolvedPart),
                 behavior: HitTestBehavior.opaque,
                 child: IgnorePointer(
                   child: Row(
@@ -141,7 +156,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
                           connectUpper: false,
                           connectLower: false,
                         ),
-                        child: controller.partById(widget.part) == null
+                        child: resolvedPart == null
                             ? Container(
                                 color: hasBackground
                                     ? context.theme.colorScheme.errorContainer.withValues(alpha: 0.4)
@@ -174,11 +189,11 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
                                     constraints: const BoxConstraints(maxHeight: 100),
                                     child: ReplyScope(
                                       child: InteractiveHolder(
-                                        message: part,
+                                        message: resolvedPart,
                                       ),
                                     ),
                                   )
-                                : part.attachments.isEmpty
+                                : resolvedPart.attachments.isEmpty
                                     ? Container(
                                         color: hasBackground
                                             ? (message.isFromMe! ? context.theme.colorScheme.primary : getBubbleColor())
@@ -205,7 +220,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
                                             child: FutureBuilder<List<InlineSpan>>(
                                                 future: buildEnrichedMessageSpans(
                                                   context,
-                                                  part,
+                                                  resolvedPart,
                                                   message,
                                                   colorOverride: (message.isFromMe!
                                                           ? context.theme.colorScheme.primary
@@ -214,7 +229,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
                                                 ),
                                                 initialData: buildMessageSpans(
                                                   context,
-                                                  part,
+                                                  resolvedPart,
                                                   message,
                                                   colorOverride: (message.isFromMe!
                                                           ? context.theme.colorScheme.primary
@@ -238,7 +253,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
                                         constraints: const BoxConstraints(maxHeight: 100),
                                         child: ReplyScope(
                                           child: AttachmentHolder(
-                                            message: part,
+                                            message: resolvedPart,
                                           ),
                                         ),
                                       ),

--- a/lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart
@@ -32,7 +32,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
   late MessageState _ms;
   MessageState get controller => _ms;
 
-  MessagePart get part => controller.parts[widget.part];
+  MessagePart get part => controller.partById(widget.part)!;
   Message get message => controller.message;
 
   @override
@@ -141,7 +141,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
                           connectUpper: false,
                           connectLower: false,
                         ),
-                        child: controller.parts.length <= widget.part
+                        child: controller.partById(widget.part) == null
                             ? Container(
                                 color: hasBackground
                                     ? context.theme.colorScheme.errorContainer.withValues(alpha: 0.4)

--- a/lib/app/layouts/conversation_view/widgets/message/reply/reply_thread_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reply/reply_thread_popup.dart
@@ -17,7 +17,13 @@ import 'package:flutter_acrylic/flutter_acrylic.dart';
 void showReplyThread(BuildContext context, Message message, MessagePart part, MessagesService service,
     ConversationViewController cvController) {
   final originatorPart = message.threadOriginatorGuid != null ? message.normalizedThreadPart : part.part;
-  final _messages = service.struct.threads(message.threadOriginatorGuid ?? message.guid!, originatorPart);
+  final originatorGuid = message.threadOriginatorGuid ?? message.guid!;
+  final _messages = message.threadOriginatorGuid != null
+      ? service.struct.threads(originatorGuid, originatorPart)
+      : service.struct.threadsForParts(
+          originatorGuid,
+          part.attachmentPartIndices ?? [part.part],
+        );
   _messages.sort((a, b) => Message.sort(a, b, descending: false));
   _buildThreadView(_messages, originatorPart, cvController, context);
 }

--- a/lib/app/layouts/conversation_view/widgets/text_field/reply_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/reply_holder.dart
@@ -31,7 +31,7 @@ class _ReplyHolderState extends State<ReplyHolder> with ThemeHelpers {
       final chatGuid = message?.chat.target?.guid ?? ChatStateScope.maybeChatOf(context)?.guid;
       final resolvedReply = message?.guid == null || chatGuid == null
           ? message
-          : (maybeFindMessagesSvc(chatGuid)?.getMessageStateIfExists(message!.guid!)?.parts[part] ?? message);
+          : (maybeFindMessagesSvc(chatGuid)?.getMessageStateIfExists(message!.guid!)?.partById(part) ?? message);
       final reply = resolvedReply is MessagePart && attachmentGuid != null
           ? MessagePart(
               part: resolvedReply.part,

--- a/lib/app/layouts/conversation_view/widgets/text_field/reply_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/reply_holder.dart
@@ -26,22 +26,30 @@ class _ReplyHolderState extends State<ReplyHolder> with ThemeHelpers {
   Widget build(BuildContext context) {
     return Obx(() {
       final message = widget.controller.replyToMessage?.message;
-      final part = widget.controller.replyToMessage?.partIndex ?? 0;
+      final partIndex = widget.controller.replyToMessage?.partIndex ?? 0;
       final attachmentGuid = widget.controller.replyToMessage?.attachmentGuid;
       final chatGuid = message?.chat.target?.guid ?? ChatStateScope.maybeChatOf(context)?.guid;
-      final resolvedReply = message?.guid == null || chatGuid == null
-          ? message
-          : (maybeFindMessagesSvc(chatGuid)?.getMessageStateIfExists(message!.guid!)?.partById(part) ?? message);
-      final reply = resolvedReply is MessagePart && attachmentGuid != null
+      MessagePart? matched;
+      if (message?.guid != null && chatGuid != null) {
+        final state = maybeFindMessagesSvc(chatGuid)?.getMessageStateIfExists(message!.guid!);
+        if (state != null) {
+          if (attachmentGuid != null) {
+            matched = state.parts.firstWhereOrNull((p) => p.attachments.any((a) => a.guid == attachmentGuid));
+          }
+          matched ??= state.partById(partIndex);
+        }
+      }
+      final resolvedReply = matched ?? message;
+      final reply = matched != null && attachmentGuid != null
           ? MessagePart(
-              part: resolvedReply.part,
-              text: resolvedReply.text,
-              subject: resolvedReply.subject,
-              attachments: resolvedReply.attachments.where((a) => a.guid == attachmentGuid).toList(),
-              mentions: resolvedReply.mentions,
-              edits: resolvedReply.edits,
-              isUnsent: resolvedReply.isUnsent,
-              shouldRedact: resolvedReply.shouldRedact,
+              part: matched.part,
+              text: matched.text,
+              subject: matched.subject,
+              attachments: matched.attachments.where((a) => a.guid == attachmentGuid).toList(),
+              mentions: matched.mentions,
+              edits: matched.edits,
+              isUnsent: matched.isUnsent,
+              shouldRedact: matched.shouldRedact,
             )
           : resolvedReply;
       final date = widget.controller.scheduledDate.value;

--- a/lib/app/state/message_state.dart
+++ b/lib/app/state/message_state.dart
@@ -132,6 +132,22 @@ class MessageState extends StatefulController {
     return idx >= 0 ? parts[idx] : null;
   }
 
+  /// Whether [p] is the leading bubble of this message (covers raw part 0).
+  ///
+  /// Uses [MessagePart.coversPartId]; collapsed galleries keep a span in
+  /// [MessagePart.attachmentPartIndices] and set [MessagePart.part] to the first id.
+  bool isLeadingMessagePart(MessagePart p) => p.coversPartId(0);
+
+  /// Whether [p] is the trailing bubble of this message (covers the last raw part id).
+  ///
+  /// Uses [parts] from [buildMessageParts] (not the collapsed UI list). Collapsed
+  /// galleries keep a span in [MessagePart.attachmentPartIndices] and set
+  /// [MessagePart.part] to the first id, so trailing is decided via [MessagePart.coversPartId].
+  bool isTrailingMessagePart(MessagePart p) {
+    if (parts.isEmpty) return true;
+    return p.coversPartId(parts.last.part);
+  }
+
   /// Reactive state for the handle that sent this message.
   /// Null for outgoing messages or when no handle is attached.
   /// Drives sender name and bubble color without boilerplate [ever()] calls.

--- a/lib/app/state/message_state.dart
+++ b/lib/app/state/message_state.dart
@@ -73,9 +73,9 @@ class MessageState extends StatefulController {
   final RxBool isSent; // not temp guid
   final RxBool isReaction; // has associatedMessageGuid
 
-  /// Set to the part index that should play its bubble animation next frame.
+  /// Set to the message-part id that should play its bubble animation next frame.
   /// Consumers (BubbleEffects, TextBubble) wrap their animation trigger in Obx
-  /// and react when this equals their own part index.  Reset to null after
+  /// and react when this equals their own part id.  Reset to null after
   /// the animation has been kicked off so it can be retriggered later.
   final RxnInt playEffectPart = RxnInt(null);
 
@@ -125,6 +125,12 @@ class MessageState extends StatefulController {
   /// Reactive list of parsed message parts (text/attachments/edits/unsends).
   /// Populated by [buildMessageParts] in [onInit] and on content changes.
   final RxList<MessagePart> parts = <MessagePart>[].obs;
+
+  /// Finds a part by its message-part id ([MessagePart.part]), not list index.
+  MessagePart? partById(int partId) {
+    final idx = parts.indexWhere((p) => p.part == partId);
+    return idx >= 0 ? parts[idx] : null;
+  }
 
   /// Reactive state for the handle that sent this message.
   /// Null for outgoing messages or when no handle is attached.
@@ -220,7 +226,7 @@ class MessageState extends StatefulController {
 
   /// Signals that the bubble animation for [part] should play.
   /// [BubbleEffects] and [TextBubble] observe [playEffectPart] via ever() and
-  /// fire their animation when its value matches their own part index.
+  /// fire their animation when its value matches their own message-part id.
   /// Resetting to null first ensures re-triggering the same part always fires.
   void triggerBubbleEffect(int part) {
     if (playEffectPart.value == part) playEffectPart.value = null;

--- a/lib/database/global/chat_messages.dart
+++ b/lib/database/global/chat_messages.dart
@@ -21,6 +21,23 @@ class ChatMessages {
           .toList() ??
       [];
 
+  /// Returns replies whose [Message.normalizedThreadPart] matches any value in
+  /// [originatorParts], plus the originator when [returnOriginator] is true.
+  List<Message> threadsForParts(
+    String originatorGuid,
+    Iterable<int> originatorParts, {
+    bool returnOriginator = true,
+  }) {
+    final partIds = originatorParts.toSet();
+    return _threads[originatorGuid]
+            ?.values
+            .where((e) =>
+                (partIds.contains(e.normalizedThreadPart) && e.guid != originatorGuid) ||
+                (returnOriginator ? e.guid == originatorGuid : false))
+            .toList() ??
+        [];
+  }
+
   void addMessages(List<Message> __messages) {
     for (Message m in __messages) {
       if (m.associatedMessageGuid != null) {

--- a/lib/database/global/message_part.dart
+++ b/lib/database/global/message_part.dart
@@ -51,11 +51,11 @@ class MessagePart {
   int part;
 
   /// For gallery parts created by collapsing consecutive media-only parts,
-  /// maps each attachment (by index) to its original messagePart index.
+  /// maps each attachment (by index) to its original message-part id.
   /// Null for non-gallery parts or single-source-part galleries.
   List<int>? attachmentPartIndices;
 
-  /// Returns the original message part index for the attachment at [index].
+  /// Returns the original message-part id for the attachment at [index].
   /// Falls back to [part] if [attachmentPartIndices] is not set.
   int partIndexForAttachment(int index) => attachmentPartIndices?[index] ?? part;
 

--- a/lib/database/global/message_part.dart
+++ b/lib/database/global/message_part.dart
@@ -59,6 +59,17 @@ class MessagePart {
   /// Falls back to [part] if [attachmentPartIndices] is not set.
   int partIndexForAttachment(int index) => attachmentPartIndices?[index] ?? part;
 
+  /// Whether this bubble covers the raw message-part id [partId].
+  ///
+  /// For collapsed galleries, [attachmentPartIndices] is the span of original
+  /// ids; otherwise only [part] is covered. Collapsed bubbles set [part] to the
+  /// first id in that span.
+  bool coversPartId(int partId) {
+    final span = attachmentPartIndices;
+    if (span != null && span.isNotEmpty) return span.contains(partId);
+    return part == partId;
+  }
+
   bool get isEdited => edits.isNotEmpty;
   String? get url => text?.replaceAll("\n", " ").split(" ").firstWhereOrNull((String e) => e.hasUrl);
   String get fullText => sanitizeString([subject, text].where((e) => !isNullOrEmpty(e)).join("\n"));

--- a/lib/models/CLAUDE.md
+++ b/lib/models/CLAUDE.md
@@ -21,7 +21,7 @@ Barrel export: `models/models.dart`
 | `handle_sync_page.dart` | Pagination cursor for handle sync requests |
 | `location_attachment_data.dart` | Parsed location payload from a location message |
 | `message_receipt_info.dart` | Delivered/read receipt metadata for a message |
-| `message_reply_context.dart` | Context for a reply thread entry (parent GUID, part index) |
+| `message_reply_context.dart` | Context for a reply thread entry (parent message, part index, optional attachment GUID) |
 | `message_save_result.dart` | Result returned by message save action (id, status) |
 | `message_update_event.dart` | Carries field diffs for a message update notification |
 | `parsed_log_entry.dart` | Parsed structure of a single log file line |

--- a/lib/models/message_reply_context.dart
+++ b/lib/models/message_reply_context.dart
@@ -4,7 +4,11 @@ import 'package:bluebubbles/database/models.dart';
 @immutable
 class MessageReplyContext {
   final Message message;
+
+  /// Message-part id being replied to (not a collapsed list index).
   final int partIndex;
+
+  /// When set, scopes the reply to a specific attachment within [partIndex].
   final String? attachmentGuid;
 
   const MessageReplyContext(this.message, this.partIndex, {this.attachmentGuid});

--- a/lib/models/message_reply_context.dart
+++ b/lib/models/message_reply_context.dart
@@ -5,7 +5,7 @@ import 'package:bluebubbles/database/models.dart';
 class MessageReplyContext {
   final Message message;
 
-  /// Message-part id being replied to (not a collapsed list index).
+  /// Message-part id being replied to
   final int partIndex;
 
   /// When set, scopes the reply to a specific attachment within [partIndex].

--- a/lib/services/backend_ui_interop/intents.dart
+++ b/lib/services/backend_ui_interop/intents.dart
@@ -112,7 +112,7 @@ class ReplyRecentAction extends Action<ReplyRecentIntent> {
     final message = service.mostRecentReceived;
     if (message != null && SettingsSvc.settings.enablePrivateAPI.value) {
       final parts = service.getOrCreateState(message).parts;
-      cvc(chat).replyToMessage = MessageReplyContext(message, parts.length - 1);
+      cvc(chat).replyToMessage = MessageReplyContext(message, parts.isEmpty ? 0 : parts.last.part);
     }
     return null;
   }


### PR DESCRIPTION
Message-parts APIs currently incorrectly treat `parts` list indices as if they were iMessage part IDs. After edits, unsends, or gallery collapse, anything that keys off those values (replies, threads, swipe-to-reply, bubble chrome, and reactions) can target the wrong part or break.

This PR adds helpers to look up parts by id (`partById`, `coversPartId`), `attachmentGuid` for replies to a specific gallery attachment, and leading/trailing helpers (`isLeadingMessagePart` / `isTrailingMessagePart`) so collapsed galleries still get the correct tails, connect styling, and reaction/sticker placement.

### Bugs Addressed:
- Tapbacks/stickers on a photo in a collapsed gallery applied to / rendered on the wrong attachment (or didn’t appear)
- Popover Reply on a gallery image replied to the wrong part and previewed the wrong attachment
- Reply-thread open / reply-bubble render crashed or showed the whole parent message when the target part was missing
- Bubble effects, tails, avatars, and Material multi-bubble connectors broke on collapsed galleries because leading/trailing used list index instead of the gallery’s covered part ids
- “Reply recent” could target the wrong part when part ids don’t match parts.length - 1
- Reply-thread line decoration (and originator thread open via a gallery part) missed replies whose thread part id sat inside a collapsed gallery span; bubble-level “X Replies” on galleries is suppressed in favor of per-attachment reply UX

**Each architecture change is commit-by-commit, so you can review each commit individually for the scoped changes:**
``partById`` implementation → ``partById`` call sites → ``attachmentGuid`` for reply contexts→ null guards for missing messageParts→ leading/trailing part helpers → per-part/per-attachment reaction and sticker matching → ``threadsForParts`` so reply threads match any part id in a collapsed gallery span.

<details>
<summary>see file changes</summary>

### 1. add partById to resolve message parts by id instead of unstable list index

Adds `MessageState.partById` and switches reply/thread UI from `parts[index]` to lookup by `MessagePart.part`, so targeting survives edits, unsends, and gallery collapse.

- `lib/app/state/message_state.dart` — Add `partById` (lookup by `MessagePart.part`)
- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — Resolve reply-target parts by id
- `lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart` — Load the replied-to part by id
- `lib/app/layouts/conversation_view/widgets/text_field/reply_holder.dart` — Reply composer preview uses id lookup
- `lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart` — Thread originator resolved by id

### 2. fix: use message-part ids for swipe-to-reply, bubble effects, reply-recent, and gallery cards

Propagates part ids through the remaining interaction surfaces, and records original part ids per attachment when consecutive media parts collapse into a gallery.

- `lib/database/global/message_part.dart` — `partIndexForAttachment` / `attachmentPartIndices` for collapsed galleries
- `lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart` — Per-card swipe/reply uses each attachment’s original part id
- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — Swipe-to-reply / bubble effects use part ids
- `lib/app/layouts/conversation_view/widgets/message/misc/message_part_content.dart` — Pass part id through content wrapper
- `lib/services/backend_ui_interop/intents.dart` — Reply Recent targets `parts.last.part`, not `parts.length - 1`

### 3. fix: plumb attachmentGuid through reply context to resolve specific attachments

Extends reply context so a reply can target a specific attachment inside a multi-attachment part/gallery, not just the part id.

- `lib/models/message_reply_context.dart` — Optional `attachmentGuid` on reply context
- `lib/app/layouts/conversation_view/widgets/message/misc/swipe_to_reply_wrapper.dart` — Carry `attachmentGuid` into `MessageReplyContext`
- `lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart` — Popover reply sets guid when the part has a single attachment
- `lib/app/layouts/conversation_view/widgets/text_field/reply_holder.dart` — Preview resolves by guid first, then falls back to `partById`

### 4. fix: guard reply/thread paths when a reply targets a missing message part

Makes reply/thread paths null-safe when `partById` misses (deleted, unsent, or out-of-sync parts) instead of force-unwrapping.

- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — Null-safe matched part when rendering a reply target
- `lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart` — Nullable part; skip/fallback instead of `!`
- `lib/app/layouts/conversation_view/widgets/message/popup/actions/navigation_actions.dart` — Guard thread open when originator part is missing
- `lib/app/layouts/conversation_view/widgets/message/misc/swipe_to_reply_wrapper.dart` — Align with safer reply-context construction
- `lib/models/message_reply_context.dart` — Clarify `partIndex` as message-part id

### 5. fix: add isLeading/isTrailingMessagePart helpers for multipart layouts

Replaces list-position leading/trailing checks with span-aware helpers so bubble tails, connect styling, and chrome stay correct for collapsed galleries.

- `lib/database/global/message_part.dart` — `coversPartId` for single parts and gallery spans
- `lib/app/state/message_state.dart` — `isLeadingMessagePart` / `isTrailingMessagePart` via `coversPartId`
- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — Stickers, effects, connectUpper, tails use leading/trailing helpers
- `lib/app/layouts/conversation_view/widgets/message/parts/message_part_wrapper.dart` — Same for bubble wrapper chrome
- `lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart` — Tail only on trailing part
- `lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart` — Edit-history bubble chrome matches leading/trailing

### 6. fix: target correct message parts for bubble reactions/stickers for collapsed galleries via coversPartId

Switches reaction/sticker matching to `coversPartId` so associations against any id in a collapsed gallery span still render on that bubble.

- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — `reactionsForPart` takes `MessagePart` and filters via `coversPartId`
- `lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart` — Reactions, stickers, and spacing use span-aware matching
- `lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart` — Samsung timestamp padding uses the updated callback
- `lib/app/layouts/conversation_view/widgets/message/message_holder/message_reactions.dart` — Reaction widget callback signature matches

### 7. fix: resolve reply threads by message-part id across collapsed gallery part spans

Adds a multi-part thread lookup so replies keyed to any id covered by a collapsed gallery are found together, and keeps gallery reply UX per-attachment (native iMessage).

- `lib/database/global/chat_messages.dart` — `threadsForParts` matches `normalizedThreadPart` against any originator part id in the set
- `lib/app/layouts/conversation_view/widgets/message/message_holder.dart` — Reply line decoration uses `threadsForParts` with `attachmentPartIndices`
- `lib/app/layouts/conversation_view/widgets/message/misc/message_properties.dart` — Skip aggregate reply count on media galleries; otherwise use `threadsForParts`
- `lib/app/layouts/conversation_view/widgets/message/reply/reply_thread_popup.dart` — Opening a thread from a gallery originator unions replies across covered part ids

</details>

Groundwork for addressing #3122, #2605, and #2812 