### PR TITLE
fix: don't rebuild FCM config from the SharedPreferences mirror

### DIFF
--- a/lib/database/io/fcm_data.dart
+++ b/lib/database/io/fcm_data.dart
@@ -70,17 +70,13 @@ class FCMData {
   }
 
   static FCMData getFCM() {
+    // ObjectBox is the durable source of truth for FCM configuration. When it's empty the
+    // config isn't present, so return an unconfigured FCMData rather than rebuilding it from
+    // the SharedPreferences mirror. That mirror can lag behind the database (e.g. a clear
+    // whose async prefs write didn't flush before the app exited), and reading it here would
+    // otherwise resurrect a configuration the user already cleared.
     final result = Database.fcmData.getAll();
-    if (result.isEmpty) {
-      return FCMData(
-        projectID: PrefsSvc.firebase.getProjectID(),
-        storageBucket: PrefsSvc.firebase.getStorageBucket(),
-        apiKey: PrefsSvc.firebase.getApiKey(),
-        firebaseURL: PrefsSvc.firebase.getFirebaseURL(),
-        clientID: PrefsSvc.firebase.getClientID(),
-        applicationID: PrefsSvc.firebase.getApplicationID(),
-      );
-    }
+    if (result.isEmpty) return FCMData();
     return result.first;
   }
 


### PR DESCRIPTION
getFCM() treats the SharedPreferences copy of the FCM config as a fallback: when the ObjectBox
store is empty it rebuilds FCMData from prefs. That mirror can lag behind the database, so an FCM
config that was cleared from ObjectBox gets resurrected from a stale prefs copy.

ObjectBox is the durable source of truth here (FCMData.save() writes both stores together, and the
DB is the primary). When it's empty, return an unconfigured FCMData instead of reading the prefs
mirror. A cleared config then stays cleared. No change for configured installs, since the DB has
the record and is returned as before.

This is independent of #3164 (they address the same "clear doesn't stick" symptom at different
layers) and applies as defense-in-depth even if the prefs write in that PR flushes correctly.
