### PR TITLE
feat: add skin-aware BBSlider with cupertino and m3e slider support

### DIFF
--- a/docs/THEMING_AND_COMPONENTS.md
+++ b/docs/THEMING_AND_COMPONENTS.md
@@ -108,6 +108,39 @@ BBSwitch(
 internally, so every settings toggle built on top of it is skin-aware for free. Prefer `BBSwitch`
 over raw `Switch`/`CupertinoSwitch` for any new toggle outside of `SettingsSwitch`.
 
+## `BBSlider`
+
+`lib/app/components/bb_slider.dart`
+
+Skin-aware slider: renders `CupertinoSlider` under the iOS skin (`context.iOS`) and a Material 3
+Expressive-styled `Slider` under Material/Samsung. Drop-in replacement for either — takes `value`,
+`onChanged`, `onChangeStart`, `onChangeEnd`, `min`, `max`, an optional `divisions` (step count),
+`label` (Material discrete-drag tooltip), and optional `activeColor` / `inactiveColor` /
+`thumbColor` overrides. Colors default to the active `ColorScheme` (`primary` / `secondaryContainer`)
+when omitted — never hardcode slider colors at the call site.
+
+```dart
+BBSlider(
+  value: currentValue,
+  min: 0,
+  max: 10,
+  divisions: 10,
+  label: currentValue.toStringAsFixed(1),
+  onChanged: (val) => setState(() => currentValue = val),
+)
+```
+
+The Material/Samsung styling comes from `M3ESlider.themeData()` (`lib/app/components/m3e/m3e_slider.dart`)
+— part of the `m3e/` Material 3 Expressive primitive set (`lib/app/components/CLAUDE.md`): a 16dp
+track, an oversized (14dp radius) round thumb, and dotted stop-indicators for discrete steps, all
+colored from the active `ColorScheme` rather than hardcoded.
+
+`SettingsSlider` (`lib/app/layouts/settings/widgets/content/settings_slider.dart`) uses `BBSlider`
+internally, so every settings slider built on top of it is skin-aware for free. Prefer `BBSlider`
+over raw `Slider`/`CupertinoSlider` for any new numeric picker outside of `SettingsSlider` — the
+in-app camera scrubber and audio-message playback scrubber are the two intentional exceptions
+(they overlay media and are deliberately theme-independent).
+
 ## Dialogs (`dialog_helpers.dart`)
 
 `lib/helpers/ui/dialog_helpers.dart`

--- a/lib/app/components/CLAUDE.md
+++ b/lib/app/components/CLAUDE.md
@@ -16,6 +16,7 @@ Color gradient from address: `toColorGradient(handle?.address)`. Custom color: `
 ## Other Components
 - `bb_chip.dart` — chip/tag widget (used for labels, selected contacts, etc.)
 - `bb_switch.dart` — `BBSwitch`, skin-aware toggle (`CupertinoSwitch` on iOS skin, Material `Switch` otherwise). Used internally by `SettingsSwitch`; prefer it over raw `Switch`/`CupertinoSwitch` for any new toggle.
+- `bb_slider.dart` — `BBSlider`, skin-aware slider (`CupertinoSlider` on iOS skin, Material 3 Expressive-styled `Slider` via `m3e/m3e_slider.dart` on Material/Samsung). Supports `divisions` (steps). Used internally by `SettingsSlider`; prefer it over raw `Slider`/`CupertinoSlider` for any new slider/number-picker.
 - `circle_progress_bar.dart` — circular progress indicator
 - `custom_text_editing_controllers.dart` — `TextEditingController` subclasses for mention detection and rich formatting in the message composer
 - `sliver_decoration.dart` — decorative header for `CustomScrollView` / `SliverAppBar`
@@ -32,6 +33,10 @@ corner silently reflows layout.
 
 `M3ETonalButton` takes a nullable `onPressed`; pass null for a busy/unavailable state rather than
 an empty callback, and it handles the dimming, the inert ink, and the semantics.
+
+`M3ESlider.themeData(context, ...)` returns a `SliderThemeData` (thick track, oversized thumb,
+dotted step indicators) built from the active `ColorScheme` — consumed by `BBSlider`, not used
+directly by feature code.
 
 ## Charts (`charts/`)
 Thin `fl_chart` wrappers and stat-display primitives, shared across any feature that needs simple

--- a/lib/app/components/bb_slider.dart
+++ b/lib/app/components/bb_slider.dart
@@ -1,0 +1,78 @@
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// A skin-aware slider — renders [CupertinoSlider] under the iOS skin and a
+/// Material 3 Expressive-styled [Slider] (see [M3ESlider]) under the Material
+/// and Samsung skins. Use this instead of either widget directly.
+class BBSlider extends StatelessWidget {
+  final double value;
+  final ValueChanged<double>? onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
+  final double min;
+  final double max;
+
+  /// Number of discrete steps between [min] and [max]. Null renders a continuous slider.
+  final int? divisions;
+
+  /// Shown above the thumb while dragging a discrete (Material/Samsung) slider.
+  final String? label;
+
+  final Color? activeColor;
+  final Color? inactiveColor;
+  final Color? thumbColor;
+
+  const BBSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.onChangeStart,
+    this.onChangeEnd,
+    required this.min,
+    required this.max,
+    this.divisions,
+    this.label,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (context.iOS) {
+      return CupertinoSlider(
+        value: value,
+        onChanged: onChanged,
+        onChangeStart: onChangeStart,
+        onChangeEnd: onChangeEnd,
+        min: min,
+        max: max,
+        divisions: divisions,
+        activeColor: activeColor ?? context.theme.colorScheme.primary,
+        thumbColor: thumbColor ?? CupertinoColors.white,
+      );
+    }
+
+    return SliderTheme(
+      data: M3ESlider.themeData(
+        context,
+        activeColor: activeColor,
+        inactiveColor: inactiveColor,
+        thumbColor: thumbColor,
+      ),
+      child: Slider(
+        value: value,
+        onChanged: onChanged,
+        onChangeStart: onChangeStart,
+        onChangeEnd: onChangeEnd,
+        min: min,
+        max: max,
+        divisions: divisions,
+        label: label,
+        mouseCursor: MouseCursor.defer,
+      ),
+    );
+  }
+}

--- a/lib/app/components/m3e/m3e.dart
+++ b/lib/app/components/m3e/m3e.dart
@@ -4,6 +4,7 @@ export 'm3e_motion.dart';
 export 'm3e_section.dart';
 export 'm3e_section_header.dart';
 export 'm3e_shapes.dart';
+export 'm3e_slider.dart';
 export 'm3e_spacing.dart';
 export 'm3e_stat_tile.dart';
 export 'm3e_tonal_button.dart';

--- a/lib/app/components/m3e/m3e_slider.dart
+++ b/lib/app/components/m3e/m3e_slider.dart
@@ -1,0 +1,43 @@
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Material 3 Expressive slider theming — a thicker track, an oversized round
+/// thumb, and dotted stop indicators for discrete steps, built from the app's
+/// active [ColorScheme]. Used by [BBSlider] (`lib/app/components/bb_slider.dart`)
+/// under the Material and Samsung skins.
+abstract final class M3ESlider {
+  static const double trackHeight = 16;
+  static const double thumbRadius = 14;
+  static const double overlayRadius = 24;
+  static const double tickMarkRadius = 1.5;
+
+  static SliderThemeData themeData(
+    BuildContext context, {
+    Color? activeColor,
+    Color? inactiveColor,
+    Color? thumbColor,
+  }) {
+    final colorScheme = context.theme.colorScheme;
+    final active = activeColor ?? colorScheme.primary;
+    final inactive = inactiveColor ?? colorScheme.secondaryContainer;
+    final thumb = thumbColor ?? active;
+
+    return SliderThemeData(
+      trackHeight: trackHeight,
+      activeTrackColor: active,
+      inactiveTrackColor: inactive,
+      secondaryActiveTrackColor: active.withValues(alpha: 0.6),
+      disabledActiveTrackColor: active.withValues(alpha: 0.38),
+      disabledInactiveTrackColor: inactive.withValues(alpha: 0.38),
+      thumbColor: thumb,
+      disabledThumbColor: thumb.withValues(alpha: 0.38),
+      overlayColor: active.withValues(alpha: 0.12),
+      activeTickMarkColor: colorScheme.onPrimary.withValues(alpha: 0.6),
+      inactiveTickMarkColor: colorScheme.onSecondaryContainer.withValues(alpha: 0.6),
+      trackShape: const RoundedRectSliderTrackShape(),
+      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: thumbRadius, disabledThumbRadius: thumbRadius),
+      overlayShape: const RoundSliderOverlayShape(overlayRadius: overlayRadius),
+      tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: tickMarkRadius),
+    );
+  }
+}

--- a/lib/app/layouts/settings/pages/theming/background/background_crop.dart
+++ b/lib/app/layouts/settings/pages/theming/background/background_crop.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 
+import 'package:bluebubbles/app/components/bb_slider.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
 import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
@@ -315,7 +316,7 @@ class _BackgroundCropState extends State<BackgroundCrop> with ThemeHelpers {
               color: context.theme.colorScheme.onSurfaceVariant,
             ),
             Expanded(
-              child: Slider(
+              child: BBSlider(
                 min: 0,
                 max: 10,
                 value: _blurSigma,

--- a/lib/app/layouts/settings/widgets/content/CLAUDE.md
+++ b/lib/app/layouts/settings/widgets/content/CLAUDE.md
@@ -9,7 +9,7 @@ These are the **primary building blocks** for all settings pages. Assemble setti
 | `SettingsTile` | `settings_tile.dart` | Base row: title, subtitle, leading icon, trailing widget, onTap |
 | `SettingsSwitch` | `settings_switch.dart` | Toggle row with a `BBSwitch` (skin-aware — `lib/app/components/bb_switch.dart`); tap toggles |
 | `SettingsOptions<T>` | `settings_dropdown.dart` | Dropdown selector (Material) or segmented control (iOS) |
-| `SettingsSlider` | `settings_slider.dart` | Slider input row |
+| `SettingsSlider` | `settings_slider.dart` | Slider input row with a `BBSlider` (skin-aware — `lib/app/components/bb_slider.dart`) |
 | `SettingsLeadingIcon` | `settings_leading_icon.dart` | Styled leading icon (colored rounded square) |
 | `SettingsSubtitle` | `settings_subtitle.dart` | Section subtitle / description text |
 | `NextButton` | `next_button.dart` | Navigation arrow button for settings flows |

--- a/lib/app/layouts/settings/widgets/content/settings_slider.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_slider.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/components/bb_slider.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -38,11 +39,7 @@ class SettingsSlider extends StatelessWidget {
       leading: leading,
       trailing: Text(value, style: context.theme.textTheme.bodyLarge),
       minLeadingWidth: leadingMinWidth,
-      title: Slider(
-        activeColor: context.theme.colorScheme.primary.oppositeLightenOrDarken(20),
-        secondaryActiveColor: context.theme.colorScheme.primary.withValues(alpha: 0.6),
-        thumbColor: context.theme.colorScheme.primary,
-        inactiveColor: context.theme.colorScheme.primary.withValues(alpha: 0.2),
+      title: BBSlider(
         value: startingVal,
         onChanged: update,
         onChangeEnd: onChangeEnd,
@@ -50,7 +47,6 @@ class SettingsSlider extends StatelessWidget {
         divisions: divisions,
         min: min,
         max: max,
-        mouseCursor: MouseCursor.defer,
       ),
     );
   }

--- a/lib/app/layouts/setup/pages/sync/sync_settings.dart
+++ b/lib/app/layouts/setup/pages/sync/sync_settings.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/components/bb_slider.dart';
 import 'package:bluebubbles/helpers/ui/theme_helpers.dart';
 import 'package:bluebubbles/app/layouts/setup/pages/page_template.dart';
 import 'package:bluebubbles/app/layouts/setup/setup_view.dart';
@@ -251,7 +252,7 @@ class _NumberOfMessagesSliderState extends CustomState<NumberOfMessagesSlider, i
           ),
         ),
         const SizedBox(height: 10),
-        Slider(
+        BBSlider(
           value: numberOfMessages,
           onChanged: (double value) {
             controller.updateNumberToDownload(value.toInt());


### PR DESCRIPTION
Sliders across settings pages were plain Material widgets even under the
iOS skin, unlike BBSwitch/BBChip which already skin themselves. BBSlider
renders CupertinoSlider on iOS and a Material 3 Expressive-styled Slider
(via the new m3e/m3e_slider.dart theme helper) on Material/Samsung, with
divisions/steps supported on both. SettingsSlider now delegates to it
internally, and the background-crop blur slider and sync-setup message
count slider are migrated directly.