### PR TITLE
Fix reaction picker wrapping logic based on actual available width

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -184,9 +184,20 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
 
   @override
   Widget build(BuildContext context) {
-    double narrowWidth =
-        message.isFromMe! || !(chat.isGroup || SettingsSvc.settings.alwaysShowAvatars.value) ? 330 : 360;
-    bool narrowScreen = NavigationSvc.width(widthContext) < narrowWidth;
+    // Decide whether the tapback row needs to wrap to a second line by comparing its actual
+    // content width (derived from the fixed per-item padding/icon sizes used below) against the
+    // real horizontal space available at the picker's anchor position, rather than guessing from
+    // overall screen width. widget.childPosition.dx already reflects any avatar space the bubble
+    // was pushed past, so no avatar/group special-casing is needed here.
+    final double screenWidth = NavigationSvc.width(widthContext);
+    const double reactionPickerEdgeMargin = 15;
+    final double reactionPickerAvailableWidth = message.isFromMe!
+        ? screenWidth - reactionPickerEdgeMargin - reactionPickerEdgeMargin
+        : screenWidth - (widget.childPosition.dx + 10) - reactionPickerEdgeMargin;
+    final double reactionItemWidth = iOS ? 47.0 : 44.0; // icon/emoji + its fixed padding, see item build below
+    // + container padding
+    final double reactionRowContentWidth = reactionItemWidth * ReactionTypes.toList().length + 10;
+    bool narrowScreen = reactionRowContentWidth > reactionPickerAvailableWidth;
 
     return Theme(
       data: context.theme.copyWith(

--- a/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/popup/message_popup.dart
@@ -184,7 +184,8 @@ class _MessagePopupState extends State<MessagePopup> with SingleTickerProviderSt
 
   @override
   Widget build(BuildContext context) {
-    double narrowWidth = message.isFromMe! || !SettingsSvc.settings.alwaysShowAvatars.value ? 330 : 360;
+    double narrowWidth =
+        message.isFromMe! || !(chat.isGroup || SettingsSvc.settings.alwaysShowAvatars.value) ? 330 : 360;
     bool narrowScreen = NavigationSvc.width(widthContext) < narrowWidth;
 
     return Theme(


### PR DESCRIPTION
## Summary
Improved the reaction picker's line-wrapping behavior by calculating available width based on the picker's actual anchor position rather than making assumptions based on screen width and avatar visibility.

## Key Changes
- Replaced the simple `narrowScreen` calculation that guessed based on overall screen width and avatar settings with a more precise approach
- Now calculates `reactionPickerAvailableWidth` by considering:
  - The picker's actual horizontal position (`widget.childPosition.dx`)
  - Edge margins (15px on each side)
  - Whether the message is from the current user (affects available space calculation)
- Computes `reactionRowContentWidth` based on the fixed dimensions of reaction items (47px on iOS, 44px on Android) and the total number of reaction types
- Compares actual content width against available width to determine if wrapping is needed

## Implementation Details
- The calculation now accounts for the space the message bubble occupies, which is already reflected in `widget.childPosition.dx`
- Removed the need for avatar/group special-casing since the anchor position already reflects any space the bubble was pushed past
- Uses platform-specific reaction item widths (iOS: 47px, Android: 44px) plus fixed container padding (10px)

https://claude.ai/code/session_01Bb2nUn7fX9ZG83Fuz7LjcN