### PR TITLE
feat: add an option to disable FCM notifications

### DIFF
--- a/lib/app/layouts/settings/pages/advanced/firebase_panel.dart
+++ b/lib/app/layouts/settings/pages/advanced/firebase_panel.dart
@@ -83,10 +83,32 @@ class _FirebasePanelState extends State<FirebasePanel> with ThemeHelpers {
                       (SocketSvc.socket?.connected ?? false);
                   final fcmRegistered =
                       SettingsSvc.settings.firstFcmRegisterDate.value != 0 && !SettingsSvc.fcmData.isNull;
+                  // On mobile, hide the (re-)register actions when FCM is turned off — they call
+                  // registerDevice(), which early-returns, and would report a misleading success.
+                  final fcmEnabled = kIsDesktop || kIsWeb || SettingsSvc.settings.enableFcm.value;
 
                   return SettingsSection(
                   backgroundColor: tileColor,
                   children: [
+                    if (!kIsDesktop && !kIsWeb)
+                      Obx(() => SettingsSwitch(
+                            onChanged: (bool val) async {
+                              SettingsSvc.settings.enableFcm.value = val;
+                              await SettingsSvc.settings.saveOneAsync('enableFcm');
+                            },
+                            initialVal: SettingsSvc.settings.enableFcm.value,
+                            title: "Use Firebase (FCM)",
+                            subtitle:
+                                "Receive notifications through Google Firebase. Turn off if you use another provider such as UnifiedPush and don't want Firebase.",
+                            isThreeLine: true,
+                            backgroundColor: tileColor,
+                            leading: const SettingsLeadingIcon(
+                              iosIcon: CupertinoIcons.bell_fill,
+                              materialIcon: Icons.notifications_active,
+                              containerColor: Colors.blueAccent,
+                            ),
+                          )),
+                    if (!kIsDesktop && !kIsWeb) const SettingsDivider(),
                     SettingsTile(
                         backgroundColor: tileColor,
                         title: "Firebase Status",
@@ -102,8 +124,8 @@ class _FirebasePanelState extends State<FirebasePanel> with ThemeHelpers {
                           materialIcon: Icons.settings,
                           containerColor: statusOk ? Colors.green : Colors.redAccent,
                         )),
-                    if (!socketReady) const SettingsDivider(),
-                    if (!socketReady)
+                    if (fcmEnabled && !socketReady) const SettingsDivider(),
+                    if (fcmEnabled && !socketReady)
                       SettingsTile(
                         backgroundColor: tileColor,
                         title: "Load Configurations from Server",
@@ -231,8 +253,8 @@ class _FirebasePanelState extends State<FirebasePanel> with ThemeHelpers {
                             NavigationSvc.pushSettings(context, const OauthPanel());
                           },
                           trailing: const NextButton()),
-                    if (!kIsDesktop && !kIsWeb && fcmRegistered) const SettingsDivider(),
-                    if (!kIsDesktop && !kIsWeb && fcmRegistered)
+                    if (fcmEnabled && !kIsDesktop && !kIsWeb && fcmRegistered) const SettingsDivider(),
+                    if (fcmEnabled && !kIsDesktop && !kIsWeb && fcmRegistered)
                       SettingsTile(
                         backgroundColor: tileColor,
                         title: "Re-register Device with Server",

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -151,6 +151,11 @@ class Settings {
   final RxBool enableUnifiedPush = false.obs;
   final RxString endpointUnifiedPush = RxString("");
 
+  // FCM (Firebase) push delivery — Android's default notification transport. Turn off to
+  // skip Firebase registration when using another provider (e.g. UnifiedPush) or the
+  // background service; the server then drops the device via its inactivity purge.
+  final RxBool enableFcm = true.obs;
+
   // Quick tapback settings
   final RxBool enableQuickTapback = false.obs;
   final RxString quickTapbackType = ReactionTypes.toList()[0].obs; // The 'love' reaction
@@ -395,6 +400,7 @@ class Settings {
       'privateAPIAttachmentSend': privateAPIAttachmentSend.value,
       'enableUnifiedPush': enableUnifiedPush.value,
       'endpointUnifiedPush': endpointUnifiedPush.value,
+      'enableFcm': enableFcm.value,
       'highlightSelectedChat': highlightSelectedChat.value,
       'enablePrivateAPI': enablePrivateAPI.value,
       'privateSendTypingIndicators': privateSendTypingIndicators.value,
@@ -630,6 +636,7 @@ class Settings {
         map['enableUnifiedPush'] ?? SettingsSvc.settings.enableUnifiedPush.value;
     SettingsSvc.settings.endpointUnifiedPush.value =
         map['endpointUnifiedPush'] ?? SettingsSvc.settings.endpointUnifiedPush.value;
+    SettingsSvc.settings.enableFcm.value = map['enableFcm'] ?? SettingsSvc.settings.enableFcm.value;
     SettingsSvc.settings.enableQuickTapback.value =
         map['enableQuickTapback'] ?? SettingsSvc.settings.enableQuickTapback.value;
     SettingsSvc.settings.quickTapbackType.value =
@@ -826,6 +833,7 @@ class Settings {
     s.hideMessageContent.value = map['generateFakeMessageContent'] ?? false;
     s.enableUnifiedPush.value = map['enableUnifiedPush'] ?? false;
     s.endpointUnifiedPush.value = map['endpointUnifiedPush'] ?? "";
+    s.enableFcm.value = map['enableFcm'] ?? true;
     s.enableQuickTapback.value = map['enableQuickTapback'] ?? false;
     s.quickTapbackType.value = map['quickTapbackType'] ?? ReactionTypes.toList()[0];
     s.notificationReactionAction.value = map['notificationReactionAction'] ?? true;

--- a/lib/services/network/firebase/cloud_messaging_service.dart
+++ b/lib/services/network/firebase/cloud_messaging_service.dart
@@ -26,6 +26,15 @@ class CloudMessagingService {
 
   /// Register this device with FCM
   Future<void> registerDevice() async {
+    // On mobile the user can disable FCM (e.g. they rely on UnifiedPush or the background service).
+    // Skip registration entirely in that case: nothing is attempted, so a transient Firebase failure
+    // can't surface the "Failed to register FCM device!" banner for a transport they aren't using.
+    // The server drops the device via its inactivity purge, so FCM stops being a delivery route.
+    if (!kIsDesktop && !kIsWeb && !SettingsSvc.settings.enableFcm.value) {
+      Logger.debug("FCM is disabled in settings, skipping registration", tag: 'FCM-Auth');
+      return;
+    }
+
     // Make sure setup is complete, and that we aren't currently registering with FCM
     // Users can also choose to disable FCM in settings
     if (!SettingsSvc.settings.finishedSetup.value || SettingsSvc.settings.keepAppAlive.value) return;


### PR DESCRIPTION
Adds a "Use Firebase (FCM)" switch (default on) to the Firebase settings panel on mobile.

Why: users who get notifications through UnifiedPush/ntfy, or who run the keep-alive
background service, don't use FCM, but the app still registers with Firebase on every launch.
When that registration transiently fails they see a "Failed to register FCM device!" toast for
a channel they aren't using. Today the only way to avoid FCM is to enable keepAppAlive, which
forces a foreground service.

When the toggle is off:
- registerDevice() skips Firebase registration entirely, so the transient failure toast can't fire.
- The server drops the device through its existing 31-day inactivity purge, so it stops being a
  delivery route.
- The Firebase panel's register/re-register actions are hidden (they would otherwise no-op and
  report a misleading success).

Default is on, so existing installs are unchanged. Scoped to mobile (desktop/web don't register
with FCM). Small footprint: one setting, the guard, and the settings tile.
