### PR TITLE
fix: don't crash when a message lands before the messages view loads

### DIFF
--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -413,6 +413,17 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
       return;
     }
 
+    // service.init() registers this callback before the initial loadChunk above
+    // has awaited, so a message arriving in that window (e.g. from incremental
+    // sync) lands here while the mixin's service reference is still null.
+    // MessagesService._handleNewMessage has already added the message to struct
+    // and created its MessageState, so the initializeMessagesService pass that
+    // follows the load picks it up — there is no built list to insert into yet.
+    if (!isMessagesServiceInitialized) {
+      Logger.debug("handleNewMessage: View not initialized yet, deferring ${message.guid} to initial load");
+      return;
+    }
+
     Logger.debug("handleNewMessage: Received new message ${message.guid}, current count: ${_messages.length}");
 
     // Check if message already exists to prevent duplicates


### PR DESCRIPTION
### The bug

`MessagesView` registers `handleNewMessage` as the service's `newFunc` (via `service.init()`) before it awaits the initial `loadChunk`, but the mixin's `_messageService` isn't assigned until `initializeMessagesService()` runs after that await. A message that arrives in the window between those two (an incremental sync delivering one, for example) reaches `createStateForMessage` while `_messageService` is still null, so the null-check operator throws. The guarding `assert` is stripped in release, so AOT builds go straight to the crash:

```
Null check operator used on a null value
#0 MessagesServiceMixin.createStateForMessage
#1 MessagesViewState.handleNewMessage
#3 MessagesService.addNewMessage -> SyncService.startIncrementalSync
```

### The fix

Bail out of `handleNewMessage` early when the view hasn't finished initialising, right next to the existing `mounted` check (one guard plus a comment). Nothing is dropped: `MessagesService._handleNewMessage` has already added the message to `struct` and created its `MessageState` before it ever calls `newFunc`, so the `initializeMessagesService()` pass that follows the load picks it up. There is no built list to insert into at that point anyway, since the list key is recreated immediately after.

The `isMessagesServiceInitialized` getter this uses already exists on `master`; `handleNewMessage` just wasn't gating on it.
