### PR TITLE
feat: add contacts management page and fix stale permission caching

### DIFF
--- a/lib/app/components/m3e/m3e_list_tile.dart
+++ b/lib/app/components/m3e/m3e_list_tile.dart
@@ -13,6 +13,12 @@ class M3EListTile extends StatelessWidget {
   final bool destructive;
   final bool nested;
 
+  /// Overrides the leading icon's tint (icon + tonal container color).
+  /// Defaults to `colorScheme.primary` (or `error` when [destructive]) —
+  /// pass this for rows that carry their own brand/identity color, e.g. a
+  /// per-account icon in the contacts sync selector.
+  final Color? iconColor;
+
   const M3EListTile({
     super.key,
     required this.icon,
@@ -23,12 +29,13 @@ class M3EListTile extends StatelessWidget {
     this.onLongPress,
     this.destructive = false,
     this.nested = false,
+    this.iconColor,
   });
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = context.theme.colorScheme;
-    final accent = destructive ? colorScheme.error : colorScheme.primary;
+    final accent = iconColor ?? (destructive ? colorScheme.error : colorScheme.primary);
 
     return Material(
       color: Colors.transparent,

--- a/lib/app/layouts/settings/pages/contacts/contacts_management_controller.dart
+++ b/lib/app/layouts/settings/pages/contacts/contacts_management_controller.dart
@@ -1,6 +1,8 @@
+import 'package:bluebubbles/app/layouts/settings/widgets/search/settings_items_actions.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
 
@@ -23,6 +25,10 @@ class ContactsManagementController extends GetxController {
   final RxnInt lastDeviceContactCount = RxnInt();
   final RxnInt lastMatchedContactCount = RxnInt();
   final RxnInt lastAffectedHandleCount = RxnInt();
+
+  final RxBool uploadingContacts = false.obs;
+  final RxnDouble exportProgress = RxnDouble();
+  final RxnInt exportTotalSize = RxnInt();
 
   @override
   void onInit() {
@@ -103,5 +109,15 @@ class ContactsManagementController extends GetxController {
     } finally {
       syncing.value = false;
     }
+  }
+
+  /// Uploads device contacts to the server, showing a progress dialog.
+  Future<void> exportContacts(BuildContext context) async {
+    await SettingsItemsActions.exportContacts(
+      context: context,
+      progress: exportProgress,
+      totalSize: exportTotalSize,
+      uploadingContacts: uploadingContacts,
+    );
   }
 }

--- a/lib/app/layouts/settings/pages/contacts/contacts_management_controller.dart
+++ b/lib/app/layouts/settings/pages/contacts/contacts_management_controller.dart
@@ -1,0 +1,107 @@
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+/// Owns permission status, the account list with live per-account contact
+/// counts, and manual-refresh/sync-stats state for the Contacts Management
+/// page. Shared across all three skins (mirrors `StorageAnalyzerController`'s
+/// single-instance, untagged pattern).
+class ContactsManagementController extends GetxController {
+  final Rx<PermissionStatus> permissionStatus = PermissionStatus.denied.obs;
+  final RxBool checkingPermission = false.obs;
+
+  final RxList<Map<String, dynamic>> accounts = <Map<String, dynamic>>[].obs;
+  final RxBool loadingAccounts = false.obs;
+
+  /// Null means "all accounts" — the default, unfiltered behavior.
+  final RxnString selectedAccountName = RxnString();
+  final RxnString selectedAccountType = RxnString();
+
+  final RxBool syncing = false.obs;
+  final RxnInt lastDeviceContactCount = RxnInt();
+  final RxnInt lastMatchedContactCount = RxnInt();
+  final RxnInt lastAffectedHandleCount = RxnInt();
+
+  @override
+  void onInit() {
+    super.onInit();
+    selectedAccountName.value = SettingsSvc.settings.contactSyncAccountName.value;
+    selectedAccountType.value = SettingsSvc.settings.contactSyncAccountType.value;
+    refreshPermissionStatus();
+    refreshAccounts();
+  }
+
+  /// Re-checks the OS permission status directly (never shows the OS prompt)
+  /// — always live, unlike the resume-time throttled check.
+  Future<void> refreshPermissionStatus() async {
+    if (kIsWeb || kIsDesktop) return;
+
+    checkingPermission.value = true;
+    try {
+      await ContactsSvcV2.checkPermissionStatus();
+      permissionStatus.value = await Permission.contacts.status;
+    } finally {
+      checkingPermission.value = false;
+    }
+  }
+
+  /// Requests the OS permission (shows the system prompt if not yet decided).
+  Future<void> requestPermission() async {
+    checkingPermission.value = true;
+    try {
+      await ContactsSvcV2.requestContactPermission();
+      permissionStatus.value = await Permission.contacts.status;
+    } finally {
+      checkingPermission.value = false;
+    }
+  }
+
+  Future<void> refreshAccounts() async {
+    if (kIsWeb || kIsDesktop) return;
+
+    loadingAccounts.value = true;
+    try {
+      final result = await ContactsSvcV2.getAccountContactCounts();
+      accounts.assignAll(result);
+    } finally {
+      loadingAccounts.value = false;
+    }
+  }
+
+  bool isAccountSelected(Map<String, dynamic>? account) {
+    if (account == null) return selectedAccountName.value == null;
+    return selectedAccountName.value == account['name'] && selectedAccountType.value == account['type'];
+  }
+
+  /// Selects an account to filter contact sync to, or `null` for "All
+  /// accounts" (the default). Persists the choice and immediately re-syncs
+  /// so the change takes effect right away.
+  Future<void> selectAccount(Map<String, dynamic>? account) async {
+    selectedAccountName.value = account?['name'] as String?;
+    selectedAccountType.value = account?['type'] as String?;
+
+    SettingsSvc.settings.contactSyncAccountName.value = selectedAccountName.value;
+    SettingsSvc.settings.contactSyncAccountType.value = selectedAccountType.value;
+    await SettingsSvc.settings.saveManyAsync(['contactSyncAccountName', 'contactSyncAccountType']);
+
+    await refreshContactsNow();
+  }
+
+  /// Manually triggers a contact sync and updates the diagnostic counts.
+  Future<void> refreshContactsNow() async {
+    syncing.value = true;
+    try {
+      final stats = await ContactsSvcV2.syncContactsToHandlesWithStats();
+      lastDeviceContactCount.value = stats['deviceContactCount'] as int?;
+      lastMatchedContactCount.value = stats['matchedContactCount'] as int?;
+      lastAffectedHandleCount.value = (stats['affectedHandleIds'] as List).length;
+      // Per-account counts may have shifted since the last check (e.g. new
+      // contacts synced onto an account) — keep the selector's numbers fresh.
+      await refreshAccounts();
+    } finally {
+      syncing.value = false;
+    }
+  }
+}

--- a/lib/app/layouts/settings/pages/contacts/contacts_management_helpers.dart
+++ b/lib/app/layouts/settings/pages/contacts/contacts_management_helpers.dart
@@ -1,4 +1,13 @@
+import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
+
+/// Icon + brand color for a device contacts account, keyed by Android
+/// account type (package name).
+class ContactAccountIcon {
+  final IconData icon;
+  final Color color;
+  const ContactAccountIcon(this.icon, this.color);
+}
 
 /// Shared presentation helpers for the Contacts Management page, mixed into
 /// every skin's widgets so status/label formatting stays in one place.
@@ -26,4 +35,50 @@ mixin ContactsManagementHelpersMixin {
   String accountSubtitle(Map<String, dynamic> account) => account['type'] as String? ?? '';
 
   int accountCount(Map<String, dynamic> account) => account['count'] as int? ?? 0;
+
+  static const ContactAccountIcon _defaultAccountIcon = ContactAccountIcon(Icons.person_outline_rounded, Colors.blueGrey);
+
+  /// Icon/color keyed by a prefix of the Android account type (package
+  /// name). Checked in order — more specific prefixes must come before
+  /// broader ones that would otherwise swallow them (e.g. the Google Meet
+  /// package contains `com.google`, and Outlook contains `com.microsoft`,
+  /// so both specific entries are listed first).
+  static const Map<String, ContactAccountIcon> _accountIconsByType = {
+    // Google Meet (still shipped as the old Duo package name) before the
+    // generic Google entry, which would otherwise match it first.
+    'com.google.android.apps.tachyon': ContactAccountIcon(Icons.duo_rounded, Color(0xFF00AC47)),
+    'com.google': ContactAccountIcon(Icons.g_mobiledata_rounded, Color(0xFF4285F4)),
+    'com.whatsapp': ContactAccountIcon(Icons.chat_rounded, Color(0xFF25D366)),
+    'org.thoughtcrime.securesms': ContactAccountIcon(Icons.forum_rounded, Color(0xFF3A76F0)),
+    'com.facebook': ContactAccountIcon(Icons.facebook_rounded, Color(0xFF1877F2)),
+    'org.telegram.messenger': ContactAccountIcon(Icons.telegram_rounded, Color(0xFF26A5E4)),
+    'com.discord': ContactAccountIcon(Icons.discord_rounded, Color(0xFF5865F2)),
+    'com.snapchat.android': ContactAccountIcon(Icons.snapchat_rounded, Color(0xFFFFFC00)),
+    'com.skype.raider': ContactAccountIcon(Icons.video_call_rounded, Color(0xFF00AFF0)),
+    'com.viber.voip': ContactAccountIcon(Icons.phone_in_talk_rounded, Color(0xFF7360F2)),
+    'com.tencent.mm': ContactAccountIcon(Icons.wechat_rounded, Color(0xFF07C160)),
+    'jp.naver.line.android': ContactAccountIcon(Icons.chat_bubble_rounded, Color(0xFF06C755)),
+    'com.linkedin.android': ContactAccountIcon(Icons.business_center_rounded, Color(0xFF0A66C2)),
+    'com.yahoo.mobile.client.android.mail': ContactAccountIcon(Icons.mail_rounded, Color(0xFF6001D2)),
+    // Outlook before the generic Microsoft entry (Exchange/Teams/other
+    // Microsoft-account syncs), which would otherwise match it first.
+    'com.microsoft.office.outlook': ContactAccountIcon(Icons.mail_rounded, Color(0xFF0078D4)),
+    'com.microsoft': ContactAccountIcon(Icons.mail_lock_rounded, Color(0xFF0078D4)),
+    'com.android.exchange': ContactAccountIcon(Icons.mail_rounded, Color(0xFF0078D4)),
+    'com.osp.app.signin': ContactAccountIcon(Icons.badge_rounded, Color(0xFF1428A0)),
+    'com.samsung': ContactAccountIcon(Icons.badge_rounded, Color(0xFF1428A0)),
+    'vnd.sec.contact.phone': ContactAccountIcon(Icons.smartphone_rounded, Colors.grey),
+    'com.android': ContactAccountIcon(Icons.smartphone_rounded, Colors.grey),
+  };
+
+  /// Resolves the icon/color to show for an account row, matching its
+  /// `type` (Android account package name) against [_accountIconsByType]
+  /// by prefix, or falling back to a generic person icon.
+  ContactAccountIcon accountIcon(Map<String, dynamic> account) {
+    final type = (account['type'] as String? ?? '').toLowerCase();
+    for (final entry in _accountIconsByType.entries) {
+      if (type.contains(entry.key)) return entry.value;
+    }
+    return _defaultAccountIcon;
+  }
 }

--- a/lib/app/layouts/settings/pages/contacts/contacts_management_helpers.dart
+++ b/lib/app/layouts/settings/pages/contacts/contacts_management_helpers.dart
@@ -1,0 +1,29 @@
+import 'package:permission_handler/permission_handler.dart';
+
+/// Shared presentation helpers for the Contacts Management page, mixed into
+/// every skin's widgets so status/label formatting stays in one place.
+mixin ContactsManagementHelpersMixin {
+  String permissionStatusLabel(PermissionStatus status) {
+    if (status.isGranted) return "Granted";
+    if (status.isPermanentlyDenied) return "Permanently Denied";
+    if (status.isRestricted) return "Restricted";
+    return "Not Granted";
+  }
+
+  String permissionStatusDescription(PermissionStatus status) {
+    if (status.isGranted) {
+      return "BlueBubbles can read your device's contacts.";
+    }
+    if (status.isPermanentlyDenied) {
+      return "Access was denied and can only be re-enabled from system Settings.";
+    }
+    return "Grant access to show contact names and photos in your conversations.";
+  }
+
+  /// Display label for an account row: `{'name': String, 'type': String, 'count': int}`.
+  String accountLabel(Map<String, dynamic> account) => account['name'] as String? ?? 'Unknown account';
+
+  String accountSubtitle(Map<String, dynamic> account) => account['type'] as String? ?? '';
+
+  int accountCount(Map<String, dynamic> account) => account['count'] as int? ?? 0;
+}

--- a/lib/app/layouts/settings/pages/contacts/contacts_management_panel.dart
+++ b/lib/app/layouts/settings/pages/contacts/contacts_management_panel.dart
@@ -1,0 +1,36 @@
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_controller.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/material_contacts_management_panel.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/samsung_contacts_management_panel.dart';
+import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Entry point for the Contacts Management settings page. Owns the
+/// controller's lifecycle directly (single global instance, following
+/// `StorageAnalyzerPanel`'s pattern) since nothing else needs it.
+class ContactsManagementPanel extends StatefulWidget {
+  const ContactsManagementPanel({super.key});
+
+  @override
+  State<ContactsManagementPanel> createState() => _ContactsManagementPanelState();
+}
+
+class _ContactsManagementPanelState extends State<ContactsManagementPanel> {
+  late final controller = Get.put(ContactsManagementController());
+
+  @override
+  void dispose() {
+    Get.delete<ContactsManagementController>();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ThemeSwitcher(
+      iOSSkin: CupertinoContactsManagementPanel(controller: controller),
+      materialSkin: MaterialContactsManagementPanel(controller: controller),
+      samsungSkin: SamsungContactsManagementPanel(controller: controller),
+    );
+  }
+}

--- a/lib/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart
+++ b/lib/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart
@@ -2,10 +2,13 @@ import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_managem
 import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_helpers.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:universal_io/io.dart';
 
 /// iOS skin — plain `SettingsTile`/`SettingsSection` rows, matching
 /// `troubleshoot_panel.dart`'s style (no M3E, which is Material/Samsung only).
@@ -67,7 +70,41 @@ class CupertinoContactsManagementPanel extends StatelessWidget with ContactsMana
                     trailing: controller.syncing.value ? const CupertinoActivityIndicator() : null,
                     onTap: controller.syncing.value ? null : controller.refreshContactsNow,
                   )),
-              const SettingsDivider(),
+              if (Platform.isAndroid) ...[
+                const SettingsDivider(),
+                Obx(() => SettingsSwitch(
+                      initialVal: SettingsSvc.settings.syncContactsAutomatically.value,
+                      title: "Auto-Sync Contacts",
+                      subtitle: "Automatically re-upload contacts to server when changes are detected",
+                      backgroundColor: context.tileColor,
+                      onChanged: (bool val) async {
+                        SettingsSvc.settings.syncContactsAutomatically.value = val;
+                        await SettingsSvc.settings.saveOneAsync("syncContactsAutomatically");
+                      },
+                      leading: const SettingsLeadingIcon(
+                        iosIcon: CupertinoIcons.person_2,
+                        materialIcon: Icons.people,
+                        containerColor: Colors.green,
+                      ),
+                    )),
+              ],
+              if (!kIsWeb && !kIsDesktop) ...[
+                const SettingsDivider(),
+                SettingsTile(
+                  leading: const SettingsLeadingIcon(
+                    iosIcon: CupertinoIcons.group_solid,
+                    materialIcon: Icons.contacts,
+                    containerColor: Colors.green,
+                  ),
+                  title: "Export Contacts",
+                  subtitle: "Sync contacts to the desktop app",
+                  onTap: () => controller.exportContacts(context),
+                ),
+              ],
+            ]),
+            SettingsHeader(
+                iosSubtitle: context.iosSubtitle, materialSubtitle: context.materialSubtitle, text: "Sync Info"),
+            SettingsSection(backgroundColor: context.tileColor, children: [
               Obx(() => SettingsTile(
                     title: "Device Contacts Found",
                     trailing: Text('${controller.lastDeviceContactCount.value ?? "—"}'),
@@ -97,6 +134,11 @@ class CupertinoContactsManagementPanel extends StatelessWidget with ContactsMana
 
               return SettingsSection(backgroundColor: context.tileColor, children: [
                 SettingsTile(
+                  leading: const SettingsLeadingIcon(
+                    iosIcon: CupertinoIcons.square_grid_2x2,
+                    materialIcon: Icons.select_all_rounded,
+                    containerColor: Colors.blueAccent,
+                  ),
                   title: "All Accounts",
                   subtitle: "Sync contacts from every account on this device (default).",
                   trailing: controller.isAccountSelected(null)
@@ -107,6 +149,11 @@ class CupertinoContactsManagementPanel extends StatelessWidget with ContactsMana
                 for (final account in controller.accounts) ...[
                   const SettingsDivider(),
                   SettingsTile(
+                    leading: SettingsLeadingIcon(
+                      iosIcon: accountIcon(account).icon,
+                      materialIcon: accountIcon(account).icon,
+                      containerColor: accountIcon(account).color,
+                    ),
                     title: accountLabel(account),
                     subtitle: "${accountSubtitle(account)} • ${accountCount(account)} contacts",
                     trailing: controller.isAccountSelected(account)

--- a/lib/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart
+++ b/lib/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart
@@ -1,0 +1,125 @@
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_controller.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_helpers.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+/// iOS skin — plain `SettingsTile`/`SettingsSection` rows, matching
+/// `troubleshoot_panel.dart`'s style (no M3E, which is Material/Samsung only).
+class CupertinoContactsManagementPanel extends StatelessWidget with ContactsManagementHelpersMixin {
+  const CupertinoContactsManagementPanel({super.key, required this.controller});
+
+  final ContactsManagementController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: "Contacts Management",
+      initialHeader: "Permission",
+      iosSubtitle: context.iosSubtitle,
+      materialSubtitle: context.materialSubtitle,
+      tileColor: context.tileColor,
+      headerColor: context.headerColor,
+      bodySlivers: [
+        SliverList(
+          delegate: SliverChildListDelegate([
+            SettingsSection(backgroundColor: context.tileColor, children: [
+              Obx(() {
+                final status = controller.permissionStatus.value;
+                return SettingsTile(
+                  leading: SettingsLeadingIcon(
+                    iosIcon: CupertinoIcons.person_crop_circle_badge_checkmark,
+                    materialIcon: Icons.contacts_rounded,
+                    containerColor: status.isGranted ? Colors.green : context.theme.colorScheme.error,
+                  ),
+                  title: "Contacts Permission: ${permissionStatusLabel(status)}",
+                  subtitle: permissionStatusDescription(status),
+                  isThreeLine: true,
+                  trailing: controller.checkingPermission.value
+                      ? const CupertinoActivityIndicator()
+                      : CupertinoButton(
+                          padding: EdgeInsets.zero,
+                          onPressed: status.isPermanentlyDenied
+                              ? openAppSettings
+                              : status.isGranted
+                                  ? controller.refreshPermissionStatus
+                                  : controller.requestPermission,
+                          child: Text(
+                            status.isPermanentlyDenied ? "Open Settings" : status.isGranted ? "Refresh" : "Grant",
+                          ),
+                        ),
+                );
+              }),
+            ]),
+            SettingsHeader(iosSubtitle: context.iosSubtitle, materialSubtitle: context.materialSubtitle, text: "Sync"),
+            SettingsSection(backgroundColor: context.tileColor, children: [
+              Obx(() => SettingsTile(
+                    leading: const SettingsLeadingIcon(
+                      iosIcon: CupertinoIcons.refresh,
+                      materialIcon: Icons.sync_rounded,
+                      containerColor: Colors.blueAccent,
+                    ),
+                    title: "Refresh Contacts Now",
+                    subtitle: "Manually re-sync device contacts and match them to conversations.",
+                    trailing: controller.syncing.value ? const CupertinoActivityIndicator() : null,
+                    onTap: controller.syncing.value ? null : controller.refreshContactsNow,
+                  )),
+              const SettingsDivider(),
+              Obx(() => SettingsTile(
+                    title: "Device Contacts Found",
+                    trailing: Text('${controller.lastDeviceContactCount.value ?? "—"}'),
+                  )),
+              const SettingsDivider(),
+              Obx(() => SettingsTile(
+                    title: "Matched To Conversations",
+                    trailing: Text('${controller.lastMatchedContactCount.value ?? "—"}'),
+                  )),
+              const SettingsDivider(),
+              Obx(() => SettingsTile(
+                    title: "Conversations Updated",
+                    trailing: Text('${controller.lastAffectedHandleCount.value ?? "—"}'),
+                  )),
+            ]),
+            SettingsHeader(
+                iosSubtitle: context.iosSubtitle,
+                materialSubtitle: context.materialSubtitle,
+                text: "Sync From Account"),
+            Obx(() {
+              if (controller.loadingAccounts.value && controller.accounts.isEmpty) {
+                return const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: Center(child: CupertinoActivityIndicator()),
+                );
+              }
+
+              return SettingsSection(backgroundColor: context.tileColor, children: [
+                SettingsTile(
+                  title: "All Accounts",
+                  subtitle: "Sync contacts from every account on this device (default).",
+                  trailing: controller.isAccountSelected(null)
+                      ? const Icon(CupertinoIcons.check_mark, color: Colors.blueAccent)
+                      : null,
+                  onTap: () => controller.selectAccount(null),
+                ),
+                for (final account in controller.accounts) ...[
+                  const SettingsDivider(),
+                  SettingsTile(
+                    title: accountLabel(account),
+                    subtitle: "${accountSubtitle(account)} • ${accountCount(account)} contacts",
+                    trailing: controller.isAccountSelected(account)
+                        ? const Icon(CupertinoIcons.check_mark, color: Colors.blueAccent)
+                        : null,
+                    onTap: () => controller.selectAccount(account),
+                  ),
+                ],
+              ]);
+            }),
+          ]),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/settings/pages/contacts/material_contacts_management_panel.dart
+++ b/lib/app/layouts/settings/pages/contacts/material_contacts_management_panel.dart
@@ -1,0 +1,29 @@
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_controller.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Material M3 Expressive skin — built on the existing `lib/app/components/m3e/`
+/// primitives, following `material_storage_analyzer_panel.dart` as the
+/// reference implementation.
+class MaterialContactsManagementPanel extends StatelessWidget {
+  const MaterialContactsManagementPanel({super.key, required this.controller});
+
+  final ContactsManagementController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: "Contacts Management",
+      initialHeader: null,
+      iosSubtitle: context.iosSubtitle,
+      materialSubtitle: context.materialSubtitle,
+      tileColor: context.tileColor,
+      headerColor: context.headerColor,
+      bodySlivers: [
+        SliverToBoxAdapter(child: ContactsExpressiveBody(controller: controller)),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/settings/pages/contacts/samsung_contacts_management_panel.dart
+++ b/lib/app/layouts/settings/pages/contacts/samsung_contacts_management_panel.dart
@@ -1,0 +1,29 @@
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_controller.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Samsung M3 Expressive skin — identical structure to the Material skin;
+/// `SettingsScaffold` already branches Samsung internally, following
+/// `samsung_storage_analyzer_panel.dart` as the reference implementation.
+class SamsungContactsManagementPanel extends StatelessWidget {
+  const SamsungContactsManagementPanel({super.key, required this.controller});
+
+  final ContactsManagementController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: "Contacts Management",
+      initialHeader: null,
+      iosSubtitle: context.iosSubtitle,
+      materialSubtitle: context.materialSubtitle,
+      tileColor: context.tileColor,
+      headerColor: context.headerColor,
+      bodySlivers: [
+        SliverToBoxAdapter(child: ContactsExpressiveBody(controller: controller)),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart
+++ b/lib/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart
@@ -1,11 +1,15 @@
+import 'package:bluebubbles/app/components/bb_switch.dart';
 import 'package:bluebubbles/app/components/charts/charts.dart';
 import 'package:bluebubbles/app/components/m3e/m3e.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_controller.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_helpers.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:universal_io/io.dart';
 
 /// Expressive body shared by the Material and Samsung skins — M3E stat tiles
 /// for permission/sync status, and `M3ESection`-grouped rows for the sync
@@ -69,6 +73,7 @@ class ContactsExpressiveBody extends StatelessWidget with ContactsManagementHelp
           const M3ESectionHeader(label: "Sync", padding: EdgeInsets.only(left: 4, bottom: 8)),
           Obx(() => M3ESection(
                 backgroundColor: context.tileColor,
+                margin: EdgeInsets.zero,
                 children: [
                   M3EListTile(
                     icon: Icons.sync_rounded,
@@ -79,6 +84,41 @@ class ContactsExpressiveBody extends StatelessWidget with ContactsManagementHelp
                         : null,
                     onTap: controller.syncing.value ? null : controller.refreshContactsNow,
                   ),
+                  if (Platform.isAndroid)
+                    Obx(() => M3EListTile(
+                          icon: Icons.people,
+                          iconColor: context.theme.colorScheme.secondary,
+                          title: "Auto-Sync Contacts",
+                          supportingText: "Automatically re-upload contacts to server when changes are detected.",
+                          trailing: BBSwitch(
+                            value: SettingsSvc.settings.syncContactsAutomatically.value,
+                            onChanged: (bool val) async {
+                              SettingsSvc.settings.syncContactsAutomatically.value = val;
+                              await SettingsSvc.settings.saveOneAsync("syncContactsAutomatically");
+                            },
+                          ),
+                          onTap: () async {
+                            final val = !SettingsSvc.settings.syncContactsAutomatically.value;
+                            SettingsSvc.settings.syncContactsAutomatically.value = val;
+                            await SettingsSvc.settings.saveOneAsync("syncContactsAutomatically");
+                          },
+                        )),
+                  if (!kIsWeb && !kIsDesktop)
+                    M3EListTile(
+                      icon: Icons.contacts_rounded,
+                      iconColor: context.theme.colorScheme.tertiary,
+                      title: "Export Contacts",
+                      supportingText: "Sync contacts to the desktop app.",
+                      onTap: () => controller.exportContacts(context),
+                    ),
+                ],
+              )),
+          const SizedBox(height: 8),
+          const M3ESectionHeader(label: "Sync Info", padding: EdgeInsets.only(left: 4, bottom: 8)),
+          Obx(() => M3ESection(
+                backgroundColor: context.tileColor,
+                margin: EdgeInsets.zero,
+                children: [
                   M3EListTile(
                     icon: Icons.link_rounded,
                     title: "Matched To Conversations",
@@ -103,6 +143,7 @@ class ContactsExpressiveBody extends StatelessWidget with ContactsManagementHelp
 
             return M3ESection(
               backgroundColor: context.tileColor,
+              margin: EdgeInsets.zero,
               children: [
                 M3EListTile(
                   icon: Icons.select_all_rounded,
@@ -115,7 +156,8 @@ class ContactsExpressiveBody extends StatelessWidget with ContactsManagementHelp
                 ),
                 for (final account in controller.accounts)
                   M3EListTile(
-                    icon: Icons.person_outline_rounded,
+                    icon: accountIcon(account).icon,
+                    iconColor: accountIcon(account).color,
                     title: accountLabel(account),
                     supportingText: "${accountSubtitle(account)} • ${accountCount(account)} contacts",
                     trailing: controller.isAccountSelected(account)

--- a/lib/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart
+++ b/lib/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart
@@ -1,0 +1,133 @@
+import 'package:bluebubbles/app/components/charts/charts.dart';
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_controller.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_helpers.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+/// Expressive body shared by the Material and Samsung skins — M3E stat tiles
+/// for permission/sync status, and `M3ESection`-grouped rows for the sync
+/// action and account selector. Same data as the iOS skin, M3E chrome only.
+class ContactsExpressiveBody extends StatelessWidget with ContactsManagementHelpersMixin {
+  const ContactsExpressiveBody({super.key, required this.controller});
+
+  final ContactsManagementController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Obx(() {
+            final status = controller.permissionStatus.value;
+            return StatTileGrid(
+              tiles: [
+                M3EStatTile(
+                  value: permissionStatusLabel(status),
+                  label: "Contacts Permission",
+                  icon: status.isGranted ? Icons.check_circle_outline : Icons.error_outline,
+                  containerColor: status.isGranted
+                      ? context.theme.colorScheme.tertiaryContainer
+                      : context.theme.colorScheme.errorContainer,
+                  onContainerColor:
+                      status.isGranted ? context.theme.colorScheme.onTertiaryContainer : context.theme.colorScheme.onErrorContainer,
+                ),
+                M3EStatTile(
+                  value: '${controller.lastDeviceContactCount.value ?? "—"}',
+                  label: "Device Contacts",
+                  icon: Icons.contacts_outlined,
+                  containerColor: context.theme.colorScheme.primaryContainer,
+                  onContainerColor: context.theme.colorScheme.onPrimaryContainer,
+                ),
+              ],
+            );
+          }),
+          const SizedBox(height: 8),
+          Obx(() {
+            final status = controller.permissionStatus.value;
+            if (status.isGranted) return const SizedBox.shrink();
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: SizedBox(
+                width: double.infinity,
+                child: M3ETonalButton(
+                  icon: status.isPermanentlyDenied ? Icons.settings_outlined : Icons.lock_open_rounded,
+                  label: status.isPermanentlyDenied ? "Open Settings" : "Grant Permission",
+                  onPressed: controller.checkingPermission.value
+                      ? null
+                      : status.isPermanentlyDenied
+                          ? openAppSettings
+                          : controller.requestPermission,
+                ),
+              ),
+            );
+          }),
+          const M3ESectionHeader(label: "Sync", padding: EdgeInsets.only(left: 4, bottom: 8)),
+          Obx(() => M3ESection(
+                backgroundColor: context.tileColor,
+                children: [
+                  M3EListTile(
+                    icon: Icons.sync_rounded,
+                    title: "Refresh Contacts Now",
+                    supportingText: "Manually re-sync device contacts and match them to conversations.",
+                    trailing: controller.syncing.value
+                        ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                        : null,
+                    onTap: controller.syncing.value ? null : controller.refreshContactsNow,
+                  ),
+                  M3EListTile(
+                    icon: Icons.link_rounded,
+                    title: "Matched To Conversations",
+                    trailing: Text('${controller.lastMatchedContactCount.value ?? "—"}'),
+                  ),
+                  M3EListTile(
+                    icon: Icons.mark_chat_read_outlined,
+                    title: "Conversations Updated",
+                    trailing: Text('${controller.lastAffectedHandleCount.value ?? "—"}'),
+                  ),
+                ],
+              )),
+          const SizedBox(height: 8),
+          const M3ESectionHeader(label: "Sync From Account", padding: EdgeInsets.only(left: 4, bottom: 8)),
+          Obx(() {
+            if (controller.loadingAccounts.value && controller.accounts.isEmpty) {
+              return const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Center(child: CircularProgressIndicator()),
+              );
+            }
+
+            return M3ESection(
+              backgroundColor: context.tileColor,
+              children: [
+                M3EListTile(
+                  icon: Icons.select_all_rounded,
+                  title: "All Accounts",
+                  supportingText: "Sync contacts from every account on this device (default).",
+                  trailing: controller.isAccountSelected(null)
+                      ? Icon(Icons.check_rounded, color: context.theme.colorScheme.primary)
+                      : null,
+                  onTap: () => controller.selectAccount(null),
+                ),
+                for (final account in controller.accounts)
+                  M3EListTile(
+                    icon: Icons.person_outline_rounded,
+                    title: accountLabel(account),
+                    supportingText: "${accountSubtitle(account)} • ${accountCount(account)} contacts",
+                    trailing: controller.isAccountSelected(account)
+                        ? Icon(Icons.check_rounded, color: context.theme.colorScheme.primary)
+                        : null,
+                    onTap: () => controller.selectAccount(account),
+                  ),
+              ],
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/layouts/settings/pages/server/connection_panel/connection_panel_helpers.dart
+++ b/lib/app/layouts/settings/pages/server/connection_panel/connection_panel_helpers.dart
@@ -450,23 +450,6 @@ mixin ConnectionPanelHelpersMixin {
                 if (result) SocketSvc.restartSocket();
               },
             ),
-            if (Platform.isAndroid) const SettingsDivider(),
-            if (Platform.isAndroid)
-              Obx(() => SettingsSwitch(
-                    initialVal: SettingsSvc.settings.syncContactsAutomatically.value,
-                    title: "Auto-Sync Contacts",
-                    subtitle: "Automatically re-upload contacts to server when changes are detected",
-                    backgroundColor: tileColor,
-                    onChanged: (bool val) async {
-                      SettingsSvc.settings.syncContactsAutomatically.value = val;
-                      await SettingsSvc.settings.saveOneAsync("syncContactsAutomatically");
-                    },
-                    leading: const SettingsLeadingIcon(
-                      iosIcon: CupertinoIcons.person_2,
-                      materialIcon: Icons.people,
-                      containerColor: Colors.green,
-                    ),
-                  )),
             const SettingsDivider(),
             SettingsTile(
               leading: Column(

--- a/lib/app/layouts/settings/settings_page.dart
+++ b/lib/app/layouts/settings/settings_page.dart
@@ -26,10 +26,6 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> with ThemeHelpers {
-  final RxBool uploadingContacts = false.obs;
-  final RxnDouble progress = RxnDouble();
-  final RxnInt totalSize = RxnInt();
-
   String searchQuery = "";
 
   List<Widget> _getSettingsItemList(BuildContext context) {
@@ -43,9 +39,6 @@ class _SettingsPageState extends State<SettingsPage> with ThemeHelpers {
       iosSubtitle: iosSubtitle,
       materialSubtitle: materialSubtitle,
       ns: NavigationSvc,
-      progress: progress,
-      totalSize: totalSize,
-      uploadingContacts: uploadingContacts,
     );
   }
 

--- a/lib/app/layouts/settings/widgets/content/settings_tile.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_tile.dart
@@ -84,7 +84,8 @@ class SettingsTile extends StatelessWidget {
                         color: context.theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.75), height: 1.5),
                   )
                 : null,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: 16.0, vertical: SettingsSvc.settings.skin.value == Skins.iOS ? 0.0 : 4.0),
           ),
         ),
       ),

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -20,6 +20,7 @@ import 'package:bluebubbles/app/layouts/settings/pages/misc/troubleshoot_panel.d
 import 'package:bluebubbles/app/layouts/settings/pages/profile/profile_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/server/backup_restore_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/server/server_management_panel.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/contacts/contacts_management_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/storage/storage_analyzer_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/system/notification_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/theming/theming_panel.dart';
@@ -729,6 +730,35 @@ List<Widget> buildSettingItemList({
             ),
           ),
         ),
+
+        if (!kIsWeb)
+          SearchableSettingItem(
+            title: "Contacts Management",
+            searchTags: const [
+              "Contacts Permission",
+              "Refresh Contacts",
+              "Sync From Account",
+              "Contact Accounts",
+              "GrapheneOS",
+            ],
+            onTap: () {
+              ns.pushAndRemoveSettingsUntil(context, const ContactsManagementPanel(), (Route route) => route.isFirst);
+            },
+            child: SettingsTile(
+              backgroundColor: tileColor,
+              onTap: () {
+                ns.pushAndRemoveSettingsUntil(context, const ContactsManagementPanel(), (Route route) => route.isFirst);
+              },
+              leading: const SettingsLeadingIcon(
+                iosIcon: CupertinoIcons.person_crop_circle_badge_checkmark,
+                materialIcon: Icons.contacts_rounded,
+                containerColor: Colors.green,
+              ),
+              title: "Contacts Management",
+              subtitle: "Permission status, manual refresh, and per-account sync",
+              trailing: const NextButton(),
+            ),
+          ),
 
         // Danger Zone Section
         if (!kIsWeb)

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -46,9 +46,6 @@ List<Widget> buildSettingItemList({
   required TextStyle iosSubtitle,
   required TextStyle materialSubtitle,
   required NavigatorService ns,
-  required RxnDouble progress,
-  required RxnInt totalSize,
-  required RxBool uploadingContacts,
 }) {
   // return searchable items, headers, tiles, or sections
   return [
@@ -68,7 +65,6 @@ List<Widget> buildSettingItemList({
             title: SettingsSvc.settings.redactedMode.value && SettingsSvc.settings.hideContactInfo.value
                 ? "User Name"
                 : SettingsSvc.settings.userName.value,
-            subtitle: "Tap to view more details",
             onTap: () {
               ns.pushAndRemoveSettingsUntil(context, const ProfilePanel(), (Route route) => route.isFirst);
             },
@@ -564,6 +560,58 @@ List<Widget> buildSettingItemList({
           ),
         ),
 
+        // Contacts Management Tile
+        if (!kIsWeb)
+          SearchableSettingItem(
+            title: "Contacts Management",
+            searchTags: const [
+              "Contacts Permission",
+              "Refresh Contacts",
+              "Sync From Account",
+              "Contact Accounts",
+              "GrapheneOS",
+            ],
+            onTap: () {
+              ns.pushAndRemoveSettingsUntil(context, const ContactsManagementPanel(), (Route route) => route.isFirst);
+            },
+            child: SettingsTile(
+              backgroundColor: tileColor,
+              onTap: () {
+                ns.pushAndRemoveSettingsUntil(context, const ContactsManagementPanel(), (Route route) => route.isFirst);
+              },
+              leading: const SettingsLeadingIcon(
+                iosIcon: CupertinoIcons.person_crop_circle_badge_checkmark,
+                materialIcon: Icons.contacts_rounded,
+                containerColor: Colors.green,
+              ),
+              title: "Contacts Management",
+              trailing: const NextButton(),
+            ),
+          ),
+
+        // Storage Analyzer Tile
+        if (!kIsWeb)
+          SearchableSettingItem(
+            title: "Storage Analyzer",
+            searchTags: const ["Delete Attachments", "Free Up Space", "Manage Storage", "Clear Cache"],
+            onTap: () {
+              ns.pushAndRemoveSettingsUntil(context, const StorageAnalyzerPanel(), (Route route) => route.isFirst);
+            },
+            child: SettingsTile(
+              backgroundColor: tileColor,
+              onTap: () {
+                ns.pushAndRemoveSettingsUntil(context, const StorageAnalyzerPanel(), (Route route) => route.isFirst);
+              },
+              leading: SettingsLeadingIcon(
+                iosIcon: CupertinoIcons.chart_pie_fill,
+                materialIcon: Icons.pie_chart_outline,
+                containerColor: Colors.red[700],
+              ),
+              title: "Storage Analyzer",
+              trailing: const NextButton(),
+            ),
+          ),
+
         // Developer Tools Tile
         SearchableSettingItem(
           title: "Developer Tools", // Title to search
@@ -592,15 +640,14 @@ List<Widget> buildSettingItemList({
               containerColor: Colors.lightBlue,
             ),
             title: "Developer Tools",
-            subtitle: "View logs, troubleshoot bugs, and more",
             trailing: const NextButton(),
           ),
         ),
       ],
     ),
     SearchableSettingItem(
-      title: "Backup and restore",
-      child: SettingsHeader(iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: "Backup and Restore"),
+      title: "More",
+      child: SettingsHeader(iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: "More"),
     ),
     SettingsSection(
       backgroundColor: tileColor,
@@ -630,43 +677,20 @@ List<Widget> buildSettingItemList({
               containerColor: Colors.blueGrey,
             ),
             title: "Backup & Restore",
-            subtitle: "Settings and custom themes",
           ),
         ),
 
-        if (!kIsWeb && !kIsDesktop)
-          SearchableSettingItem(
-            title: "Export Contacts", // Title to search
-            child: SettingsTile(
-              backgroundColor: tileColor,
-              onTap: () => SettingsItemsActions.exportContacts(
-                context: context,
-                progress: progress,
-                totalSize: totalSize,
-                uploadingContacts: uploadingContacts,
-              ),
-              leading: const SettingsLeadingIcon(
-                iosIcon: CupertinoIcons.group_solid,
-                materialIcon: Icons.contacts,
-                containerColor: Colors.green,
-              ),
-              title: "Export Contacts",
-              subtitle: "Sync contacts to the desktop app",
-            ),
-          ),
         // About & Links Section
         SearchableSettingItem(
           title: "Leave Us a Review", // Title to search
           child: SettingsTile(
             title: "Leave Us a Review",
-            subtitle: "Rate us on the ${Platform.isAndroid ? 'Play Store' : 'Microsoft Store'}",
             onTap: SettingsItemsActions.openStoreReview,
             leading: const SettingsLeadingIcon(
               iosIcon: CupertinoIcons.star_fill,
               materialIcon: Icons.star,
               containerColor: Colors.blue,
             ),
-            isThreeLine: false,
           ),
         ),
 
@@ -675,14 +699,12 @@ List<Widget> buildSettingItemList({
             title: "Make a Donation", // Title to search
             child: SettingsTile(
               title: "Make a Donation",
-              subtitle: "Support the BlueBubbles team",
               onTap: SettingsItemsActions.openDonationPage,
               leading: SettingsLeadingIcon(
                 iosIcon: CupertinoIcons.money_dollar_circle,
                 materialIcon: Icons.attach_money,
                 containerColor: Colors.green,
               ),
-              isThreeLine: false,
             ),
           ),
 
@@ -690,7 +712,6 @@ List<Widget> buildSettingItemList({
           title: "Join Our Discord", // Title to search
           child: SettingsTile(
             title: "Join Our Discord",
-            subtitle: "Chat with other users and the developers",
             onTap: SettingsItemsActions.openDiscord,
             leading: SettingsLeadingIcon(
               iosIcon: Icons.discord,
@@ -718,7 +739,6 @@ List<Widget> buildSettingItemList({
           child: SettingsTile(
             backgroundColor: tileColor,
             title: "About & More",
-            subtitle: "Links, Changelog, & More",
             onTap: () {
               ns.pushAndRemoveSettingsUntil(context, const AboutPanel(), (Route route) => route.isFirst);
             },
@@ -731,59 +751,7 @@ List<Widget> buildSettingItemList({
           ),
         ),
 
-        if (!kIsWeb)
-          SearchableSettingItem(
-            title: "Contacts Management",
-            searchTags: const [
-              "Contacts Permission",
-              "Refresh Contacts",
-              "Sync From Account",
-              "Contact Accounts",
-              "GrapheneOS",
-            ],
-            onTap: () {
-              ns.pushAndRemoveSettingsUntil(context, const ContactsManagementPanel(), (Route route) => route.isFirst);
-            },
-            child: SettingsTile(
-              backgroundColor: tileColor,
-              onTap: () {
-                ns.pushAndRemoveSettingsUntil(context, const ContactsManagementPanel(), (Route route) => route.isFirst);
-              },
-              leading: const SettingsLeadingIcon(
-                iosIcon: CupertinoIcons.person_crop_circle_badge_checkmark,
-                materialIcon: Icons.contacts_rounded,
-                containerColor: Colors.green,
-              ),
-              title: "Contacts Management",
-              subtitle: "Permission status, manual refresh, and per-account sync",
-              trailing: const NextButton(),
-            ),
-          ),
-
         // Danger Zone Section
-        if (!kIsWeb)
-          SearchableSettingItem(
-            title: "Storage Analyzer",
-            searchTags: const ["Delete Attachments", "Free Up Space", "Manage Storage", "Clear Cache"],
-            onTap: () {
-              ns.pushAndRemoveSettingsUntil(context, const StorageAnalyzerPanel(), (Route route) => route.isFirst);
-            },
-            child: SettingsTile(
-              backgroundColor: tileColor,
-              onTap: () {
-                ns.pushAndRemoveSettingsUntil(context, const StorageAnalyzerPanel(), (Route route) => route.isFirst);
-              },
-              leading: SettingsLeadingIcon(
-                iosIcon: CupertinoIcons.chart_pie_fill,
-                materialIcon: Icons.pie_chart_outline,
-                containerColor: Colors.red[700],
-              ),
-              title: "Storage Analyzer",
-              subtitle: "View and free up attachment storage",
-              trailing: const NextButton(),
-            ),
-          ),
-
         if (!kIsWeb)
           SearchableSettingItem(
             title: "Reset App", // Title to search
@@ -812,7 +780,6 @@ List<Widget> buildSettingItemList({
                 containerColor: Colors.red[700],
               ),
               title: kIsWeb ? "Logout" : "Reset App",
-              subtitle: kIsWeb ? null : "Resets the app to default settings",
             ),
           ),
       ],

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -116,6 +116,14 @@ class Settings {
   final RxnString receiveSoundPath = RxnString();
   final RxInt soundVolume = 100.obs;
   final RxBool syncContactsAutomatically = false.obs;
+  /// Device account to sync contacts from, e.g. "user@gmail.com" (Android's
+  /// `Account.name`). Null means "all accounts" — the default, unfiltered
+  /// behavior. Must be set together with [contactSyncAccountType].
+  final RxnString contactSyncAccountName = RxnString();
+  /// Device account type to sync contacts from, e.g. "com.google" (Android's
+  /// `Account.type`). Null means "all accounts". Must be set together with
+  /// [contactSyncAccountName].
+  final RxnString contactSyncAccountType = RxnString();
   final RxBool scrollToBottomOnSend = true.obs;
   final RxBool sendEventsToTasker = false.obs;
   final RxBool keepAppAlive = false.obs;
@@ -385,6 +393,8 @@ class Settings {
       'useLocalIpv6': useLocalIpv6.value,
       'soundVolume': soundVolume.value,
       'syncContactsAutomatically': syncContactsAutomatically.value,
+      'contactSyncAccountName': contactSyncAccountName.value,
+      'contactSyncAccountType': contactSyncAccountType.value,
       'scrollToBottomOnSend': scrollToBottomOnSend.value,
       'sendEventsToTasker': sendEventsToTasker.value,
       'keepAppAlive': keepAppAlive.value,
@@ -588,6 +598,10 @@ class Settings {
     SettingsSvc.settings.soundVolume.value = map['soundVolume'] ?? SettingsSvc.settings.soundVolume.value;
     SettingsSvc.settings.syncContactsAutomatically.value =
         map['syncContactsAutomatically'] ?? SettingsSvc.settings.syncContactsAutomatically.value;
+    SettingsSvc.settings.contactSyncAccountName.value =
+        map['contactSyncAccountName'] ?? SettingsSvc.settings.contactSyncAccountName.value;
+    SettingsSvc.settings.contactSyncAccountType.value =
+        map['contactSyncAccountType'] ?? SettingsSvc.settings.contactSyncAccountType.value;
     SettingsSvc.settings.scrollToBottomOnSend.value =
         map['scrollToBottomOnSend'] ?? SettingsSvc.settings.scrollToBottomOnSend.value;
     SettingsSvc.settings.sendEventsToTasker.value =
@@ -801,6 +815,8 @@ class Settings {
     s.receiveSoundPath.value = map['receiveSoundPath'];
     s.soundVolume.value = map['soundVolume'] ?? 100;
     s.syncContactsAutomatically.value = map['syncContactsAutomatically'] ?? false;
+    s.contactSyncAccountName.value = map['contactSyncAccountName'];
+    s.contactSyncAccountType.value = map['contactSyncAccountType'];
     s.scrollToBottomOnSend.value = map['scrollToBottomOnSend'] ?? true;
     s.sendEventsToTasker.value = map['sendEventsToTasker'] ?? false;
     s.keepAppAlive.value = map['keepAppAlive'] ?? false;

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -508,6 +508,7 @@ class StartupTasks {
     // (contact change events are queued instead of synced while cached).
     if (GetIt.I.isRegistered<ContactServiceV2>() && GetIt.I.isReadySync<ContactServiceV2>()) {
       unawaited(ContactsSvcV2.runPendingContactSync());
+      unawaited(ContactsSvcV2.refreshPermissionStatusOnResume());
     }
 
     // On app resume, use the global isolate so it's ready for other tasks.

--- a/lib/services/backend/actions/contact_v2_actions.dart
+++ b/lib/services/backend/actions/contact_v2_actions.dart
@@ -18,7 +18,7 @@ import 'package:path/path.dart' as p;
 /// This follows the architecture outlined in FR-1.md
 class ContactV2Actions {
   /// Completer to ensure syncContactsToHandles only runs once at a time
-  static Completer<List<int>>? _syncCompleter;
+  static Completer<_ContactSyncStats>? _syncCompleter;
 
   /// Generate multiple normalized variants of a phone number to handle country code mismatches
   ///
@@ -72,7 +72,24 @@ class ContactV2Actions {
 
   /// Fetch all contacts from device and match them to existing handles
   /// This is the main operation described in Section II.A of FR-1.md
+  ///
+  /// Returns only the affected handle IDs — the shape every existing caller
+  /// depends on. Use [syncContactsToHandlesWithStats] for the fetch/match
+  /// counts as well (e.g. for diagnostic display).
   static Future<List<int>> syncContactsToHandles(dynamic data) async {
+    final stats = await _syncContactsToHandlesInternal(data);
+    return stats.affectedHandleIds;
+  }
+
+  /// Same operation as [syncContactsToHandles], but also returns the device
+  /// contact count and matched-contact count — used by the Contacts
+  /// Management page's manual refresh to show live diagnostic feedback.
+  static Future<Map<String, dynamic>> syncContactsToHandlesWithStats(dynamic data) async {
+    final stats = await _syncContactsToHandlesInternal(data);
+    return stats.toMap();
+  }
+
+  static Future<_ContactSyncStats> _syncContactsToHandlesInternal(dynamic data) async {
     // If already processing, wait for the existing operation to complete
     if (_syncCompleter != null && !_syncCompleter!.isCompleted) {
       Logger.info('[ContactV2] Sync already in progress, waiting for completion...');
@@ -80,10 +97,19 @@ class ContactV2Actions {
     }
 
     // Create a new completer for this sync operation
-    _syncCompleter = Completer<List<int>>();
+    _syncCompleter = Completer<_ContactSyncStats>();
+
+    // Optional account filter — set via the Contacts Management page. Null
+    // means "all accounts" (the default, unfiltered behavior).
+    final dataMap = data is Map ? data : const {};
+    final accountName = dataMap['accountName'] as String?;
+    final accountType = dataMap['accountType'] as String?;
+    final account =
+        (accountName != null && accountType != null) ? fc.Account(id: '', name: accountName, type: accountType) : null;
 
     final startTime = DateTime.now().millisecondsSinceEpoch;
     final affectedHandleIds = <int>[];
+    int matchedContactCount = 0;
 
     try {
       List<fc.Contact> deviceContacts = [];
@@ -134,9 +160,22 @@ class ContactV2Actions {
         }
       } else {
         // Step 1: Fetch contacts using flutter_contacts
-        Logger.info('[ContactV2] Starting contact fetch from device (flutter_contacts)...');
-        deviceContacts = await fc.FlutterContacts.getAll(properties: fc.ContactProperties.allProperties);
+        Logger.info('[ContactV2] Starting contact fetch from device (flutter_contacts)'
+            '${account != null ? ' for account ${account.name} (${account.type})' : ''}...');
+        deviceContacts =
+            await fc.FlutterContacts.getAll(properties: fc.ContactProperties.allProperties, account: account);
         Logger.info('[ContactV2] Fetched ${deviceContacts.length} contacts from device');
+        if (deviceContacts.isEmpty) {
+          // The OS permission check passed (we only reach this branch with contacts
+          // access granted), yet the provider returned nothing. This is expected for
+          // a genuinely empty address book, but it's also exactly what a privacy
+          // sandbox that virtualizes the Contacts provider per-app (e.g. GrapheneOS's
+          // Contact Scopes) looks like: the permission reads as granted, but the app
+          // only sees whatever the user explicitly scoped in — zero, until configured.
+          Logger.warn('[ContactV2] Contacts permission is granted but 0 device contacts were returned. '
+              'If contacts are expected to exist, check for a privacy sandbox / contact '
+              'scoping feature (e.g. GrapheneOS Contact Scopes) restricting this app\'s access.');
+        }
 
         // Step 1.5: Pre-fetch and save all contact avatars (async operations must be done BEFORE transaction)
         for (final rawContact in deviceContacts) {
@@ -379,6 +418,8 @@ class ContactV2Actions {
             }
           }
 
+          if (matchedHandles.isNotEmpty) matchedContactCount++;
+
           // Compare new handles with existing handles to detect changes
           final newHandleIds = matchedHandles.map((h) => h.id).whereType<int>().toSet();
           final handlesChanged = existingContact == null ||
@@ -432,15 +473,27 @@ class ContactV2Actions {
       Logger.info('[ContactV2] Contact fetch and match completed in ${endTime - startTime}ms');
       Logger.info('[ContactV2] Affected ${uniqueAffected.length} handles');
 
-      // Complete the completer with the result
-      _syncCompleter?.complete(uniqueAffected);
-      return uniqueAffected;
-    } catch (e, stack) {
-      Logger.error('[ContactV2] Error fetching and matching contacts', error: e, trace: stack);
+      final stats = _ContactSyncStats(
+        affectedHandleIds: uniqueAffected,
+        deviceContactCount: deviceContacts.length,
+        matchedContactCount: matchedContactCount,
+      );
 
-      // Complete the completer with an empty list on error
-      _syncCompleter?.complete([]);
-      return [];
+      // Complete the completer with the result
+      _syncCompleter?.complete(stats);
+      return stats;
+    } catch (e, stack) {
+      // Logged with the exception's runtimeType called out explicitly so this is
+      // distinguishable in exported logs from the "0 contacts, no exception" case
+      // logged above — both currently end in an empty sync result, but only one
+      // of them is an actual failure.
+      Logger.error('[ContactV2] Error fetching and matching contacts (${e.runtimeType}): $e',
+          error: e, trace: stack);
+
+      // Complete the completer with an empty result on error
+      final stats = _ContactSyncStats(affectedHandleIds: const [], deviceContactCount: 0, matchedContactCount: 0);
+      _syncCompleter?.complete(stats);
+      return stats;
     }
   }
 
@@ -674,4 +727,48 @@ class ContactV2Actions {
       }
     }
   }
+
+  /// Returns each on-device account with contacts, plus a live contact count
+  /// per account. Used by the Contacts Management page's account selector.
+  /// Mobile only — desktop has no device accounts.
+  static Future<List<Map<String, dynamic>>> getAccountContactCounts(dynamic data) async {
+    if (kIsWeb || kIsDesktop) return [];
+
+    try {
+      final accounts = await fc.FlutterContacts.accounts.getAll();
+      final results = <Map<String, dynamic>>[];
+
+      for (final account in accounts) {
+        final contacts = await fc.FlutterContacts.getAll(account: account);
+        results.add({'name': account.name, 'type': account.type, 'count': contacts.length});
+      }
+
+      return results;
+    } catch (e, stack) {
+      Logger.error('[ContactV2] Error getting account contact counts', error: e, trace: stack);
+      return [];
+    }
+  }
+}
+
+/// Result of a device/network contact fetch-and-match pass. Kept isolate-internal
+/// (not returned directly across the isolate boundary — see
+/// [ContactV2Actions.syncContactsToHandles] vs
+/// [ContactV2Actions.syncContactsToHandlesWithStats]).
+class _ContactSyncStats {
+  final List<int> affectedHandleIds;
+  final int deviceContactCount;
+  final int matchedContactCount;
+
+  const _ContactSyncStats({
+    required this.affectedHandleIds,
+    required this.deviceContactCount,
+    required this.matchedContactCount,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'affectedHandleIds': affectedHandleIds,
+        'deviceContactCount': deviceContactCount,
+        'matchedContactCount': matchedContactCount,
+      };
 }

--- a/lib/services/backend/interfaces/contact_v2_interface.dart
+++ b/lib/services/backend/interfaces/contact_v2_interface.dart
@@ -5,22 +5,63 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/env.dart';
 import 'package:bluebubbles/services/backend/actions/contact_v2_actions.dart';
 import 'package:bluebubbles/services/isolates/global_isolate.dart';
+import 'package:bluebubbles/services/services.dart';
 import 'package:flutter_contacts/flutter_contacts.dart' as fc;
 import 'package:get_it/get_it.dart';
 
 /// ContactV2Interface provides the bridge between the main isolate and the GlobalIsolate
 /// for all ContactV2 operations. This follows the architecture outlined in FR-1.md
 class ContactV2Interface {
+  /// Builds the account-filter portion of the sync data map from the
+  /// user-selected account (Contacts Management page). Empty when unset —
+  /// "all accounts" is the default, unfiltered behavior.
+  static Map<String, dynamic> _accountFilterData() {
+    final accountName = SettingsSvc.settings.contactSyncAccountName.value;
+    final accountType = SettingsSvc.settings.contactSyncAccountType.value;
+    if (accountName == null || accountType == null) return {};
+    return {'accountName': accountName, 'accountType': accountType};
+  }
+
   /// Fetch all contacts from the device and match them to existing handles
   /// This operation is executed in the GlobalIsolate to prevent UI jank
   ///
   /// Returns a list of handle IDs that were affected by the matching
   static Future<List<int>> syncContactsToHandles() async {
+    final data = _accountFilterData();
     if (isIsolate) {
-      return await ContactV2Actions.syncContactsToHandles(<String, dynamic>{});
+      return await ContactV2Actions.syncContactsToHandles(data);
+    } else {
+      return await GetIt.I<GlobalIsolate>().send<List<int>>(IsolateRequestType.syncContactsToHandles, input: data);
+    }
+  }
+
+  /// Same as [syncContactsToHandles], but also returns the device contact
+  /// count and matched-contact count for diagnostic display (Contacts
+  /// Management page's manual refresh).
+  static Future<Map<String, dynamic>> syncContactsToHandlesWithStats() async {
+    final data = _accountFilterData();
+    if (isIsolate) {
+      return await ContactV2Actions.syncContactsToHandlesWithStats(data);
     } else {
       return await GetIt.I<GlobalIsolate>()
-          .send<List<int>>(IsolateRequestType.syncContactsToHandles, input: <String, dynamic>{});
+          .send<Map<String, dynamic>>(IsolateRequestType.syncContactsToHandlesWithStats, input: data);
+    }
+  }
+
+  /// Returns each on-device account with contacts, plus a live contact count
+  /// per account (`{'name': String, 'type': String, 'count': int}`), for the
+  /// Contacts Management page's account selector.
+  static Future<List<Map<String, dynamic>>> getAccountContactCounts() async {
+    if (isIsolate) {
+      return await ContactV2Actions.getAccountContactCounts(<String, dynamic>{});
+    } else {
+      // Received as untyped List<dynamic> across the isolate boundary — cast each
+      // entry explicitly rather than requesting List<Map<String, dynamic>> from
+      // send<T>() directly, since a concrete nested-generic type isn't guaranteed
+      // to survive the isolate message copy.
+      final result = await GetIt.I<GlobalIsolate>()
+          .send<List<dynamic>>(IsolateRequestType.getAccountContactCounts, input: <String, dynamic>{});
+      return result.map((e) => Map<String, dynamic>.from(e as Map)).toList();
     }
   }
 

--- a/lib/services/backend/settings/actions/shared_preferences_system_actions.dart
+++ b/lib/services/backend/settings/actions/shared_preferences_system_actions.dart
@@ -2,6 +2,7 @@ import 'package:bluebubbles/services/backend/settings/shared_preferences_service
 
 class SharedPreferencesSystemActions {
   static const String _backgroundCallbackHandleKey = 'backgroundCallbackHandle';
+  static const String _lastContactPermissionCheckKey = 'lastContactPermissionCheck';
 
   final SharedPreferencesService service;
 
@@ -10,4 +11,9 @@ class SharedPreferencesSystemActions {
   int? getBackgroundCallbackHandle() => service.i.getInt(_backgroundCallbackHandleKey);
 
   Future<void> setBackgroundCallbackHandle(int handle) => service.i.setInt(_backgroundCallbackHandleKey, handle);
+
+  int? getLastContactPermissionCheck() => service.i.getInt(_lastContactPermissionCheckKey);
+
+  Future<void> setLastContactPermissionCheck(int epochMillis) =>
+      service.i.setInt(_lastContactPermissionCheckKey, epochMillis);
 }

--- a/lib/services/isolates/global_isolate.dart
+++ b/lib/services/isolates/global_isolate.dart
@@ -681,6 +681,7 @@ enum IsolateRequestType {
 
   // ContactV2 actions (new contact service)
   syncContactsToHandles,
+  syncContactsToHandlesWithStats,
   getStoredContactIds,
   findOneContact,
   getContactsForHandles,
@@ -689,6 +690,7 @@ enum IsolateRequestType {
   fetchNetworkContacts,
   getContactAvatar,
   uploadContactsV2,
+  getAccountContactCounts,
 
   // Attachment actions
   saveAttachmentAsync,

--- a/lib/services/isolates/isolate_actions.dart
+++ b/lib/services/isolates/isolate_actions.dart
@@ -88,6 +88,7 @@ class IsolateActons {
 
     // ContactV2 (new contact service)
     IsolateRequestType.syncContactsToHandles: ContactV2Actions.syncContactsToHandles,
+    IsolateRequestType.syncContactsToHandlesWithStats: ContactV2Actions.syncContactsToHandlesWithStats,
     IsolateRequestType.getStoredContactIds: ContactV2Actions.getStoredContactIds,
     IsolateRequestType.findOneContact: ContactV2Actions.findOneContact,
     IsolateRequestType.getContactsForHandles: ContactV2Actions.getContactsForHandles,
@@ -95,6 +96,7 @@ class IsolateActons {
     IsolateRequestType.getAllContacts: ContactV2Actions.getAllContacts,
     IsolateRequestType.getContactAvatar: ContactV2Actions.getContactAvatar,
     IsolateRequestType.uploadContactsV2: ContactV2Actions.uploadContacts,
+    IsolateRequestType.getAccountContactCounts: ContactV2Actions.getAccountContactCounts,
 
     // Attachment
     IsolateRequestType.saveAttachmentAsync: AttachmentActions.saveAttachmentAsync,

--- a/lib/services/ui/contact_service_v2.dart
+++ b/lib/services/ui/contact_service_v2.dart
@@ -27,6 +27,18 @@ class ContactServiceV2 {
   /// in a burst, and each full sync is an expensive Contacts Provider sweep.
   static const Duration _contactChangeDebounce = Duration(seconds: 30);
 
+  /// Minimum time between OS permission re-checks on app resume while the last
+  /// known status is `granted` or `permanentlyDenied` — states unlikely to have
+  /// changed since the last check. A plain `denied` status is re-checked on
+  /// every resume instead (see [refreshPermissionStatusOnResume]), since that's
+  /// the state most likely to change from outside the app (user grants access
+  /// via system Settings and switches back).
+  static const Duration _permissionRecheckThrottle = Duration(minutes: 15);
+
+  /// Last known permission status, used to decide whether
+  /// [refreshPermissionStatusOnResume] should throttle its re-check.
+  PermissionStatus? _lastKnownPermissionStatus;
+
   /// Whether we have permission to access contacts
   bool _hasContactAccess = false;
 
@@ -54,7 +66,9 @@ class ContactServiceV2 {
     if (kIsWeb || kIsDesktop) {
       return SettingsSvc.getServerDetails().supportsContactsApi;
     } else {
-      return (await Permission.contacts.status).isGranted;
+      final status = await Permission.contacts.status;
+      _lastKnownPermissionStatus = status;
+      return status.isGranted;
     }
   }
 
@@ -63,6 +77,7 @@ class ContactServiceV2 {
     if (kIsWeb || kIsDesktop) return false;
 
     final status = await Permission.contacts.request();
+    _lastKnownPermissionStatus = status;
     _hasContactAccess = status.isGranted;
 
     if (_hasContactAccess) {
@@ -72,6 +87,78 @@ class ContactServiceV2 {
     }
 
     return _hasContactAccess;
+  }
+
+  /// Re-check the OS contacts permission status on app resume.
+  ///
+  /// A plain [PermissionStatus.denied] (never granted, or deniable again) is
+  /// re-checked on every call — it's the state most likely to have changed
+  /// from outside the app (the user grants access via system Settings and
+  /// switches back), and the check itself is a cheap platform-channel status
+  /// query. [PermissionStatus.granted] and [PermissionStatus.permanentlyDenied]
+  /// are unlikely to have changed since the last check, so those are throttled
+  /// via a persisted last-checked timestamp (survives app restarts).
+  Future<void> refreshPermissionStatusOnResume() async {
+    if (kIsWeb || kIsDesktop) return;
+
+    final lastStatus = _lastKnownPermissionStatus;
+    if (lastStatus == null || lastStatus == PermissionStatus.denied) {
+      _hasContactAccess = await _canAccessContacts();
+      return;
+    }
+
+    final lastCheckMillis = PrefsSvc.system.getLastContactPermissionCheck();
+    final lastCheck = lastCheckMillis != null ? DateTime.fromMillisecondsSinceEpoch(lastCheckMillis) : null;
+    if (lastCheck != null && DateTime.now().difference(lastCheck) < _permissionRecheckThrottle) {
+      return;
+    }
+
+    _hasContactAccess = await _canAccessContacts();
+    await PrefsSvc.system.setLastContactPermissionCheck(DateTime.now().millisecondsSinceEpoch);
+  }
+
+  /// Force a live re-check of the OS contacts permission status, bypassing
+  /// the in-memory cache. Used by the Contacts Management page's "Refresh
+  /// Status" action — unlike [requestContactPermission], this never shows
+  /// the OS permission prompt.
+  Future<bool> checkPermissionStatus() async {
+    _hasContactAccess = await _canAccessContacts();
+    return _hasContactAccess;
+  }
+
+  /// Returns each on-device account with contacts, plus a live contact count
+  /// per account, for the Contacts Management page's account selector.
+  Future<List<Map<String, dynamic>>> getAccountContactCounts() async {
+    try {
+      return await ContactV2Interface.getAccountContactCounts();
+    } catch (e, stack) {
+      Logger.error('[ContactServiceV2] Error getting account contact counts', error: e, trace: stack);
+      return [];
+    }
+  }
+
+  /// Same as [syncContactsToHandles], but also returns the device contact
+  /// count and matched-contact count — used by the Contacts Management
+  /// page's manual refresh for diagnostic display.
+  Future<Map<String, dynamic>> syncContactsToHandlesWithStats() async {
+    const Map<String, dynamic> empty = {'affectedHandleIds': <int>[], 'deviceContactCount': 0, 'matchedContactCount': 0};
+
+    final access = await hasContactAccess;
+    if (!access) return empty;
+
+    try {
+      final raw = await ContactV2Interface.syncContactsToHandlesWithStats();
+      final affectedHandleIds = (raw['affectedHandleIds'] as List).cast<int>();
+      notifyHandlesUpdated(affectedHandleIds);
+      return {
+        'affectedHandleIds': affectedHandleIds,
+        'deviceContactCount': raw['deviceContactCount'] as int? ?? 0,
+        'matchedContactCount': raw['matchedContactCount'] as int? ?? 0,
+      };
+    } catch (e, stack) {
+      Logger.error('[ContactServiceV2] Error syncing contacts with stats', error: e, trace: stack);
+      return empty;
+    }
   }
 
   /// Initialize the contact service


### PR DESCRIPTION
diagnoses a report of contacts permission showing granted but no contacts
matching (most likely GrapheneOS Contact Scopes silently restricting
access while the OS permission reads as granted):

- refresh the contacts permission status on app resume instead of
  caching a granted result forever; throttled except when the last known
  status is plain "denied", which is checked every resume so granting
  access via system settings takes effect immediately
- log a diagnostic breadcrumb when permission is granted but the device
  contact fetch returns zero contacts, and log the exception type
  distinctly on sync failures, so the two silent-failure modes are
  distinguishable in exported logs
- add a "Contacts Management" settings page (iOS/Material/Samsung skins,
  Material and Samsung using the M3E component set) showing live
  permission status, manual refresh with device/matched/updated contact
  counts, and a per-account selector with live per-account contact
  counts so a sync can be scoped to a specific device account

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019F7MaEVQFYUfm5f8k8Kg2u