### PR TITLE
fix: persist the Firebase config clear before exiting

### DIFF
--- a/lib/app/layouts/settings/pages/advanced/firebase_panel.dart
+++ b/lib/app/layouts/settings/pages/advanced/firebase_panel.dart
@@ -351,6 +351,11 @@ class _FirebasePanelState extends State<FirebasePanel> with ThemeHelpers {
 
                                     SettingsSvc.settings.firstFcmRegisterDate.value = 0;
                                     await SettingsSvc.settings.saveOneAsync('firstFcmRegisterDate');
+                                    // deleteFcmData() clears the FCM config from SharedPreferences via an
+                                    // async write. exit(0) hard-kills the process, which can terminate that
+                                    // background write before it flushes to disk, leaving a stale config that
+                                    // reloads on next launch. Give the write a moment to land before exiting.
+                                    await Future.delayed(const Duration(seconds: 1));
                                     exit(0);
                                   },
                                 ),


### PR DESCRIPTION
"Clear Configurations" in the Firebase panel doesn't stick: after clearing and relaunching,
Firebase shows as "Configured" again and the app re-registers with FCM.

Root cause: deleteFcmData() clears the FCM config from SharedPreferences (SharedPreferencesWithCache
over the async Android store), then the panel calls exit(0) a few ms later. The prefs removal is
written asynchronously, and the hard exit(0) tears the process down before that background write
flushes to disk, so the on-disk config survives and reloads on next launch. (The ObjectBox copy is
cleared durably; it's the prefs mirror that comes back, and getFCM() falls through to it.)

Confirmed with a debug build: immediately after clearConfig() the in-memory read returns cleared,
but the very next launch reads the config back from prefs.

Fix: let the async prefs write flush before exit(0). It's a brief wait before exit.

Repro: Firebase panel -> Clear Configurations -> confirm (app exits) -> reopen. Status reads
"Configured" again.
