### PR TITLE
Garcia/advanced tapbacks

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_reactions.dart
@@ -37,7 +37,7 @@ class ReactionObserver extends StatelessWidget {
       final isFromMe = state.isFromMe.value;
       final associatedMessages = state.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.checkReactionType(e.associatedMessageType))
           .toList();
       final reactionList = messageParts.length == 1 ? reactions : reactionsForPart(part.part, reactions).toList();
 
@@ -110,7 +110,7 @@ class ReactionSpacing extends StatelessWidget {
       // Directly observe MessageState associatedMessages for reactivity
       final associatedMessages = state.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.checkReactionType(e.associatedMessageType))
           .cast<Message>()
           .toList();
       // A gallery part can bundle several originally-separate message parts

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/message_holder_timestamps.dart
@@ -32,7 +32,7 @@ class SamsungTimestampObserver extends StatelessWidget {
       final isFromMe = ms.isFromMe.value;
       final associatedMessages = ms.associatedMessages;
       final reactions = associatedMessages
-          .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+          .where((e) => ReactionTypes.checkReactionType(e.associatedMessageType))
           .toList();
       return Padding(
         padding: (messageParts.length == 1 && reactions.isNotEmpty) || reactionsForPart(part.part, reactions).isNotEmpty

--- a/lib/app/layouts/conversation_view/widgets/message/misc/message_part_content.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/message_part_content.dart
@@ -67,7 +67,7 @@ class MessagePartContent extends StatelessWidget {
               // tapback can be associated with just one image/video, not the whole
               // gallery. Map reactions back to the specific attachment they landed on.
               final reactions = state.associatedMessages
-                  .where((e) => ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")))
+                  .where((e) => ReactionTypes.checkReactionType(e.associatedMessageType))
                   .toList();
               final reactionsByAttachmentKey = <String, List<Message>>{};
               for (int i = 0; i < messagePart.attachments.length; i++) {

--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -13,6 +13,7 @@ import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/popup/
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/popup/message_popup_action_context.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/popup/reaction_picker_clipper.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/popup/widgets/reaction_details.dart';
+import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/popup/widgets/emoji_picker_popup.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_pin_clipper.dart';
 import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
 import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
@@ -28,6 +29,7 @@ import 'package:flutter/material.dart' hide BackButton;
 import 'package:bluebubbles/database/models.dart' hide PayloadType;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:sprung/sprung.dart';
@@ -145,7 +147,7 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
       currentlySelectedReaction = null;
       reactions = getUniqueReactionMessages(message.associatedMessages
           .where((e) =>
-              ReactionTypes.toList().contains(e.associatedMessageType?.replaceAll("-", "")) &&
+              ReactionTypes.checkReactionType(e.associatedMessageType) &&
               (e.associatedMessagePart ?? 0) == part.part)
           .toList());
       final self = reactions.firstWhereOrNull((e) => e.isFromMe!)?.associatedMessageType;
@@ -345,9 +347,9 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
                                           return Row(
                                             mainAxisSize: MainAxisSize.min,
                                             mainAxisAlignment: MainAxisAlignment.start,
-                                            children: ReactionTypes.toList()
-                                                .slice(narrowScreen && index == 1 ? 3 : 0,
-                                                    narrowScreen && index == 0 ? 3 : null)
+                                            children: [...ReactionTypes.toList(), "+"]
+                                                .slice(narrowScreen && index == 1 ? 4 : 0,
+                                                    narrowScreen && index == 0 ? 4 : null)
                                                 .map((e) {
                                               return Padding(
                                                 padding: iOS
@@ -363,7 +365,17 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
                                                     height: iOS ? 35 : null,
                                                     child: InkWell(
                                                       borderRadius: BorderRadius.circular(20),
-                                                      onTap: () {
+                                                      onTap: () async {
+                                                        if (e == "+") {
+                                                          final String? customEmoji = await EmojiPickerPopup.show(context);
+                                                          if (customEmoji != null && customEmoji.isNotEmpty) {
+                                                            HapticFeedback.lightImpact();
+                                                            widget.sendTapback(selfReaction == customEmoji ? "-$customEmoji" : customEmoji, part.part);
+                                                            popDetails();
+                                                          }
+                                                          return;
+                                                        }
+
                                                         if (currentlySelectedReaction == e) {
                                                           currentlySelectedReaction = null;
                                                         } else {
@@ -377,36 +389,44 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
                                                       child: Padding(
                                                         padding: const EdgeInsets.all(6.5)
                                                             .add(EdgeInsets.only(right: e == "emphasize" ? 2.5 : 0)),
-                                                        child: iOS
-                                                            ? SvgPicture.asset(
-                                                                'assets/reactions/$e-black.svg',
-                                                                colorFilter: ColorFilter.mode(
-                                                                    e == "love" && currentlySelectedReaction == e
-                                                                        ? Colors.pink
-                                                                        : (currentlySelectedReaction == e
-                                                                            ? context.theme.colorScheme.onPrimary
-                                                                            : context.theme.colorScheme.outline),
-                                                                    BlendMode.srcIn),
+                                                        child: e == "+"
+                                                            ? Center(
+                                                                child: Icon(
+                                                                  iOS ? cupertino.CupertinoIcons.add : Icons.add,
+                                                                  color: context.theme.colorScheme.outline,
+                                                                  size: 20,
+                                                                ),
                                                               )
-                                                            : Center(
-                                                                child: Builder(builder: (context) {
-                                                                  final text = Text(
-                                                                    ReactionTypes.reactionToEmoji[e] ?? "X",
-                                                                    style: const TextStyle(
-                                                                        fontSize: 18, fontFamily: 'Apple Color Emoji'),
-                                                                    textAlign: TextAlign.center,
-                                                                  );
-                                                                  // rotate thumbs down to match iOS
-                                                                  if (e == "dislike") {
-                                                                    return Transform(
-                                                                      transform: Matrix4.identity()..rotateY(pi),
-                                                                      alignment: FractionalOffset.center,
-                                                                      child: text,
-                                                                    );
-                                                                  }
-                                                                  return text;
-                                                                }),
-                                                              ),
+                                                            : (iOS
+                                                                ? SvgPicture.asset(
+                                                                    'assets/reactions/$e-black.svg',
+                                                                    colorFilter: ColorFilter.mode(
+                                                                        e == "love" && currentlySelectedReaction == e
+                                                                            ? Colors.pink
+                                                                            : (currentlySelectedReaction == e
+                                                                                ? context.theme.colorScheme.onPrimary
+                                                                                : context.theme.colorScheme.outline),
+                                                                        BlendMode.srcIn),
+                                                                  )
+                                                                : Center(
+                                                                    child: Builder(builder: (context) {
+                                                                      final text = Text(
+                                                                        ReactionTypes.emojiForReaction(e),
+                                                                        style: const TextStyle(
+                                                                            fontSize: 18, fontFamily: 'Apple Color Emoji'),
+                                                                        textAlign: TextAlign.center,
+                                                                      );
+                                                                      // rotate thumbs down to match iOS
+                                                                      if (e == "dislike") {
+                                                                        return Transform(
+                                                                          transform: Matrix4.identity()..rotateY(pi),
+                                                                          alignment: FractionalOffset.center,
+                                                                          child: text,
+                                                                        );
+                                                                      }
+                                                                      return text;
+                                                                    }),
+                                                                  )),
                                                       ),
                                                     ),
                                                   ),

--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -29,7 +29,7 @@ import 'package:flutter/material.dart' hide BackButton;
 import 'package:bluebubbles/database/models.dart' hide PayloadType;
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
-import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:sprung/sprung.dart';

--- a/lib/app/layouts/conversation_view/widgets/message/popup/widgets/emoji_picker_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/widgets/emoji_picker_popup.dart
@@ -1,0 +1,193 @@
+import 'dart:ui';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class EmojiPickerPopup extends StatelessWidget {
+  const EmojiPickerPopup({
+    super.key,
+    required this.onEmojiSelected,
+  });
+
+  final Function(String emoji) onEmojiSelected;
+
+  static Future<String?> show(BuildContext context) {
+    return showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => EmojiPickerPopup(
+        onEmojiSelected: (emoji) => Navigator.of(context).pop(emoji),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final skin = SettingsSvc.settings.skin.value;
+    final isMaterial = skin == Skins.Material;
+    final isIOS = skin == Skins.iOS;
+    final isSamsung = skin == Skins.Samsung;
+
+    final colorScheme = context.theme.colorScheme;
+    final double sheetHeight = context.height * 0.45;
+
+    Widget sheetContent = Container(
+      height: sheetHeight,
+      decoration: BoxDecoration(
+        color: isIOS
+            ? colorScheme.surface.withOpacity(0.85)
+            : (isMaterial
+                ? (colorScheme.surfaceContainer ?? colorScheme.surface)
+                : colorScheme.surface),
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(isMaterial ? 28 : (isSamsung ? 24 : 16)),
+        ),
+        boxShadow: isIOS
+            ? []
+            : [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.15),
+                  blurRadius: 10,
+                  spreadRadius: 2,
+                )
+              ],
+      ),
+      child: Column(
+        children: [
+          // Drag handle
+          Container(
+            margin: const EdgeInsets.only(top: 10, bottom: 6),
+            width: 36,
+            height: 4,
+            decoration: BoxDecoration(
+              color: colorScheme.onSurfaceVariant.withOpacity(0.4),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          Expanded(
+            child: EmojiPicker(
+              onEmojiSelected: (category, emoji) {
+                onEmojiSelected(emoji.emoji);
+              },
+              config: Config(
+                height: sheetHeight - 20,
+                checkPlatformCompatibility: true,
+                emojiViewConfig: EmojiViewConfig(
+                  emojiSizeMax: 28,
+                  backgroundColor: Colors.transparent,
+                  columns: 8,
+                  noRecents: Text(
+                    "No Recents",
+                    style: context.textTheme.bodyMedium!.copyWith(
+                      color: colorScheme.outline,
+                    ),
+                  ),
+                ),
+                viewOrderConfig: const ViewOrderConfig(
+                  top: EmojiPickerItem.categoryBar,
+                  middle: EmojiPickerItem.emojiView,
+                  bottom: EmojiPickerItem.searchBar,
+                ),
+                skinToneConfig: const SkinToneConfig(enabled: true),
+                categoryViewConfig: CategoryViewConfig(
+                  backgroundColor: Colors.transparent,
+                  dividerColor: isIOS
+                      ? colorScheme.outline.withOpacity(0.2)
+                      : Colors.transparent,
+                  indicatorColor: colorScheme.primary,
+                  iconColor: colorScheme.onSurfaceVariant,
+                  iconColorSelected: colorScheme.primary,
+                  categoryIcons: isIOS
+                      ? const CategoryIcons(
+                          recentIcon: CupertinoIcons.clock,
+                          smileyIcon: CupertinoIcons.smiley,
+                          animalIcon: CupertinoIcons.paw,
+                          foodIcon: CupertinoIcons.heart,
+                          activityIcon: CupertinoIcons.sportscourt,
+                          travelIcon: CupertinoIcons.car_fill,
+                          objectIcon: CupertinoIcons.lightbulb,
+                          symbolIcon: CupertinoIcons.number,
+                          flagIcon: CupertinoIcons.flag,
+                        )
+                      : const CategoryIcons(
+                          recentIcon: Icons.access_time_filled_rounded,
+                          smileyIcon: Icons.sentiment_satisfied_alt_rounded,
+                          animalIcon: Icons.pets_rounded,
+                          foodIcon: Icons.fastfood_rounded,
+                          activityIcon: Icons.sports_soccer_rounded,
+                          travelIcon: Icons.directions_car_rounded,
+                          objectIcon: Icons.lightbulb_rounded,
+                          symbolIcon: Icons.emoji_symbols_rounded,
+                          flagIcon: Icons.flag_rounded,
+                        ),
+                ),
+                bottomActionBarConfig: BottomActionBarConfig(
+                  customBottomActionBar: (config, state, showSearchView) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: GestureDetector(
+                        onTap: showSearchView,
+                        child: Container(
+                          height: 44,
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          decoration: BoxDecoration(
+                            color: isMaterial
+                                ? (colorScheme.surfaceContainerHigh ?? colorScheme.surfaceContainerHighest)
+                                : colorScheme.surfaceContainerHighest.withOpacity(0.6),
+                            borderRadius: BorderRadius.circular(isMaterial ? 22 : 12),
+                            border: Border.all(
+                              color: colorScheme.outline.withOpacity(0.15),
+                            ),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(
+                                isIOS ? CupertinoIcons.search : Icons.search_rounded,
+                                color: colorScheme.onSurfaceVariant,
+                                size: 20,
+                              ),
+                              const SizedBox(width: 12),
+                              Text(
+                                "Search emojis",
+                                style: context.textTheme.bodyMedium!.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                searchViewConfig: SearchViewConfig(
+                  backgroundColor: isMaterial
+                      ? (colorScheme.surfaceContainer ?? colorScheme.surface)
+                      : colorScheme.surface,
+                  buttonIconColor: colorScheme.primary,
+                  hintText: "Search emojis...",
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (isIOS) {
+      return ClipRRect(
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: sheetContent,
+        ),
+      );
+    }
+
+    return sheetContent;
+  }
+}

--- a/lib/app/layouts/conversation_view/widgets/message/popup/widgets/emoji_picker_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/widgets/emoji_picker_popup.dart
@@ -41,7 +41,7 @@ class EmojiPickerPopup extends StatelessWidget {
         color: isIOS
             ? colorScheme.surface.withOpacity(0.85)
             : (isMaterial
-                ? (colorScheme.surfaceContainer ?? colorScheme.surface)
+                ? colorScheme.surfaceContainer
                 : colorScheme.surface),
         borderRadius: BorderRadius.vertical(
           top: Radius.circular(isMaterial ? 28 : (isSamsung ? 24 : 16)),
@@ -136,8 +136,8 @@ class EmojiPickerPopup extends StatelessWidget {
                           padding: const EdgeInsets.symmetric(horizontal: 16),
                           decoration: BoxDecoration(
                             color: isMaterial
-                                ? (colorScheme.surfaceContainerHigh ?? colorScheme.surfaceContainerHighest)
-                                : colorScheme.surfaceContainerHighest.withOpacity(0.6),
+                                ? colorScheme.surfaceContainerHigh
+                                : colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
                             borderRadius: BorderRadius.circular(isMaterial ? 22 : 12),
                             border: Border.all(
                               color: colorScheme.outline.withOpacity(0.15),
@@ -166,7 +166,7 @@ class EmojiPickerPopup extends StatelessWidget {
                 ),
                 searchViewConfig: SearchViewConfig(
                   backgroundColor: isMaterial
-                      ? (colorScheme.surfaceContainer ?? colorScheme.surface)
+                      ? colorScheme.surfaceContainer
                       : colorScheme.surface,
                   buttonIconColor: colorScheme.primary,
                   hintText: "Search emojis...",

--- a/lib/app/layouts/conversation_view/widgets/message/popup/widgets/reaction_details.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/widgets/reaction_details.dart
@@ -91,11 +91,11 @@ class ReactionDetails extends StatelessWidget {
                           ],
                         ),
                         child: Padding(
-                          padding: SettingsSvc.settings.skin.value == Skins.iOS
+                          padding: SettingsSvc.settings.skin.value == Skins.iOS && ReactionTypes.toList().contains(message.associatedMessageType?.replaceAll("-", ""))
                               ? const EdgeInsets.only(top: 8.0, left: 7.0, right: 7.0, bottom: 7.0)
                                   .add(EdgeInsets.only(right: message.associatedMessageType == "emphasize" ? 1 : 0))
                               : EdgeInsets.zero,
-                          child: SettingsSvc.settings.skin.value == Skins.iOS
+                          child: SettingsSvc.settings.skin.value == Skins.iOS && ReactionTypes.toList().contains(message.associatedMessageType?.replaceAll("-", ""))
                               ? SvgPicture.asset(
                                   'assets/reactions/${message.associatedMessageType}-black.svg',
                                   colorFilter: ColorFilter.mode(
@@ -110,7 +110,7 @@ class ReactionDetails extends StatelessWidget {
                               : Center(
                                   child: Builder(builder: (context) {
                                     final text = Text(
-                                      ReactionTypes.reactionToEmoji[message.associatedMessageType] ?? "X",
+                                      ReactionTypes.emojiForReaction(message.associatedMessageType),
                                       style: const TextStyle(fontSize: 18, fontFamily: 'Apple Color Emoji'),
                                       textAlign: TextAlign.center,
                                     );

--- a/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
@@ -181,7 +181,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
               child: Center(
                 child: Builder(builder: (context) {
                   final text = Text(
-                    ReactionTypes.reactionToEmoji[reactionType] ?? "X",
+                    ReactionTypes.emojiForReaction(reactionType),
                     style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
                     textAlign: TextAlign.center,
                   );
@@ -238,16 +238,24 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
                           child: Padding(
                         padding:
                             const EdgeInsets.all(6.5).add(EdgeInsets.only(right: reactionType == "emphasize" ? 1 : 0)),
-                        child: SvgPicture.asset(
-                          'assets/reactions/$reactionType-black.svg',
-                          colorFilter: ColorFilter.mode(
-                              reactionType == "love"
-                                  ? Colors.pink
-                                  : (reactionIsFromMe
-                                      ? context.theme.colorScheme.onPrimary
-                                      : context.theme.colorScheme.onSurfaceVariant),
-                              BlendMode.srcIn),
-                        ),
+                        child: ReactionTypes.toList().contains(reactionType.replaceAll("-", ""))
+                            ? SvgPicture.asset(
+                                'assets/reactions/$reactionType-black.svg',
+                                colorFilter: ColorFilter.mode(
+                                    reactionType == "love"
+                                        ? Colors.pink
+                                        : (reactionIsFromMe
+                                            ? context.theme.colorScheme.onPrimary
+                                            : context.theme.colorScheme.onSurfaceVariant),
+                                    BlendMode.srcIn),
+                              )
+                            : Center(
+                                child: Text(
+                                  ReactionTypes.emojiForReaction(reactionType),
+                                  style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
                       )),
                     ));
               })),
@@ -341,7 +349,7 @@ class ReactionWidgetState extends State<ReactionWidget> with ThemeHelpers {
         child: Center(
           child: Builder(builder: (ctx) {
             final text = Text(
-              ReactionTypes.reactionToEmoji[rType] ?? "X",
+              ReactionTypes.emojiForReaction(rType),
               style: const TextStyle(fontSize: 15, fontFamily: 'Apple Color Emoji'),
               textAlign: TextAlign.center,
             );

--- a/lib/database/html/message.dart
+++ b/lib/database/html/message.dart
@@ -189,7 +189,11 @@ class Message {
       associatedMessageGuid: json["associatedMessageGuid"]?.toString().replaceAll("bp:", "").split("/").last,
       associatedMessagePart: json["associatedMessagePart"] ??
           int.tryParse(json["associatedMessageGuid"].toString().replaceAll("p:", "").split("/").first),
-      associatedMessageType: json["associatedMessageType"],
+      associatedMessageType: (json["associatedMessageEmoji"] != null && json["associatedMessageEmoji"].toString().isNotEmpty)
+          ? (json["associatedMessageType"] == "3006" || json["associatedMessageType"] == "-emoji"
+              ? "-${json["associatedMessageEmoji"]}"
+              : json["associatedMessageEmoji"])
+          : json["associatedMessageType"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
       handle: json['handle'] != null ? Handle.fromMap(json['handle']) : null,
       hasAttachments: attachments.isNotEmpty || json['hasAttachments'] == true,

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -310,7 +310,7 @@ class Chat {
 
     /// If reaction and notify reactions off, then don't notify, otherwise notify
     return !SettingsSvc.settings.notifyReactions.value &&
-        ReactionTypes.toList().contains(message?.associatedMessageType ?? "");
+        ReactionTypes.checkReactionType(message?.associatedMessageType);
   }
 
   /// Toggle unread status - pure DB operation

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -264,7 +264,11 @@ class Message {
       associatedMessageGuid: json["associatedMessageGuid"]?.toString().replaceAll("bp:", "").split("/").last,
       associatedMessagePart: json["associatedMessagePart"] ??
           int.tryParse(json["associatedMessageGuid"].toString().replaceAll("p:", "").split("/").first),
-      associatedMessageType: json["associatedMessageType"],
+      associatedMessageType: (json["associatedMessageEmoji"] != null && json["associatedMessageEmoji"].toString().isNotEmpty)
+          ? (json["associatedMessageType"] == "3006" || json["associatedMessageType"] == "-emoji"
+              ? "-${json["associatedMessageEmoji"]}"
+              : json["associatedMessageEmoji"])
+          : json["associatedMessageType"],
       expressiveSendStyleId: json["expressiveSendStyleId"],
       handle: json['handle'] != null ? Handle.fromMap(json['handle']!.cast<String, Object>()) : null,
       hasAttachments: (json['attachments'] as List? ?? []).isNotEmpty || json['hasAttachments'] == true,
@@ -616,7 +620,7 @@ class Message {
   List<Attachment> get previewAttachments => dbAttachments.where((e) => e.mimeType == null).toList();
 
   List<Message> get reactions => associatedMessages
-      .where((item) => ReactionTypes.toList().contains(item.associatedMessageType?.replaceAll("-", "")))
+      .where((item) => ReactionTypes.checkReactionType(item.associatedMessageType))
       .toList();
 
   MessageStatusIndicator get indicatorToShow {

--- a/lib/helpers/types/extensions/extensions.dart
+++ b/lib/helpers/types/extensions/extensions.dart
@@ -364,8 +364,8 @@ extension MessageNotificationExtension on Message {
         // fetch the associated message object
         Message? associatedMessage = Message.findOne(guid: associatedMessageGuid);
         if (associatedMessage != null) {
-          // grab the verb we'll use from the reactionToVerb map
-          String? verb = ReactionTypes.reactionToVerb[associatedMessageType];
+          // grab the verb we'll use from the verbForReaction helper
+          String verb = ReactionTypes.verbForReaction(associatedMessageType);
           // we need to check balloonBundleId first because for some reason
           // game pigeon messages have the text "�"
           if (associatedMessage.isInteractive) {

--- a/lib/helpers/ui/reaction_helpers.dart
+++ b/lib/helpers/ui/reaction_helpers.dart
@@ -58,6 +58,29 @@ class ReactionTypes {
     "❗": EMPHASIZE,
     "❓": QUESTION,
   };
+
+  static bool checkReactionType(String? type) {
+    if (type == null) return false;
+    String clean = type.replaceAll("-", "");
+    if (toList().contains(clean)) return true;
+    return RegExp(r'(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])').hasMatch(clean);
+  }
+
+  static String emojiForReaction(String? type) {
+    if (type == null) return "X";
+    String clean = type.replaceAll("-", "");
+    if (reactionToEmoji.containsKey(clean)) return reactionToEmoji[clean]!;
+    if (checkReactionType(clean)) return clean;
+    return "X";
+  }
+
+  static String verbForReaction(String? type) {
+    if (type == null) return "reacted to";
+    if (reactionToVerb.containsKey(type)) return reactionToVerb[type]!;
+    bool isRemoval = type.startsWith("-");
+    String emoji = type.replaceAll("-", "");
+    return isRemoval ? "removed $emoji from" : "reacted with $emoji to";
+  }
 }
 
 List<Message> getUniqueReactionMessages(List<Message> messages) {


### PR DESCRIPTION
This PR upgrades the Private API to support arbitrary tapbacks beyond the standard six reactions. See corresponding PRs to the helper and server repos as well.

Helpers PR: https://github.com/BlueBubblesApp/bluebubbles-helper/pull/68
Server PR: https://github.com/BlueBubblesApp/bluebubbles-server/pull/839

Closes https://github.com/BlueBubblesApp/bluebubbles-app/issues/2829
Closes https://github.com/BlueBubblesApp/bluebubbles-app/issues/2823

Verification Evidence:

Added '+' option to open emoji picker:
<img width="216" height="482" alt="Screenshot_20260802-211907" src="https://github.com/user-attachments/assets/4c427a70-f259-4576-a10a-fff254fe0310" />

Emoji Picker:
<img width="216" height="482" alt="Screenshot_20260802-211917" src="https://github.com/user-attachments/assets/24b7d135-f531-43b2-a974-583b321baddf" />

Chat View:
<img width="216" height="482" alt="Screenshot_20260802-211902" src="https://github.com/user-attachments/assets/0cf2bbb6-6ff8-4ba0-b368-1696eb3f2d69" />

Reaction Inspect View:
<img width="216" height="482" alt="Screenshot_20260802-211929" src="https://github.com/user-attachments/assets/d527fcb5-06c7-4ced-a8b6-3f699d730193" />

Chat List:
<img width="365" height="482" alt="Screenshot_20260802-212521" src="https://github.com/user-attachments/assets/6535a05c-d97a-45fc-9cb6-264b453e4137" />

