### PR TITLE
feat: dynamic wallpapers

### DIFF
--- a/docs/THEMING_AND_COMPONENTS.md
+++ b/docs/THEMING_AND_COMPONENTS.md
@@ -108,6 +108,39 @@ BBSwitch(
 internally, so every settings toggle built on top of it is skin-aware for free. Prefer `BBSwitch`
 over raw `Switch`/`CupertinoSwitch` for any new toggle outside of `SettingsSwitch`.
 
+## `BBSlider`
+
+`lib/app/components/bb_slider.dart`
+
+Skin-aware slider: renders `CupertinoSlider` under the iOS skin (`context.iOS`) and a Material 3
+Expressive-styled `Slider` under Material/Samsung. Drop-in replacement for either — takes `value`,
+`onChanged`, `onChangeStart`, `onChangeEnd`, `min`, `max`, an optional `divisions` (step count),
+`label` (Material discrete-drag tooltip), and optional `activeColor` / `inactiveColor` /
+`thumbColor` overrides. Colors default to the active `ColorScheme` (`primary` / `secondaryContainer`)
+when omitted — never hardcode slider colors at the call site.
+
+```dart
+BBSlider(
+  value: currentValue,
+  min: 0,
+  max: 10,
+  divisions: 10,
+  label: currentValue.toStringAsFixed(1),
+  onChanged: (val) => setState(() => currentValue = val),
+)
+```
+
+The Material/Samsung styling comes from `M3ESlider.themeData()` (`lib/app/components/m3e/m3e_slider.dart`)
+— part of the `m3e/` Material 3 Expressive primitive set (`lib/app/components/CLAUDE.md`): a 16dp
+track, an oversized (14dp radius) round thumb, and dotted stop-indicators for discrete steps, all
+colored from the active `ColorScheme` rather than hardcoded.
+
+`SettingsSlider` (`lib/app/layouts/settings/widgets/content/settings_slider.dart`) uses `BBSlider`
+internally, so every settings slider built on top of it is skin-aware for free. Prefer `BBSlider`
+over raw `Slider`/`CupertinoSlider` for any new numeric picker outside of `SettingsSlider` — the
+in-app camera scrubber and audio-message playback scrubber are the two intentional exceptions
+(they overlay media and are deliberately theme-independent).
+
 ## Dialogs (`dialog_helpers.dart`)
 
 `lib/helpers/ui/dialog_helpers.dart`

--- a/lib/app/components/CLAUDE.md
+++ b/lib/app/components/CLAUDE.md
@@ -16,6 +16,7 @@ Color gradient from address: `toColorGradient(handle?.address)`. Custom color: `
 ## Other Components
 - `bb_chip.dart` — chip/tag widget (used for labels, selected contacts, etc.)
 - `bb_switch.dart` — `BBSwitch`, skin-aware toggle (`CupertinoSwitch` on iOS skin, Material `Switch` otherwise). Used internally by `SettingsSwitch`; prefer it over raw `Switch`/`CupertinoSwitch` for any new toggle.
+- `bb_slider.dart` — `BBSlider`, skin-aware slider (`CupertinoSlider` on iOS skin, Material 3 Expressive-styled `Slider` via `m3e/m3e_slider.dart` on Material/Samsung). Supports `divisions` (steps). Used internally by `SettingsSlider`; prefer it over raw `Slider`/`CupertinoSlider` for any new slider/number-picker.
 - `circle_progress_bar.dart` — circular progress indicator
 - `custom_text_editing_controllers.dart` — `TextEditingController` subclasses for mention detection and rich formatting in the message composer
 - `sliver_decoration.dart` — decorative header for `CustomScrollView` / `SliverAppBar`
@@ -32,6 +33,10 @@ corner silently reflows layout.
 
 `M3ETonalButton` takes a nullable `onPressed`; pass null for a busy/unavailable state rather than
 an empty callback, and it handles the dimming, the inert ink, and the semantics.
+
+`M3ESlider.themeData(context, ...)` returns a `SliderThemeData` (thick track, oversized thumb,
+dotted step indicators) built from the active `ColorScheme` — consumed by `BBSlider`, not used
+directly by feature code.
 
 ## Charts (`charts/`)
 Thin `fl_chart` wrappers and stat-display primitives, shared across any feature that needs simple

--- a/lib/app/components/bb_slider.dart
+++ b/lib/app/components/bb_slider.dart
@@ -1,0 +1,78 @@
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// A skin-aware slider — renders [CupertinoSlider] under the iOS skin and a
+/// Material 3 Expressive-styled [Slider] (see [M3ESlider]) under the Material
+/// and Samsung skins. Use this instead of either widget directly.
+class BBSlider extends StatelessWidget {
+  final double value;
+  final ValueChanged<double>? onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
+  final double min;
+  final double max;
+
+  /// Number of discrete steps between [min] and [max]. Null renders a continuous slider.
+  final int? divisions;
+
+  /// Shown above the thumb while dragging a discrete (Material/Samsung) slider.
+  final String? label;
+
+  final Color? activeColor;
+  final Color? inactiveColor;
+  final Color? thumbColor;
+
+  const BBSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.onChangeStart,
+    this.onChangeEnd,
+    required this.min,
+    required this.max,
+    this.divisions,
+    this.label,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (context.iOS) {
+      return CupertinoSlider(
+        value: value,
+        onChanged: onChanged,
+        onChangeStart: onChangeStart,
+        onChangeEnd: onChangeEnd,
+        min: min,
+        max: max,
+        divisions: divisions,
+        activeColor: activeColor ?? context.theme.colorScheme.primary,
+        thumbColor: thumbColor ?? CupertinoColors.white,
+      );
+    }
+
+    return SliderTheme(
+      data: M3ESlider.themeData(
+        context,
+        activeColor: activeColor,
+        inactiveColor: inactiveColor,
+        thumbColor: thumbColor,
+      ),
+      child: Slider(
+        value: value,
+        onChanged: onChanged,
+        onChangeStart: onChangeStart,
+        onChangeEnd: onChangeEnd,
+        min: min,
+        max: max,
+        divisions: divisions,
+        label: label,
+        mouseCursor: MouseCursor.defer,
+      ),
+    );
+  }
+}

--- a/lib/app/components/bb_slider.dart
+++ b/lib/app/components/bb_slider.dart
@@ -50,7 +50,7 @@ class BBSlider extends StatelessWidget {
         min: min,
         max: max,
         divisions: divisions,
-        activeColor: activeColor ?? context.theme.colorScheme.primary,
+        activeColor: activeColor ?? Theme.of(context).colorScheme.primary,
         thumbColor: thumbColor ?? CupertinoColors.white,
       );
     }

--- a/lib/app/components/bb_vertical_select.dart
+++ b/lib/app/components/bb_vertical_select.dart
@@ -1,0 +1,87 @@
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
+
+/// A vertically-stacked single-select control -- every option gets its own
+/// full-width row instead of splitting one row's width `n` ways (as a
+/// segmented control does), so labels stay readable as the option count
+/// grows instead of getting crushed/truncated.
+///
+/// Skin-specific entry point, following the [BBSwitch]/[BBSlider] pattern:
+/// picks the implementation for the active skin. iOS is the only
+/// implementation right now -- Material/Samsung throw until one exists.
+class BBVerticalSelect<T> extends StatelessWidget {
+  final List<T> options;
+  final T value;
+  final String Function(T option) labelBuilder;
+  final IconData? Function(T option)? iconBuilder;
+  final ValueChanged<T> onChanged;
+
+  const BBVerticalSelect({
+    super.key,
+    required this.options,
+    required this.value,
+    required this.labelBuilder,
+    required this.onChanged,
+    this.iconBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (context.iOS) {
+      return _CupertinoVerticalSelect<T>(
+        options: options,
+        value: value,
+        labelBuilder: labelBuilder,
+        iconBuilder: iconBuilder,
+        onChanged: onChanged,
+      );
+    }
+
+    throw UnimplementedError(
+      'BBVerticalSelect has no Material/Samsung implementation yet -- only the iOS skin is supported.',
+    );
+  }
+}
+
+class _CupertinoVerticalSelect<T> extends StatelessWidget {
+  final List<T> options;
+  final T value;
+  final String Function(T option) labelBuilder;
+  final IconData? Function(T option)? iconBuilder;
+  final ValueChanged<T> onChanged;
+
+  const _CupertinoVerticalSelect({
+    required this.options,
+    required this.value,
+    required this.labelBuilder,
+    required this.onChanged,
+    this.iconBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (int i = 0; i < options.length; i++) ...[
+          if (i > 0) const SettingsDivider(padding: EdgeInsets.only(left: 16)),
+          _buildRow(context, options[i]),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildRow(BuildContext context, T option) {
+    final selected = option == value;
+    final icon = iconBuilder?.call(option);
+    return SettingsTile(
+      leading: icon == null ? null : Icon(icon, color: context.theme.colorScheme.onSurfaceVariant),
+      title: labelBuilder(option),
+      trailing:
+          selected ? Icon(CupertinoIcons.check_mark, color: context.theme.colorScheme.primary, size: 20) : null,
+      onTap: () => onChanged(option),
+    );
+  }
+}

--- a/lib/app/components/custom/custom_cupertino_alert_dialog.dart
+++ b/lib/app/components/custom/custom_cupertino_alert_dialog.dart
@@ -457,16 +457,10 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
 // section is given whatever height remains.
 class _RenderCupertinoDialog extends RenderBox {
   _RenderCupertinoDialog({
-    RenderBox? contentSection,
-    RenderBox? actionsSection,
-    double dividerThickness = 0.0,
-    bool isInAccessibilityMode = false,
+    this._dividerThickness = 0.0,
+    this._isInAccessibilityMode = false,
     required Color dividerColor,
-  })  : _contentSection = contentSection,
-        _actionsSection = actionsSection,
-        _dividerThickness = dividerThickness,
-        _isInAccessibilityMode = isInAccessibilityMode,
-        _dividerPaint = Paint()
+  })  : _contentSection = null, _actionsSection = null, _dividerPaint = Paint()
           ..color = dividerColor
           ..style = PaintingStyle.fill;
 
@@ -1211,11 +1205,10 @@ class CupertinoDialogAction extends StatelessWidget {
 class _CupertinoDialogActionsRenderWidget extends MultiChildRenderObjectWidget {
   const _CupertinoDialogActionsRenderWidget({
     required List<Widget> actionButtons,
-    double dividerThickness = 0.0,
+    this._dividerThickness = 0.0,
     required this.dialogColor,
     required this.pressedDialogColor,
-  })  : _dividerThickness = dividerThickness,
-        super(children: actionButtons);
+  })  : super(children: actionButtons);
 
   final double _dividerThickness;
   final Color dialogColor;
@@ -1283,13 +1276,12 @@ class _RenderCupertinoDialogActions extends RenderBox
         RenderBoxContainerDefaultsMixin<RenderBox, MultiChildLayoutParentData> {
   _RenderCupertinoDialogActions({
     List<RenderBox>? children,
-    required double dialogWidth,
-    double dividerThickness = 0.0,
+    required this._dialogWidth,
+    this._dividerThickness = 0.0,
     required Color dialogColor,
     required Color dialogPressedColor,
     required Color dividerColor,
-  })  : _dialogWidth = dialogWidth,
-        _buttonBackgroundPaint = Paint()
+  })  : _buttonBackgroundPaint = Paint()
           ..color = dialogColor
           ..style = PaintingStyle.fill,
         _pressedButtonBackgroundPaint = Paint()
@@ -1297,8 +1289,7 @@ class _RenderCupertinoDialogActions extends RenderBox
           ..style = PaintingStyle.fill,
         _dividerPaint = Paint()
           ..color = dividerColor
-          ..style = PaintingStyle.fill,
-        _dividerThickness = dividerThickness {
+          ..style = PaintingStyle.fill {
     addAll(children);
   }
 

--- a/lib/app/components/m3e/m3e.dart
+++ b/lib/app/components/m3e/m3e.dart
@@ -4,6 +4,7 @@ export 'm3e_motion.dart';
 export 'm3e_section.dart';
 export 'm3e_section_header.dart';
 export 'm3e_shapes.dart';
+export 'm3e_slider.dart';
 export 'm3e_spacing.dart';
 export 'm3e_stat_tile.dart';
 export 'm3e_tonal_button.dart';

--- a/lib/app/components/m3e/m3e_slider.dart
+++ b/lib/app/components/m3e/m3e_slider.dart
@@ -1,0 +1,43 @@
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Material 3 Expressive slider theming — a thicker track, an oversized round
+/// thumb, and dotted stop indicators for discrete steps, built from the app's
+/// active [ColorScheme]. Used by [BBSlider] (`lib/app/components/bb_slider.dart`)
+/// under the Material and Samsung skins.
+abstract final class M3ESlider {
+  static const double trackHeight = 16;
+  static const double thumbRadius = 14;
+  static const double overlayRadius = 24;
+  static const double tickMarkRadius = 1.5;
+
+  static SliderThemeData themeData(
+    BuildContext context, {
+    Color? activeColor,
+    Color? inactiveColor,
+    Color? thumbColor,
+  }) {
+    final colorScheme = context.theme.colorScheme;
+    final active = activeColor ?? colorScheme.primary;
+    final inactive = inactiveColor ?? colorScheme.secondaryContainer;
+    final thumb = thumbColor ?? active;
+
+    return SliderThemeData(
+      trackHeight: trackHeight,
+      activeTrackColor: active,
+      inactiveTrackColor: inactive,
+      secondaryActiveTrackColor: active.withValues(alpha: 0.6),
+      disabledActiveTrackColor: active.withValues(alpha: 0.38),
+      disabledInactiveTrackColor: inactive.withValues(alpha: 0.38),
+      thumbColor: thumb,
+      disabledThumbColor: thumb.withValues(alpha: 0.38),
+      overlayColor: active.withValues(alpha: 0.12),
+      activeTickMarkColor: colorScheme.onPrimary.withValues(alpha: 0.6),
+      inactiveTickMarkColor: colorScheme.onSecondaryContainer.withValues(alpha: 0.6),
+      trackShape: const RoundedRectSliderTrackShape(),
+      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: thumbRadius, disabledThumbRadius: thumbRadius),
+      overlayShape: const RoundSliderOverlayShape(overlayRadius: overlayRadius),
+      tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: tickMarkRadius),
+    );
+  }
+}

--- a/lib/app/components/m3e/m3e_slider.dart
+++ b/lib/app/components/m3e/m3e_slider.dart
@@ -1,5 +1,5 @@
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 /// Material 3 Expressive slider theming — a thicker track, an oversized round
 /// thumb, and dotted stop indicators for discrete steps, built from the app's

--- a/lib/app/components/wallpaper/chat_wallpaper_type.dart
+++ b/lib/app/components/wallpaper/chat_wallpaper_type.dart
@@ -1,0 +1,32 @@
+/// How a chat's background is rendered.
+///
+/// Stored on [Chat.wallpaperType] as [name]. `none` means no custom wallpaper
+/// (falls back to the app-wide gradient/background); `image` means a static
+/// custom background image (`Chat.customBackgroundPath`); `dynamic` means an
+/// animated wallpaper resolved via [DynamicWallpaperRegistry] using
+/// `Chat.dynamicWallpaperId` + `Chat.dynamicWallpaperConfig`.
+enum ChatWallpaperType {
+  none,
+  image,
+  dynamic;
+
+  static ChatWallpaperType fromName(String? name) {
+    return ChatWallpaperType.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => ChatWallpaperType.none,
+    );
+  }
+
+  /// Resolves the effective wallpaper type for a chat, treating an unset
+  /// [storedType] with an existing [imagePath] as "image" — chats that had a
+  /// custom background before this enum existed never persisted a type, so
+  /// they must still resolve to "image" rather than silently reverting to
+  /// the default background.
+  static ChatWallpaperType resolve(String? storedType, String? imagePath) {
+    final type = fromName(storedType);
+    if (type == ChatWallpaperType.none && imagePath != null && imagePath.isNotEmpty) {
+      return ChatWallpaperType.image;
+    }
+    return type;
+  }
+}

--- a/lib/app/components/wallpaper/dynamic_wallpaper_config_field.dart
+++ b/lib/app/components/wallpaper/dynamic_wallpaper_config_field.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+/// Generic, skin-agnostic description of one editable control on a dynamic
+/// wallpaper's config screen. [DynamicWallpaperDefinition.buildConfigFields]
+/// returns a list of these; the config page shell (one body per skin) turns
+/// each into the appropriate row widget. This is what makes adding a new
+/// dynamic wallpaper type "free" from a UI perspective — it only has to
+/// describe its knobs, not build three skin-specific screens for them.
+sealed class ConfigField {
+  final String label;
+  const ConfigField(this.label);
+}
+
+class ConfigSliderField extends ConfigField {
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final String Function(double value)? format;
+  final void Function(double value) onChanged;
+
+  const ConfigSliderField({
+    required String label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.onChanged,
+    this.format,
+  }) : super(label);
+}
+
+class ConfigChoiceOption {
+  final String value;
+  final String label;
+  final IconData? icon;
+
+  const ConfigChoiceOption({required this.value, required this.label, this.icon});
+}
+
+class ConfigChoiceField extends ConfigField {
+  final String value;
+  final List<ConfigChoiceOption> options;
+  final void Function(String value) onChanged;
+
+  const ConfigChoiceField({
+    required String label,
+    required this.value,
+    required this.options,
+    required this.onChanged,
+  }) : super(label);
+}
+
+class ConfigToggleField extends ConfigField {
+  final bool value;
+  final void Function(bool value) onChanged;
+
+  const ConfigToggleField({
+    required String label,
+    required this.value,
+    required this.onChanged,
+  }) : super(label);
+}
+
+/// A palette swatch picker. When [maxSelected] is 1 this behaves as a
+/// single-select (e.g. floating-shape color); larger values allow selecting
+/// several colors in order (e.g. wave layer colors).
+class ConfigColorField extends ConfigField {
+  final List<Color> palette;
+  final List<Color> selected;
+  final int maxSelected;
+  final void Function(List<Color> selected) onChanged;
+
+  const ConfigColorField({
+    required String label,
+    required this.palette,
+    required this.selected,
+    required this.onChanged,
+    this.maxSelected = 1,
+  }) : super(label);
+}

--- a/lib/app/components/wallpaper/dynamic_wallpaper_definition.dart
+++ b/lib/app/components/wallpaper/dynamic_wallpaper_definition.dart
@@ -1,0 +1,61 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/components/wallpaper/floating_wallpaper.dart';
+import 'package:bluebubbles/app/components/wallpaper/wave_wallpaper.dart';
+import 'package:flutter/material.dart';
+
+/// One entry in the dynamic wallpaper catalog. Implementations own their own
+/// config schema (as a plain JSON-able `Map<String, dynamic>`) and know how
+/// to render both the live wallpaper and their own config screen controls.
+///
+/// To add a new dynamic wallpaper: implement this class and add an instance
+/// to [DynamicWallpaperRegistry._definitions] — the picker gallery, live
+/// previews, config screen, and persistence all pick it up automatically.
+abstract class DynamicWallpaperDefinition {
+  /// Stable identifier persisted as `Chat.dynamicWallpaperId`. Never rename
+  /// once shipped — existing chats reference it directly.
+  final String id;
+  final String displayName;
+  final IconData icon;
+
+  const DynamicWallpaperDefinition({
+    required this.id,
+    required this.displayName,
+    required this.icon,
+  });
+
+  /// A sensible starting config, seeded from the chat's active theme (so the
+  /// first preview a user sees already matches their bubble color).
+  Map<String, dynamic> defaultConfig(BuildContext context, {required bool isIMessage});
+
+  /// Renders the wallpaper itself. Used both as the actual chat background
+  /// and (at a smaller scale, `IgnorePointer`-wrapped by the caller) as the
+  /// live preview on the gallery tile and config screen.
+  Widget buildView(BuildContext context, Map<String, dynamic> config);
+
+  /// The editable controls for [config], described generically so a single
+  /// skin-aware config screen shell can render any dynamic wallpaper type.
+  /// Each field's `onChanged` callback should call [onConfigChanged] with a
+  /// new map (`{...config, 'key': value}`) rather than mutating in place.
+  List<ConfigField> buildConfigFields(
+    BuildContext context,
+    Map<String, dynamic> config,
+    void Function(Map<String, dynamic> next) onConfigChanged,
+  );
+}
+
+abstract final class DynamicWallpaperRegistry {
+  static final List<DynamicWallpaperDefinition> _definitions = [
+    WaveWallpaperDefinition(),
+    FloatingWallpaperDefinition(),
+  ];
+
+  static List<DynamicWallpaperDefinition> get all => List.unmodifiable(_definitions);
+
+  static DynamicWallpaperDefinition? byId(String? id) {
+    if (id == null) return null;
+    for (final definition in _definitions) {
+      if (definition.id == id) return definition;
+    }
+    return null;
+  }
+}

--- a/lib/app/components/wallpaper/dynamic_wallpaper_definition.dart
+++ b/lib/app/components/wallpaper/dynamic_wallpaper_definition.dart
@@ -1,5 +1,7 @@
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
 import 'package:bluebubbles/app/components/wallpaper/floating_wallpaper.dart';
+import 'package:bluebubbles/app/components/wallpaper/moving_background_wallpaper.dart';
+import 'package:bluebubbles/app/components/wallpaper/particles_wallpaper.dart';
 import 'package:bluebubbles/app/components/wallpaper/wave_wallpaper.dart';
 import 'package:flutter/material.dart';
 
@@ -47,6 +49,8 @@ abstract final class DynamicWallpaperRegistry {
   static final List<DynamicWallpaperDefinition> _definitions = [
     WaveWallpaperDefinition(),
     FloatingWallpaperDefinition(),
+    MovingBackgroundWallpaperDefinition(),
+    ParticlesWallpaperDefinition(),
   ];
 
   static List<DynamicWallpaperDefinition> get all => List.unmodifiable(_definitions);

--- a/lib/app/components/wallpaper/dynamic_wallpaper_view.dart
+++ b/lib/app/components/wallpaper/dynamic_wallpaper_view.dart
@@ -1,0 +1,22 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
+import 'package:flutter/material.dart';
+
+/// Resolves a `dynamicWallpaperId` + config map to the actual animated
+/// wallpaper widget via [DynamicWallpaperRegistry]. Used both as the live
+/// chat background (`GradientBackground`) and as the small-scale preview on
+/// the picker gallery tiles / config screen — callers control interactivity
+/// and clipping, this just renders.
+class DynamicWallpaperView extends StatelessWidget {
+  final String? wallpaperId;
+  final Map<String, dynamic>? config;
+
+  const DynamicWallpaperView({super.key, required this.wallpaperId, required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    final definition = DynamicWallpaperRegistry.byId(wallpaperId);
+    if (definition == null) return const SizedBox.shrink();
+    final resolvedConfig = config ?? definition.defaultConfig(context, isIMessage: true);
+    return IgnorePointer(child: definition.buildView(context, resolvedConfig));
+  }
+}

--- a/lib/app/components/wallpaper/floating_wallpaper.dart
+++ b/lib/app/components/wallpaper/floating_wallpaper.dart
@@ -1,0 +1,171 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
+import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:floating_animation/floating_animation.dart';
+import 'package:flutter/material.dart';
+
+/// Dynamic wallpaper backed by the `floating_animation` package — a stream
+/// of slowly floating shapes/icons in a color drawn from the chat's theme.
+class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
+  FloatingWallpaperDefinition() : super(id: 'floating', displayName: 'Floating Shapes', icon: Icons.bubble_chart_rounded);
+
+  static const _shapes = <ConfigChoiceOption>[
+    ConfigChoiceOption(value: 'circle', label: 'Circles', icon: Icons.circle),
+    ConfigChoiceOption(value: 'rectangle', label: 'Squares', icon: Icons.square_rounded),
+    ConfigChoiceOption(value: 'triangle', label: 'Triangles', icon: Icons.change_history_rounded),
+    ConfigChoiceOption(value: 'heart', label: 'Hearts', icon: Icons.favorite_rounded),
+  ];
+
+  // FloatingDirection only supports up/down.
+  static const _directions = <ConfigChoiceOption>[
+    ConfigChoiceOption(value: 'up', label: 'Up', icon: Icons.arrow_upward_rounded),
+    ConfigChoiceOption(value: 'down', label: 'Down', icon: Icons.arrow_downward_rounded),
+  ];
+
+  static String _shape(Map<String, dynamic> c) => (c['shape'] as String?) ?? 'circle';
+  static int _maxShapes(Map<String, dynamic> c) => (c['maxShapes'] as num?)?.toInt() ?? 60;
+  static double _speed(Map<String, dynamic> c) => (c['speedMultiplier'] as num?)?.toDouble() ?? 1.0;
+  static double _size(Map<String, dynamic> c) => (c['sizeMultiplier'] as num?)?.toDouble() ?? 1.0;
+  static double _spawnRate(Map<String, dynamic> c) => (c['spawnRate'] as num?)?.toDouble() ?? 10.0;
+  static bool _rotation(Map<String, dynamic> c) => (c['enableRotation'] as bool?) ?? false;
+  static bool _pulse(Map<String, dynamic> c) => (c['enablePulse'] as bool?) ?? false;
+
+  static FloatingDirection _direction(Map<String, dynamic> c) {
+    final raw = (c['direction'] as String?) ?? 'up';
+    return FloatingDirection.values.firstWhere((e) => e.name == raw, orElse: () => FloatingDirection.up);
+  }
+
+  static Color _color(Map<String, dynamic> c, List<Color> fallbackPalette) {
+    final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
+    if (raw != null && raw.isNotEmpty) return raw.first;
+    return fallbackPalette.isNotEmpty ? fallbackPalette.first : Colors.blue;
+  }
+
+  @override
+  Map<String, dynamic> defaultConfig(BuildContext context, {required bool isIMessage}) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: isIMessage);
+    return {
+      'shape': 'circle',
+      'maxShapes': 60.0,
+      'speedMultiplier': 1.0,
+      'sizeMultiplier': 1.0,
+      'direction': 'up',
+      'spawnRate': 10.0,
+      'enableRotation': false,
+      'enablePulse': true,
+      'colors': [palette.isNotEmpty ? palette.first.toARGB32() : Colors.blue.toARGB32()],
+    };
+  }
+
+  @override
+  Widget buildView(BuildContext context, Map<String, dynamic> config) {
+    return _FloatingWallpaperView(config: config);
+  }
+
+  @override
+  List<ConfigField> buildConfigFields(
+    BuildContext context,
+    Map<String, dynamic> config,
+    void Function(Map<String, dynamic> next) onConfigChanged,
+  ) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final selectedColor = _color(config, palette);
+
+    return [
+      ConfigChoiceField(
+        label: "Shape",
+        value: _shape(config),
+        options: _shapes,
+        onChanged: (v) => onConfigChanged({...config, 'shape': v}),
+      ),
+      ConfigChoiceField(
+        label: "Direction",
+        value: (config['direction'] as String?) ?? 'up',
+        options: _directions,
+        onChanged: (v) => onConfigChanged({...config, 'direction': v}),
+      ),
+      ConfigSliderField(
+        label: "Count",
+        value: _maxShapes(config).toDouble(),
+        min: 5,
+        max: 150,
+        divisions: 29,
+        format: (v) => v.toStringAsFixed(0),
+        onChanged: (v) => onConfigChanged({...config, 'maxShapes': v}),
+      ),
+      ConfigSliderField(
+        label: "Spawn rate",
+        value: _spawnRate(config),
+        min: 1,
+        max: 30,
+        divisions: 29,
+        format: (v) => v.toStringAsFixed(0),
+        onChanged: (v) => onConfigChanged({...config, 'spawnRate': v}),
+      ),
+      ConfigSliderField(
+        label: "Speed",
+        value: _speed(config),
+        min: 0.2,
+        max: 3.0,
+        divisions: 28,
+        format: (v) => "${v.toStringAsFixed(1)}x",
+        onChanged: (v) => onConfigChanged({...config, 'speedMultiplier': v}),
+      ),
+      ConfigSliderField(
+        label: "Size",
+        value: _size(config),
+        min: 0.4,
+        max: 3.0,
+        divisions: 26,
+        format: (v) => "${v.toStringAsFixed(1)}x",
+        onChanged: (v) => onConfigChanged({...config, 'sizeMultiplier': v}),
+      ),
+      ConfigToggleField(
+        label: "Rotate while floating",
+        value: _rotation(config),
+        onChanged: (v) => onConfigChanged({...config, 'enableRotation': v}),
+      ),
+      ConfigToggleField(
+        label: "Pulse opacity",
+        value: _pulse(config),
+        onChanged: (v) => onConfigChanged({...config, 'enablePulse': v}),
+      ),
+      ConfigColorField(
+        label: "Color",
+        palette: palette,
+        selected: [selectedColor],
+        maxSelected: 1,
+        onChanged: (colors) => onConfigChanged({...config, 'colors': colors.map((c) => c.toARGB32()).toList()}),
+      ),
+    ];
+  }
+}
+
+class _FloatingWallpaperView extends StatelessWidget {
+  final Map<String, dynamic> config;
+
+  const _FloatingWallpaperView({required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final shape = FloatingWallpaperDefinition._shape(config);
+    final color = FloatingWallpaperDefinition._color(config, palette);
+
+    return ColoredBox(
+      color: context.theme.colorScheme.surface,
+      child: FloatingAnimation(
+        maxShapes: FloatingWallpaperDefinition._maxShapes(config),
+        speedMultiplier: FloatingWallpaperDefinition._speed(config),
+        sizeMultiplier: FloatingWallpaperDefinition._size(config),
+        selectedShape: shape,
+        shapeColors: {shape: color},
+        direction: FloatingWallpaperDefinition._direction(config),
+        spawnRate: FloatingWallpaperDefinition._spawnRate(config),
+        enableRotation: FloatingWallpaperDefinition._rotation(config),
+        enablePulse: FloatingWallpaperDefinition._pulse(config),
+      ),
+    );
+  }
+}

--- a/lib/app/components/wallpaper/floating_wallpaper.dart
+++ b/lib/app/components/wallpaper/floating_wallpaper.dart
@@ -25,7 +25,7 @@ class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
 
   static String _shape(Map<String, dynamic> c) => (c['shape'] as String?) ?? 'circle';
   static int _maxShapes(Map<String, dynamic> c) => (c['maxShapes'] as num?)?.toInt() ?? 60;
-  static double _speed(Map<String, dynamic> c) => (c['speedMultiplier'] as num?)?.toDouble() ?? 1.0;
+  static double _speed(Map<String, dynamic> c) => (c['speedMultiplier'] as num?)?.toDouble() ?? 0.5;
   static double _size(Map<String, dynamic> c) => (c['sizeMultiplier'] as num?)?.toDouble() ?? 1.0;
   static double _spawnRate(Map<String, dynamic> c) => (c['spawnRate'] as num?)?.toDouble() ?? 10.0;
   static bool _rotation(Map<String, dynamic> c) => (c['enableRotation'] as bool?) ?? false;
@@ -48,7 +48,9 @@ class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
     return {
       'shape': 'circle',
       'maxShapes': 60.0,
-      'speedMultiplier': 1.0,
+      // Fairly slow by default -- a wallpaper should read as calm background
+      // motion, not something competing for attention with the conversation.
+      'speedMultiplier': 0.5,
       'sizeMultiplier': 1.0,
       'direction': 'up',
       'spawnRate': 10.0,

--- a/lib/app/components/wallpaper/floating_wallpaper.dart
+++ b/lib/app/components/wallpaper/floating_wallpaper.dart
@@ -1,9 +1,9 @@
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
 import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:floating_animation/floating_animation.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 /// Dynamic wallpaper backed by the `floating_animation` package — a stream
 /// of slowly floating shapes/icons in a color drawn from the chat's theme.
@@ -24,10 +24,10 @@ class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
   ];
 
   static String _shape(Map<String, dynamic> c) => (c['shape'] as String?) ?? 'circle';
-  static int _maxShapes(Map<String, dynamic> c) => (c['maxShapes'] as num?)?.toInt() ?? 60;
+  static int _maxShapes(Map<String, dynamic> c) => (c['maxShapes'] as num?)?.toInt() ?? 25;
   static double _speed(Map<String, dynamic> c) => (c['speedMultiplier'] as num?)?.toDouble() ?? 0.5;
   static double _size(Map<String, dynamic> c) => (c['sizeMultiplier'] as num?)?.toDouble() ?? 1.0;
-  static double _spawnRate(Map<String, dynamic> c) => (c['spawnRate'] as num?)?.toDouble() ?? 10.0;
+  static double _spawnRate(Map<String, dynamic> c) => (c['spawnRate'] as num?)?.toDouble() ?? 5.0;
   static bool _rotation(Map<String, dynamic> c) => (c['enableRotation'] as bool?) ?? false;
   static bool _pulse(Map<String, dynamic> c) => (c['enablePulse'] as bool?) ?? false;
 
@@ -47,13 +47,13 @@ class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
     final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: isIMessage);
     return {
       'shape': 'circle',
-      'maxShapes': 60.0,
+      'maxShapes': 25.0,
       // Fairly slow by default -- a wallpaper should read as calm background
       // motion, not something competing for attention with the conversation.
       'speedMultiplier': 0.5,
       'sizeMultiplier': 1.0,
       'direction': 'up',
-      'spawnRate': 10.0,
+      'spawnRate': 5.0,
       'enableRotation': false,
       'enablePulse': true,
       'colors': [palette.isNotEmpty ? palette.first.toARGB32() : Colors.blue.toARGB32()],
@@ -91,8 +91,8 @@ class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
         label: "Count",
         value: _maxShapes(config).toDouble(),
         min: 5,
-        max: 150,
-        divisions: 29,
+        max: 50,
+        divisions: 45,
         format: (v) => v.toStringAsFixed(0),
         onChanged: (v) => onConfigChanged({...config, 'maxShapes': v}),
       ),
@@ -100,17 +100,17 @@ class FloatingWallpaperDefinition extends DynamicWallpaperDefinition {
         label: "Spawn rate",
         value: _spawnRate(config),
         min: 1,
-        max: 30,
-        divisions: 29,
+        max: 20,
+        divisions: 19,
         format: (v) => v.toStringAsFixed(0),
         onChanged: (v) => onConfigChanged({...config, 'spawnRate': v}),
       ),
       ConfigSliderField(
         label: "Speed",
         value: _speed(config),
-        min: 0.2,
-        max: 3.0,
-        divisions: 28,
+        min: 0.1,
+        max: 1.0,
+        divisions: 9,
         format: (v) => "${v.toStringAsFixed(1)}x",
         onChanged: (v) => onConfigChanged({...config, 'speedMultiplier': v}),
       ),
@@ -154,19 +154,29 @@ class _FloatingWallpaperView extends StatelessWidget {
     final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
     final shape = FloatingWallpaperDefinition._shape(config);
     final color = FloatingWallpaperDefinition._color(config, palette);
+    final speed = FloatingWallpaperDefinition._speed(config);
+    final size = FloatingWallpaperDefinition._size(config);
+    final rotation = FloatingWallpaperDefinition._rotation(config);
+    final pulse = FloatingWallpaperDefinition._pulse(config);
 
     return ColoredBox(
       color: context.theme.colorScheme.surface,
       child: FloatingAnimation(
+        // `FloatingAnimation` only reads speed/size/rotation/pulse once, in
+        // its own `initState()` -- it never re-reads them on rebuild, so
+        // those sliders would otherwise silently do nothing after the first
+        // frame. Keying on them forces a fresh instance (and a fresh
+        // `initState()`) whenever one changes.
+        key: ValueKey('$speed-$size-$rotation-$pulse'),
         maxShapes: FloatingWallpaperDefinition._maxShapes(config),
-        speedMultiplier: FloatingWallpaperDefinition._speed(config),
-        sizeMultiplier: FloatingWallpaperDefinition._size(config),
+        speedMultiplier: speed,
+        sizeMultiplier: size,
         selectedShape: shape,
         shapeColors: {shape: color},
         direction: FloatingWallpaperDefinition._direction(config),
         spawnRate: FloatingWallpaperDefinition._spawnRate(config),
-        enableRotation: FloatingWallpaperDefinition._rotation(config),
-        enablePulse: FloatingWallpaperDefinition._pulse(config),
+        enableRotation: rotation,
+        enablePulse: pulse,
       ),
     );
   }

--- a/lib/app/components/wallpaper/moving_background_wallpaper.dart
+++ b/lib/app/components/wallpaper/moving_background_wallpaper.dart
@@ -1,0 +1,141 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
+import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_moving_background/flutter_moving_background.dart';
+
+/// Dynamic wallpaper backed by the `flutter_moving_background` package —
+/// soft, blurred, slowly drifting circles in colors drawn from the chat's
+/// theme palette.
+class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
+  MovingBackgroundWallpaperDefinition()
+      : super(id: 'moving_background', displayName: 'Moving Background', icon: Icons.gradient_rounded);
+
+  static const _animationTypes = <ConfigChoiceOption>[
+    ConfigChoiceOption(value: 'moveAndFade', label: 'Move & fade', icon: Icons.blur_on_rounded),
+    ConfigChoiceOption(value: 'move', label: 'Move', icon: Icons.open_with_rounded),
+    ConfigChoiceOption(value: 'pulse', label: 'Pulse', icon: Icons.radio_button_checked_rounded),
+    ConfigChoiceOption(value: 'scale', label: 'Scale', icon: Icons.zoom_out_map_rounded),
+  ];
+
+  static AnimationType _animationType(Map<String, dynamic> c) {
+    final raw = (c['animationType'] as String?) ?? 'moveAndFade';
+    return AnimationType.values.firstWhere((e) => e.name == raw, orElse: () => AnimationType.moveAndFade);
+  }
+
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 1.0;
+  static int _circleCount(Map<String, dynamic> c) => ((c['circleCount'] as num?)?.toInt() ?? 4).clamp(2, 6).toInt();
+  static double _circleSize(Map<String, dynamic> c) => (c['circleSize'] as num?)?.toDouble() ?? 1.0;
+
+  static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
+    final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
+    if (raw != null && raw.isNotEmpty) return raw;
+    return fallbackPalette.isNotEmpty ? fallbackPalette : const [Colors.blue, Colors.purple];
+  }
+
+  @override
+  Map<String, dynamic> defaultConfig(BuildContext context, {required bool isIMessage}) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: isIMessage);
+    final colors = palette.take(3).toList();
+    return {
+      'animationType': 'moveAndFade',
+      'speed': 1.0,
+      'circleCount': colors.isEmpty ? 3.0 : colors.length.clamp(2, 6).toDouble(),
+      'circleSize': 1.0,
+      'colors': (colors.isEmpty ? [Colors.blue, Colors.purple] : colors).map((c) => c.toARGB32()).toList(),
+    };
+  }
+
+  @override
+  Widget buildView(BuildContext context, Map<String, dynamic> config) {
+    return _MovingBackgroundWallpaperView(config: config);
+  }
+
+  @override
+  List<ConfigField> buildConfigFields(
+    BuildContext context,
+    Map<String, dynamic> config,
+    void Function(Map<String, dynamic> next) onConfigChanged,
+  ) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final circleCount = _circleCount(config);
+    final selected = _colors(config, palette).take(6).toList();
+
+    return [
+      ConfigChoiceField(
+        label: "Animation",
+        value: _animationType(config).name,
+        options: _animationTypes,
+        onChanged: (v) => onConfigChanged({...config, 'animationType': v}),
+      ),
+      ConfigSliderField(
+        label: "Speed",
+        value: _speed(config),
+        min: 0.3,
+        max: 3.0,
+        divisions: 27,
+        format: (v) => "${v.toStringAsFixed(1)}x",
+        onChanged: (v) => onConfigChanged({...config, 'speed': v}),
+      ),
+      ConfigSliderField(
+        label: "Circle count",
+        value: circleCount.toDouble(),
+        min: 2,
+        max: 6,
+        divisions: 4,
+        format: (v) => v.toStringAsFixed(0),
+        onChanged: (v) => onConfigChanged({...config, 'circleCount': v}),
+      ),
+      ConfigSliderField(
+        label: "Circle size",
+        value: _circleSize(config),
+        min: 0.5,
+        max: 2.0,
+        divisions: 15,
+        format: (v) => "${v.toStringAsFixed(1)}x",
+        onChanged: (v) => onConfigChanged({...config, 'circleSize': v}),
+      ),
+      ConfigColorField(
+        label: "Colors",
+        palette: palette,
+        selected: selected,
+        maxSelected: 6,
+        onChanged: (colors) => onConfigChanged({...config, 'colors': colors.map((c) => c.toARGB32()).toList()}),
+      ),
+    ];
+  }
+}
+
+class _MovingBackgroundWallpaperView extends StatelessWidget {
+  final Map<String, dynamic> config;
+
+  const _MovingBackgroundWallpaperView({required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final colors = MovingBackgroundWallpaperDefinition._colors(config, palette);
+    final circleCount = MovingBackgroundWallpaperDefinition._circleCount(config);
+    final sizeMultiplier = MovingBackgroundWallpaperDefinition._circleSize(config);
+    final speed = MovingBackgroundWallpaperDefinition._speed(config);
+    final durationMs = (14000 / speed).round();
+
+    return ColoredBox(
+      color: context.theme.colorScheme.surface,
+      child: MovingBackground(
+        backgroundColor: Colors.transparent,
+        animationType: MovingBackgroundWallpaperDefinition._animationType(config),
+        duration: Duration(milliseconds: durationMs),
+        circles: List.generate(
+          circleCount,
+          (i) => MovingCircle(
+            color: colors[i % colors.length].withValues(alpha: 0.55),
+            radius: (110 + i * 35) * sizeMultiplier,
+            blurSigma: 30,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/components/wallpaper/moving_background_wallpaper.dart
+++ b/lib/app/components/wallpaper/moving_background_wallpaper.dart
@@ -24,7 +24,7 @@ class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
     return AnimationType.values.firstWhere((e) => e.name == raw, orElse: () => AnimationType.moveAndFade);
   }
 
-  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 1.0;
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.5;
   static int _circleCount(Map<String, dynamic> c) => ((c['circleCount'] as num?)?.toInt() ?? 4).clamp(2, 6).toInt();
   static double _circleSize(Map<String, dynamic> c) => (c['circleSize'] as num?)?.toDouble() ?? 1.0;
 
@@ -40,7 +40,9 @@ class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
     final colors = palette.take(3).toList();
     return {
       'animationType': 'moveAndFade',
-      'speed': 1.0,
+      // Fairly slow by default -- a wallpaper should read as calm background
+      // motion, not something competing for attention with the conversation.
+      'speed': 0.5,
       'circleCount': colors.isEmpty ? 3.0 : colors.length.clamp(2, 6).toDouble(),
       'circleSize': 1.0,
       'colors': (colors.isEmpty ? [Colors.blue, Colors.purple] : colors).map((c) => c.toARGB32()).toList(),

--- a/lib/app/components/wallpaper/moving_background_wallpaper.dart
+++ b/lib/app/components/wallpaper/moving_background_wallpaper.dart
@@ -1,16 +1,16 @@
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
 import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_moving_background/flutter_moving_background.dart';
+import 'package:get/get.dart';
 
 /// Dynamic wallpaper backed by the `flutter_moving_background` package —
 /// soft, blurred, slowly drifting circles in colors drawn from the chat's
 /// theme palette.
 class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
   MovingBackgroundWallpaperDefinition()
-      : super(id: 'moving_background', displayName: 'Moving Background', icon: Icons.gradient_rounded);
+      : super(id: 'moving_background', displayName: 'Drifting Circles', icon: Icons.gradient_rounded);
 
   static const _animationTypes = <ConfigChoiceOption>[
     ConfigChoiceOption(value: 'moveAndFade', label: 'Move & fade', icon: Icons.blur_on_rounded),
@@ -27,6 +27,7 @@ class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
   static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.5;
   static int _circleCount(Map<String, dynamic> c) => ((c['circleCount'] as num?)?.toInt() ?? 4).clamp(2, 6).toInt();
   static double _circleSize(Map<String, dynamic> c) => (c['circleSize'] as num?)?.toDouble() ?? 1.0;
+  static double _blur(Map<String, dynamic> c) => (c['blur'] as num?)?.toDouble() ?? 2.0;
 
   static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
     final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
@@ -45,6 +46,9 @@ class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
       'speed': 0.5,
       'circleCount': colors.isEmpty ? 3.0 : colors.length.clamp(2, 6).toDouble(),
       'circleSize': 1.0,
+      // Almost no blur by default -- the circles read as soft shapes with a
+      // gentle edge rather than a hazy, indistinct glow.
+      'blur': 2.0,
       'colors': (colors.isEmpty ? [Colors.blue, Colors.purple] : colors).map((c) => c.toARGB32()).toList(),
     };
   }
@@ -98,6 +102,15 @@ class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
         format: (v) => "${v.toStringAsFixed(1)}x",
         onChanged: (v) => onConfigChanged({...config, 'circleSize': v}),
       ),
+      ConfigSliderField(
+        label: "Blur",
+        value: _blur(config),
+        min: 0,
+        max: 20,
+        divisions: 40,
+        format: (v) => v.toStringAsFixed(1),
+        onChanged: (v) => onConfigChanged({...config, 'blur': v}),
+      ),
       ConfigColorField(
         label: "Colors",
         palette: palette,
@@ -121,6 +134,7 @@ class _MovingBackgroundWallpaperView extends StatelessWidget {
     final circleCount = MovingBackgroundWallpaperDefinition._circleCount(config);
     final sizeMultiplier = MovingBackgroundWallpaperDefinition._circleSize(config);
     final speed = MovingBackgroundWallpaperDefinition._speed(config);
+    final blur = MovingBackgroundWallpaperDefinition._blur(config);
     final durationMs = (14000 / speed).round();
 
     return ColoredBox(
@@ -134,7 +148,7 @@ class _MovingBackgroundWallpaperView extends StatelessWidget {
           (i) => MovingCircle(
             color: colors[i % colors.length].withValues(alpha: 0.55),
             radius: (110 + i * 35) * sizeMultiplier,
-            blurSigma: 30,
+            blurSigma: blur,
           ),
         ),
       ),

--- a/lib/app/components/wallpaper/moving_background_wallpaper.dart
+++ b/lib/app/components/wallpaper/moving_background_wallpaper.dart
@@ -122,35 +122,58 @@ class MovingBackgroundWallpaperDefinition extends DynamicWallpaperDefinition {
   }
 }
 
-class _MovingBackgroundWallpaperView extends StatelessWidget {
+class _MovingBackgroundWallpaperView extends StatefulWidget {
   final Map<String, dynamic> config;
 
   const _MovingBackgroundWallpaperView({required this.config});
 
   @override
+  State<_MovingBackgroundWallpaperView> createState() => _MovingBackgroundWallpaperViewState();
+}
+
+class _MovingBackgroundWallpaperViewState extends State<_MovingBackgroundWallpaperView> {
+  // `MovingBackground` resets every circle's position (`didUpdateWidget`
+  // compares `circles` by identity) whenever it's handed a new `circles`
+  // list -- rebuilding one fresh with `List.generate` on every build (e.g.
+  // an unrelated ancestor rebuild) reset the animation on every rebuild,
+  // not just an actual config change. Cache it and only build a new one when
+  // the values that actually shape it change.
+  String? _circlesKey;
+  List<MovingCircle>? _circles;
+
+  List<MovingCircle> _circlesFor(List<Color> colors, int circleCount, double sizeMultiplier, double blur) {
+    final key = '$circleCount-$sizeMultiplier-$blur-${colors.map((c) => c.toARGB32()).join(',')}';
+    if (_circlesKey != key) {
+      _circlesKey = key;
+      _circles = List.generate(
+        circleCount,
+        (i) => MovingCircle(
+          color: colors[i % colors.length].withValues(alpha: 0.55),
+          radius: (110 + i * 35) * sizeMultiplier,
+          blurSigma: blur,
+        ),
+      );
+    }
+    return _circles!;
+  }
+
+  @override
   Widget build(BuildContext context) {
     final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
-    final colors = MovingBackgroundWallpaperDefinition._colors(config, palette);
-    final circleCount = MovingBackgroundWallpaperDefinition._circleCount(config);
-    final sizeMultiplier = MovingBackgroundWallpaperDefinition._circleSize(config);
-    final speed = MovingBackgroundWallpaperDefinition._speed(config);
-    final blur = MovingBackgroundWallpaperDefinition._blur(config);
+    final colors = MovingBackgroundWallpaperDefinition._colors(widget.config, palette);
+    final circleCount = MovingBackgroundWallpaperDefinition._circleCount(widget.config);
+    final sizeMultiplier = MovingBackgroundWallpaperDefinition._circleSize(widget.config);
+    final speed = MovingBackgroundWallpaperDefinition._speed(widget.config);
+    final blur = MovingBackgroundWallpaperDefinition._blur(widget.config);
     final durationMs = (14000 / speed).round();
 
     return ColoredBox(
       color: context.theme.colorScheme.surface,
       child: MovingBackground(
         backgroundColor: Colors.transparent,
-        animationType: MovingBackgroundWallpaperDefinition._animationType(config),
+        animationType: MovingBackgroundWallpaperDefinition._animationType(widget.config),
         duration: Duration(milliseconds: durationMs),
-        circles: List.generate(
-          circleCount,
-          (i) => MovingCircle(
-            color: colors[i % colors.length].withValues(alpha: 0.55),
-            radius: (110 + i * 35) * sizeMultiplier,
-            blurSigma: blur,
-          ),
-        ),
+        circles: _circlesFor(colors, circleCount, sizeMultiplier, blur),
       ),
     );
   }

--- a/lib/app/components/wallpaper/particles_wallpaper.dart
+++ b/lib/app/components/wallpaper/particles_wallpaper.dart
@@ -1,0 +1,256 @@
+import 'dart:math';
+
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
+import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:particles_flutter/engine.dart';
+import 'package:particles_flutter/interactions.dart';
+import 'package:particles_flutter/physics.dart';
+
+/// Dynamic wallpaper backed by the `particles_flutter` package. Only exposes
+/// a curated set of presets built from the package's documented example
+/// scenes — not the full particle-physics API — so the config screen stays
+/// a handful of understandable knobs instead of the package's raw surface.
+class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
+  ParticlesWallpaperDefinition() : super(id: 'particles', displayName: 'Particles', icon: Icons.grain_rounded);
+
+  static const _presets = <ConfigChoiceOption>[
+    ConfigChoiceOption(value: 'starfield', label: 'Starfield', icon: Icons.auto_awesome_rounded),
+    ConfigChoiceOption(value: 'web', label: 'Web', icon: Icons.hub_outlined),
+    ConfigChoiceOption(value: 'nebula', label: 'Nebula', icon: Icons.blur_on_rounded),
+    ConfigChoiceOption(value: 'ghosts', label: 'Ghosts', icon: Icons.blur_circular_rounded),
+    ConfigChoiceOption(value: 'pulse', label: 'Pulse', icon: Icons.radio_button_checked_rounded),
+    ConfigChoiceOption(value: 'snow', label: 'Snow', icon: Icons.ac_unit_rounded),
+  ];
+
+  /// Sensible density/speed starting points per preset — applied whenever
+  /// the preset selector changes so switching effects looks right away
+  /// rather than inheriting an unrelated preset's tuning.
+  static const _presetDefaults = <String, Map<String, double>>{
+    'starfield': {'count': 120, 'speed': 1.0},
+    'web': {'count': 70, 'speed': 1.0},
+    'nebula': {'count': 10, 'speed': 1.0},
+    'ghosts': {'count': 45, 'speed': 1.0},
+    'pulse': {'count': 55, 'speed': 1.0},
+    'snow': {'count': 100, 'speed': 1.0},
+  };
+
+  static String _preset(Map<String, dynamic> c) => (c['preset'] as String?) ?? 'starfield';
+  static int _count(Map<String, dynamic> c) => ((c['count'] as num?)?.toInt() ?? 100).clamp(10, 200).toInt();
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 1.0;
+
+  static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
+    final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
+    if (raw != null && raw.isNotEmpty) return raw;
+    return fallbackPalette.isNotEmpty ? fallbackPalette : const [Colors.white];
+  }
+
+  @override
+  Map<String, dynamic> defaultConfig(BuildContext context, {required bool isIMessage}) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: isIMessage);
+    final colors = palette.take(2).toList();
+    return {
+      'preset': 'starfield',
+      'count': 120.0,
+      'speed': 1.0,
+      'colors': (colors.isEmpty ? [Colors.white] : colors).map((c) => c.toARGB32()).toList(),
+    };
+  }
+
+  @override
+  Widget buildView(BuildContext context, Map<String, dynamic> config) {
+    return _ParticlesWallpaperView(config: config);
+  }
+
+  @override
+  List<ConfigField> buildConfigFields(
+    BuildContext context,
+    Map<String, dynamic> config,
+    void Function(Map<String, dynamic> next) onConfigChanged,
+  ) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final selected = _colors(config, palette).take(3).toList();
+
+    return [
+      ConfigChoiceField(
+        label: "Effect",
+        value: _preset(config),
+        options: _presets,
+        onChanged: (preset) {
+          final tuning = _presetDefaults[preset];
+          onConfigChanged({...config, 'preset': preset, if (tuning != null) ...tuning});
+        },
+      ),
+      ConfigSliderField(
+        label: "Density",
+        value: _count(config).toDouble(),
+        min: 10,
+        max: 200,
+        divisions: 38,
+        format: (v) => v.toStringAsFixed(0),
+        onChanged: (v) => onConfigChanged({...config, 'count': v}),
+      ),
+      ConfigSliderField(
+        label: "Speed",
+        value: _speed(config),
+        min: 0.2,
+        max: 3.0,
+        divisions: 28,
+        format: (v) => "${v.toStringAsFixed(1)}x",
+        onChanged: (v) => onConfigChanged({...config, 'speed': v}),
+      ),
+      ConfigColorField(
+        label: "Colors",
+        palette: palette,
+        selected: selected,
+        maxSelected: 3,
+        onChanged: (colors) => onConfigChanged({...config, 'colors': colors.map((c) => c.toARGB32()).toList()}),
+      ),
+    ];
+  }
+
+  /// Builds the actual `Particles` widget for [preset]. Ported directly from
+  /// the package's documented example scenes (starfield/snow/ghosts/pulse),
+  /// plus `connectDots` for a constellation-style "web" and a hand-tuned
+  /// soft-cloud "nebula" built from the same primitives (not an official
+  /// example — the package has no such preset).
+  static Widget _build(String preset, int count, double speed, List<Color> colors, Size size) {
+    final rng = Random();
+    Color colorAt(int i) => colors[i % colors.length];
+
+    switch (preset) {
+      case 'snow':
+        return Particles(
+          width: size.width,
+          height: size.height,
+          boundType: BoundType.WrapAround,
+          particlePhysics: ParticlePhysics(gravityScale: 20 * speed),
+          particles: List.generate(
+            count,
+            (i) => CircularParticle(
+              radius: rng.nextDouble() * 6 + 2,
+              color: colorAt(i).withValues(alpha: 0.8),
+              velocity: Offset((rng.nextDouble() - 0.5) * 20, rng.nextDouble() * 15 + 5),
+            ),
+          ),
+        );
+      case 'ghosts':
+        return Particles(
+          width: size.width,
+          height: size.height,
+          boundType: BoundType.WrapAround,
+          particles: List.generate(
+            count,
+            (i) => CircularParticle(
+              radius: rng.nextDouble() * 14 + 8,
+              color: colorAt(i),
+              velocity: Offset((rng.nextDouble() - 0.5) * 15 * speed, (rng.nextDouble() - 0.5) * 10 * speed),
+              lifetime: rng.nextDouble() * 3.0 + 2.0,
+              startOpacity: 0.0,
+              endOpacity: 0.0,
+              startScale: 0.6,
+              endScale: 1.2,
+              scaleCurve: Curves.easeOut,
+            ),
+          ),
+        );
+      case 'pulse':
+        return Particles(
+          width: size.width,
+          height: size.height,
+          boundType: BoundType.WrapAround,
+          particles: List.generate(
+            count,
+            (i) => CircularParticle(
+              radius: 10,
+              color: colorAt(i),
+              velocity: Offset((rng.nextDouble() - 0.5) * 20 * speed, (rng.nextDouble() - 0.5) * 20 * speed),
+              lifetime: 2.5,
+              startScale: 0.1,
+              endScale: 1.8,
+              scaleCurve: Curves.easeInOut,
+              startOpacity: 0.0,
+              endOpacity: 0.0,
+            ),
+          ),
+        );
+      case 'web':
+        return Particles(
+          width: size.width,
+          height: size.height,
+          boundType: BoundType.WrapAround,
+          connectDots: true,
+          particles: List.generate(
+            count,
+            (i) => CircularParticle(
+              radius: rng.nextDouble() * 2 + 1,
+              color: colorAt(i),
+              velocity: Offset((rng.nextDouble() - 0.5) * 30 * speed, (rng.nextDouble() - 0.5) * 30 * speed),
+            ),
+          ),
+        );
+      case 'nebula':
+        return Particles(
+          width: size.width,
+          height: size.height,
+          boundType: BoundType.WrapAround,
+          particles: List.generate(
+            count,
+            (i) => CircularParticle(
+              radius: rng.nextDouble() * 40 + 20,
+              color: colorAt(i).withValues(alpha: 0.12),
+              velocity: Offset((rng.nextDouble() - 0.5) * 6 * speed, (rng.nextDouble() - 0.5) * 6 * speed),
+            ),
+          ),
+        );
+      case 'starfield':
+      default:
+        return Particles(
+          width: size.width,
+          height: size.height,
+          boundType: BoundType.WrapAround,
+          interaction: ParticleInteraction(awayRadius: 120, enableHover: true),
+          particles: List.generate(
+            count,
+            (i) => CircularParticle(
+              radius: rng.nextDouble() * 3 + 0.5,
+              color: colorAt(i).withValues(alpha: 0.7),
+              velocity: Offset((rng.nextDouble() - 0.5) * 40 * speed, (rng.nextDouble() - 0.5) * 40 * speed),
+            ),
+          ),
+        );
+    }
+  }
+}
+
+class _ParticlesWallpaperView extends StatelessWidget {
+  final Map<String, dynamic> config;
+
+  const _ParticlesWallpaperView({required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final colors = ParticlesWallpaperDefinition._colors(config, palette);
+    final preset = ParticlesWallpaperDefinition._preset(config);
+    final count = ParticlesWallpaperDefinition._count(config);
+    final speed = ParticlesWallpaperDefinition._speed(config);
+
+    return ColoredBox(
+      color: context.theme.colorScheme.surface,
+      child: ClipRect(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final size = Size(
+              constraints.maxWidth.isFinite ? constraints.maxWidth : 300,
+              constraints.maxHeight.isFinite ? constraints.maxHeight : 300,
+            );
+            return ParticlesWallpaperDefinition._build(preset, count, speed, colors, size);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/components/wallpaper/particles_wallpaper.dart
+++ b/lib/app/components/wallpaper/particles_wallpaper.dart
@@ -27,19 +27,21 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
 
   /// Sensible density/speed starting points per preset — applied whenever
   /// the preset selector changes so switching effects looks right away
-  /// rather than inheriting an unrelated preset's tuning.
+  /// rather than inheriting an unrelated preset's tuning. Speed defaults to
+  /// a fairly slow 0.5x — a wallpaper should read as calm background motion,
+  /// not something competing for attention with the conversation.
   static const _presetDefaults = <String, Map<String, double>>{
-    'starfield': {'count': 120, 'speed': 1.0},
-    'web': {'count': 70, 'speed': 1.0},
-    'nebula': {'count': 10, 'speed': 1.0},
-    'ghosts': {'count': 45, 'speed': 1.0},
-    'pulse': {'count': 55, 'speed': 1.0},
-    'snow': {'count': 100, 'speed': 1.0},
+    'starfield': {'count': 120, 'speed': 0.5},
+    'web': {'count': 70, 'speed': 0.5},
+    'nebula': {'count': 10, 'speed': 0.5},
+    'ghosts': {'count': 45, 'speed': 0.5},
+    'pulse': {'count': 55, 'speed': 0.5},
+    'snow': {'count': 100, 'speed': 0.5},
   };
 
   static String _preset(Map<String, dynamic> c) => (c['preset'] as String?) ?? 'starfield';
   static int _count(Map<String, dynamic> c) => ((c['count'] as num?)?.toInt() ?? 100).clamp(10, 200).toInt();
-  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 1.0;
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.5;
 
   static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
     final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
@@ -54,7 +56,7 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
     return {
       'preset': 'starfield',
       'count': 120.0,
-      'speed': 1.0,
+      'speed': 0.5,
       'colors': (colors.isEmpty ? [Colors.white] : colors).map((c) => c.toARGB32()).toList(),
     };
   }
@@ -132,7 +134,7 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
             (i) => CircularParticle(
               radius: rng.nextDouble() * 6 + 2,
               color: colorAt(i).withValues(alpha: 0.8),
-              velocity: Offset((rng.nextDouble() - 0.5) * 20, rng.nextDouble() * 15 + 5),
+              velocity: Offset((rng.nextDouble() - 0.5) * 20 * speed, (rng.nextDouble() * 15 + 5) * speed),
             ),
           ),
         );
@@ -211,7 +213,9 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
           width: size.width,
           height: size.height,
           boundType: BoundType.WrapAround,
-          interaction: ParticleInteraction(awayRadius: 120, enableHover: true),
+          // A wallpaper sits behind the message list -- it must never react
+          // to the user's taps/drags meant for the conversation above it.
+          interaction: ParticleInteraction.none(),
           particles: List.generate(
             count,
             (i) => CircularParticle(

--- a/lib/app/components/wallpaper/particles_wallpaper.dart
+++ b/lib/app/components/wallpaper/particles_wallpaper.dart
@@ -3,11 +3,23 @@ import 'dart:math';
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
 import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:particles_flutter/engine.dart';
 import 'package:particles_flutter/interactions.dart';
 import 'package:particles_flutter/physics.dart';
+
+/// Per-preset density/speed defaults and slider ranges -- see
+/// [ParticlesWallpaperDefinition._presetTuning].
+typedef _PresetTuning = ({
+  double count,
+  double countMin,
+  double countMax,
+  int countDivisions,
+  double speed,
+  double speedMin,
+  double speedMax,
+});
 
 /// Dynamic wallpaper backed by the `particles_flutter` package. Only exposes
 /// a curated set of presets built from the package's documented example
@@ -25,23 +37,37 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
     ConfigChoiceOption(value: 'snow', label: 'Snow', icon: Icons.ac_unit_rounded),
   ];
 
-  /// Sensible density/speed starting points per preset — applied whenever
-  /// the preset selector changes so switching effects looks right away
-  /// rather than inheriting an unrelated preset's tuning. Speed defaults to
-  /// a fairly slow 0.5x — a wallpaper should read as calm background motion,
-  /// not something competing for attention with the conversation.
-  static const _presetDefaults = <String, Map<String, double>>{
-    'starfield': {'count': 120, 'speed': 0.5},
-    'web': {'count': 70, 'speed': 0.5},
-    'nebula': {'count': 10, 'speed': 0.5},
-    'ghosts': {'count': 45, 'speed': 0.5},
-    'pulse': {'count': 55, 'speed': 0.5},
-    'snow': {'count': 100, 'speed': 0.5},
+  /// Density/speed starting points *and* slider ranges, per preset --
+  /// applied whenever the preset selector changes so switching effects
+  /// looks right away rather than inheriting an unrelated preset's tuning,
+  /// and so e.g. "Web" (small, thin dots) can cap out at a much lower count
+  /// than "Snow" (wants density) without either one having to share a
+  /// single compromise range. Speed defaults to a fairly slow 0.5x -- a
+  /// wallpaper should read as calm background motion, not something
+  /// competing for attention with the conversation.
+  static const _presetTuning = <String, _PresetTuning>{
+    'starfield':
+        (count: 120, countMin: 10, countMax: 200, countDivisions: 38, speed: 0.5, speedMin: 0.2, speedMax: 2.0),
+    'web': (count: 25, countMin: 10, countMax: 50, countDivisions: 40, speed: 0.5, speedMin: 0.2, speedMax: 2.0),
+    'nebula': (count: 10, countMin: 5, countMax: 30, countDivisions: 25, speed: 0.5, speedMin: 0.2, speedMax: 2.0),
+    'ghosts': (count: 45, countMin: 10, countMax: 90, countDivisions: 40, speed: 0.5, speedMin: 0.2, speedMax: 2.0),
+    'pulse': (count: 55, countMin: 10, countMax: 110, countDivisions: 40, speed: 0.5, speedMin: 0.2, speedMax: 2.0),
+    'snow': (count: 100, countMin: 10, countMax: 200, countDivisions: 38, speed: 0.5, speedMin: 0.2, speedMax: 2.0),
   };
 
   static String _preset(Map<String, dynamic> c) => (c['preset'] as String?) ?? 'starfield';
-  static int _count(Map<String, dynamic> c) => ((c['count'] as num?)?.toInt() ?? 100).clamp(10, 200).toInt();
-  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.5;
+  static _PresetTuning _tuningFor(String preset) => _presetTuning[preset] ?? _presetTuning['starfield']!;
+
+  static int _count(Map<String, dynamic> c) {
+    final tuning = _tuningFor(_preset(c));
+    return ((c['count'] as num?)?.toInt() ?? tuning.count.toInt())
+        .clamp(tuning.countMin.toInt(), tuning.countMax.toInt());
+  }
+
+  static double _speed(Map<String, dynamic> c) {
+    final tuning = _tuningFor(_preset(c));
+    return ((c['speed'] as num?)?.toDouble() ?? tuning.speed).clamp(tuning.speedMin, tuning.speedMax);
+  }
 
   static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
     final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
@@ -53,10 +79,11 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
   Map<String, dynamic> defaultConfig(BuildContext context, {required bool isIMessage}) {
     final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: isIMessage);
     final colors = palette.take(2).toList();
+    final tuning = _tuningFor('starfield');
     return {
       'preset': 'starfield',
-      'count': 120.0,
-      'speed': 0.5,
+      'count': tuning.count,
+      'speed': tuning.speed,
       'colors': (colors.isEmpty ? [Colors.white] : colors).map((c) => c.toARGB32()).toList(),
     };
   }
@@ -74,6 +101,7 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
   ) {
     final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
     final selected = _colors(config, palette).take(3).toList();
+    final tuning = _tuningFor(_preset(config));
 
     return [
       ConfigChoiceField(
@@ -81,25 +109,25 @@ class ParticlesWallpaperDefinition extends DynamicWallpaperDefinition {
         value: _preset(config),
         options: _presets,
         onChanged: (preset) {
-          final tuning = _presetDefaults[preset];
-          onConfigChanged({...config, 'preset': preset, if (tuning != null) ...tuning});
+          final next = _tuningFor(preset);
+          onConfigChanged({...config, 'preset': preset, 'count': next.count, 'speed': next.speed});
         },
       ),
       ConfigSliderField(
         label: "Density",
         value: _count(config).toDouble(),
-        min: 10,
-        max: 200,
-        divisions: 38,
+        min: tuning.countMin,
+        max: tuning.countMax,
+        divisions: tuning.countDivisions,
         format: (v) => v.toStringAsFixed(0),
         onChanged: (v) => onConfigChanged({...config, 'count': v}),
       ),
       ConfigSliderField(
         label: "Speed",
         value: _speed(config),
-        min: 0.2,
-        max: 3.0,
-        divisions: 28,
+        min: tuning.speedMin,
+        max: tuning.speedMax,
+        divisions: 18,
         format: (v) => "${v.toStringAsFixed(1)}x",
         onChanged: (v) => onConfigChanged({...config, 'speed': v}),
       ),
@@ -251,7 +279,19 @@ class _ParticlesWallpaperView extends StatelessWidget {
               constraints.maxWidth.isFinite ? constraints.maxWidth : 300,
               constraints.maxHeight.isFinite ? constraints.maxHeight : 300,
             );
-            return ParticlesWallpaperDefinition._build(preset, count, speed, colors, size);
+            // `Particles` only reads its `particles` list once, in
+            // `initState()` -- it never regenerates them on rebuild, so
+            // switching presets (a completely different particle profile:
+            // radius, physics, boundary behavior) would otherwise keep
+            // animating the old preset's particles under the new preset's
+            // live-updating physics, producing visibly broken motion.
+            // Keying on every field that shapes the particle set forces a
+            // fresh instance whenever any of them change.
+            final colorKey = colors.map((c) => c.toARGB32()).join(',');
+            return KeyedSubtree(
+              key: ValueKey('$preset-$count-$speed-$colorKey'),
+              child: ParticlesWallpaperDefinition._build(preset, count, speed, colors, size),
+            );
           },
         ),
       ),

--- a/lib/app/components/wallpaper/theme_wallpaper_palette.dart
+++ b/lib/app/components/wallpaper/theme_wallpaper_palette.dart
@@ -1,0 +1,31 @@
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Derives a small set of candidate colors for dynamic wallpaper config
+/// screens from the chat's currently active theme, so a wave/floating
+/// wallpaper always looks like it belongs to the conversation it's set on
+/// rather than needing a totally separate color picker.
+abstract final class ThemeWallpaperPalette {
+  static List<Color> fromContext(BuildContext context, {required bool isIMessage}) {
+    final scheme = context.theme.colorScheme;
+    final colors = <Color>[
+      scheme.bubble(context, isIMessage),
+      scheme.primary,
+      scheme.secondary,
+      scheme.tertiary,
+      scheme.primaryContainer,
+      scheme.secondaryContainer,
+      scheme.tertiaryContainer,
+      scheme.onBubble(context, isIMessage),
+    ];
+
+    // De-dupe while preserving order (multiple roles frequently resolve to
+    // the same color on smaller custom themes).
+    final seen = <int>{};
+    final deduped = <Color>[];
+    for (final c in colors) {
+      if (seen.add(c.toARGB32())) deduped.add(c);
+    }
+    return deduped;
+  }
+}

--- a/lib/app/components/wallpaper/theme_wallpaper_palette.dart
+++ b/lib/app/components/wallpaper/theme_wallpaper_palette.dart
@@ -1,5 +1,6 @@
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 /// Derives a small set of candidate colors for dynamic wallpaper config
 /// screens from the chat's currently active theme, so a wave/floating

--- a/lib/app/components/wallpaper/wallpaper.dart
+++ b/lib/app/components/wallpaper/wallpaper.dart
@@ -3,6 +3,8 @@ export 'dynamic_wallpaper_config_field.dart';
 export 'dynamic_wallpaper_definition.dart';
 export 'dynamic_wallpaper_view.dart';
 export 'floating_wallpaper.dart';
+export 'moving_background_wallpaper.dart';
+export 'particles_wallpaper.dart';
 export 'theme_wallpaper_palette.dart';
 export 'wallpaper_config_codec.dart';
 export 'wave_wallpaper.dart';

--- a/lib/app/components/wallpaper/wallpaper.dart
+++ b/lib/app/components/wallpaper/wallpaper.dart
@@ -1,0 +1,8 @@
+export 'chat_wallpaper_type.dart';
+export 'dynamic_wallpaper_config_field.dart';
+export 'dynamic_wallpaper_definition.dart';
+export 'dynamic_wallpaper_view.dart';
+export 'floating_wallpaper.dart';
+export 'theme_wallpaper_palette.dart';
+export 'wallpaper_config_codec.dart';
+export 'wave_wallpaper.dart';

--- a/lib/app/components/wallpaper/wallpaper_config_codec.dart
+++ b/lib/app/components/wallpaper/wallpaper_config_codec.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+/// JSON (de)serialization for `Chat.dynamicWallpaperConfig`. Kept as a plain
+/// `Map<String, dynamic>` rather than a typed model per wallpaper type so
+/// [DynamicWallpaperDefinition] implementations stay fully self-contained —
+/// nothing outside a definition needs to know its config shape.
+abstract final class WallpaperConfigCodec {
+  static String encode(Map<String, dynamic> config) => jsonEncode(config);
+
+  static Map<String, dynamic>? decode(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/app/components/wallpaper/wave_wallpaper.dart
+++ b/lib/app/components/wallpaper/wave_wallpaper.dart
@@ -1,8 +1,8 @@
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
 import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:wave/wave.dart';
 
 /// Dynamic wallpaper backed by the `wave` package — a stack of animated,
@@ -12,7 +12,8 @@ class WaveWallpaperDefinition extends DynamicWallpaperDefinition {
 
   static double _amplitude(Map<String, dynamic> c) => (c['amplitude'] as num?)?.toDouble() ?? 20;
   static double _frequency(Map<String, dynamic> c) => (c['frequency'] as num?)?.toDouble() ?? 1.6;
-  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.5;
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.2;
+  static double _opacity(Map<String, dynamic> c) => (c['opacity'] as num?)?.toDouble() ?? 0.5;
   static int _layerCount(Map<String, dynamic> c) => ((c['layerCount'] as num?)?.toInt() ?? 3).clamp(2, 4).toInt();
 
   static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
@@ -30,7 +31,8 @@ class WaveWallpaperDefinition extends DynamicWallpaperDefinition {
       'frequency': 1.6,
       // Fairly slow by default -- a wallpaper should read as calm background
       // motion, not something competing for attention with the conversation.
-      'speed': 0.5,
+      'speed': 0.2,
+      'opacity': 0.5,
       'layerCount': colors.length.clamp(2, 4).toDouble(),
       'colors': colors.map((c) => c.toARGB32()).toList(),
     };
@@ -73,11 +75,20 @@ class WaveWallpaperDefinition extends DynamicWallpaperDefinition {
       ConfigSliderField(
         label: "Speed",
         value: _speed(config),
-        min: 0.2,
-        max: 3.0,
-        divisions: 28,
+        min: 0.1,
+        max: 0.5,
+        divisions: 4,
         format: (v) => "${v.toStringAsFixed(1)}x",
         onChanged: (v) => onConfigChanged({...config, 'speed': v}),
+      ),
+      ConfigSliderField(
+        label: "Opacity",
+        value: _opacity(config),
+        min: 0.2,
+        max: 1.0,
+        divisions: 16,
+        format: (v) => "${(v * 100).round()}%",
+        onChanged: (v) => onConfigChanged({...config, 'opacity': v}),
       ),
       ConfigSliderField(
         label: "Wave layers",
@@ -110,8 +121,10 @@ class _WaveWallpaperView extends StatelessWidget {
     final colors = WaveWallpaperDefinition._colors(config, palette);
     final layerCount = WaveWallpaperDefinition._layerCount(config);
     final speed = WaveWallpaperDefinition._speed(config);
+    final opacity = WaveWallpaperDefinition._opacity(config);
 
-    final layerColors = List.generate(layerCount, (i) => colors[i % colors.length]);
+    final layerColors =
+        List.generate(layerCount, (i) => colors[i % colors.length].withValues(alpha: opacity));
     final durations = List.generate(layerCount, (i) => ((9000 - i * 1500) / speed).round());
     final heightPercentages = List.generate(layerCount, (i) => 0.16 + i * 0.07);
 

--- a/lib/app/components/wallpaper/wave_wallpaper.dart
+++ b/lib/app/components/wallpaper/wave_wallpaper.dart
@@ -12,7 +12,7 @@ class WaveWallpaperDefinition extends DynamicWallpaperDefinition {
 
   static double _amplitude(Map<String, dynamic> c) => (c['amplitude'] as num?)?.toDouble() ?? 20;
   static double _frequency(Map<String, dynamic> c) => (c['frequency'] as num?)?.toDouble() ?? 1.6;
-  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 1.0;
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 0.5;
   static int _layerCount(Map<String, dynamic> c) => ((c['layerCount'] as num?)?.toInt() ?? 3).clamp(2, 4).toInt();
 
   static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
@@ -28,7 +28,9 @@ class WaveWallpaperDefinition extends DynamicWallpaperDefinition {
     return {
       'amplitude': 20.0,
       'frequency': 1.6,
-      'speed': 1.0,
+      // Fairly slow by default -- a wallpaper should read as calm background
+      // motion, not something competing for attention with the conversation.
+      'speed': 0.5,
       'layerCount': colors.length.clamp(2, 4).toDouble(),
       'colors': colors.map((c) => c.toARGB32()).toList(),
     };

--- a/lib/app/components/wallpaper/wave_wallpaper.dart
+++ b/lib/app/components/wallpaper/wave_wallpaper.dart
@@ -1,0 +1,131 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_definition.dart';
+import 'package:bluebubbles/app/components/wallpaper/theme_wallpaper_palette.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:wave/wave.dart';
+
+/// Dynamic wallpaper backed by the `wave` package — a stack of animated,
+/// layered wave shapes in colors drawn from the chat's theme palette.
+class WaveWallpaperDefinition extends DynamicWallpaperDefinition {
+  WaveWallpaperDefinition() : super(id: 'wave', displayName: 'Waves', icon: Icons.waves_rounded);
+
+  static double _amplitude(Map<String, dynamic> c) => (c['amplitude'] as num?)?.toDouble() ?? 20;
+  static double _frequency(Map<String, dynamic> c) => (c['frequency'] as num?)?.toDouble() ?? 1.6;
+  static double _speed(Map<String, dynamic> c) => (c['speed'] as num?)?.toDouble() ?? 1.0;
+  static int _layerCount(Map<String, dynamic> c) => ((c['layerCount'] as num?)?.toInt() ?? 3).clamp(2, 4).toInt();
+
+  static List<Color> _colors(Map<String, dynamic> c, List<Color> fallbackPalette) {
+    final raw = (c['colors'] as List?)?.whereType<num>().map((e) => Color(e.toInt())).toList();
+    if (raw != null && raw.isNotEmpty) return raw;
+    return fallbackPalette.isNotEmpty ? fallbackPalette : const [Colors.blue, Colors.lightBlue];
+  }
+
+  @override
+  Map<String, dynamic> defaultConfig(BuildContext context, {required bool isIMessage}) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: isIMessage);
+    final colors = palette.take(3).toList();
+    return {
+      'amplitude': 20.0,
+      'frequency': 1.6,
+      'speed': 1.0,
+      'layerCount': colors.length.clamp(2, 4).toDouble(),
+      'colors': colors.map((c) => c.toARGB32()).toList(),
+    };
+  }
+
+  @override
+  Widget buildView(BuildContext context, Map<String, dynamic> config) {
+    return _WaveWallpaperView(config: config);
+  }
+
+  @override
+  List<ConfigField> buildConfigFields(
+    BuildContext context,
+    Map<String, dynamic> config,
+    void Function(Map<String, dynamic> next) onConfigChanged,
+  ) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final layerCount = _layerCount(config);
+    final selected = _colors(config, palette).take(4).toList();
+
+    return [
+      ConfigSliderField(
+        label: "Amplitude",
+        value: _amplitude(config),
+        min: 4,
+        max: 48,
+        divisions: 44,
+        format: (v) => v.toStringAsFixed(0),
+        onChanged: (v) => onConfigChanged({...config, 'amplitude': v}),
+      ),
+      ConfigSliderField(
+        label: "Frequency",
+        value: _frequency(config),
+        min: 0.4,
+        max: 3.2,
+        divisions: 28,
+        format: (v) => v.toStringAsFixed(1),
+        onChanged: (v) => onConfigChanged({...config, 'frequency': v}),
+      ),
+      ConfigSliderField(
+        label: "Speed",
+        value: _speed(config),
+        min: 0.2,
+        max: 3.0,
+        divisions: 28,
+        format: (v) => "${v.toStringAsFixed(1)}x",
+        onChanged: (v) => onConfigChanged({...config, 'speed': v}),
+      ),
+      ConfigSliderField(
+        label: "Wave layers",
+        value: layerCount.toDouble(),
+        min: 2,
+        max: 4,
+        divisions: 2,
+        format: (v) => v.toStringAsFixed(0),
+        onChanged: (v) => onConfigChanged({...config, 'layerCount': v}),
+      ),
+      ConfigColorField(
+        label: "Colors",
+        palette: palette,
+        selected: selected,
+        maxSelected: 4,
+        onChanged: (colors) => onConfigChanged({...config, 'colors': colors.map((c) => c.toARGB32()).toList()}),
+      ),
+    ];
+  }
+}
+
+class _WaveWallpaperView extends StatelessWidget {
+  final Map<String, dynamic> config;
+
+  const _WaveWallpaperView({required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ThemeWallpaperPalette.fromContext(context, isIMessage: true);
+    final colors = WaveWallpaperDefinition._colors(config, palette);
+    final layerCount = WaveWallpaperDefinition._layerCount(config);
+    final speed = WaveWallpaperDefinition._speed(config);
+
+    final layerColors = List.generate(layerCount, (i) => colors[i % colors.length]);
+    final durations = List.generate(layerCount, (i) => ((9000 - i * 1500) / speed).round());
+    final heightPercentages = List.generate(layerCount, (i) => 0.16 + i * 0.07);
+
+    return ColoredBox(
+      color: context.theme.colorScheme.surface,
+      child: WaveWidget(
+        config: CustomConfig(
+          colors: layerColors,
+          durations: durations,
+          heightPercentages: heightPercentages,
+        ),
+        waveAmplitude: WaveWallpaperDefinition._amplitude(config),
+        waveFrequency: WaveWallpaperDefinition._frequency(config),
+        backgroundColor: Colors.transparent,
+        size: const Size(double.infinity, double.infinity),
+      ),
+    );
+  }
+}

--- a/lib/app/layouts/chat_creator/chat_creator.dart
+++ b/lib/app/layouts/chat_creator/chat_creator.dart
@@ -537,7 +537,7 @@ class ChatCreatorState extends State<ChatCreator> with ThemeHelpers {
                                 closeActiveChat: false,
                                 // only used in non-tablet mode context
                                 customRoute: PageRouteBuilder(
-                                  pageBuilder: (_, __, ___) => TitleBarWrapper(
+                                  pageBuilder: (_, _, _) => TitleBarWrapper(
                                       child: ConversationView(
                                     chat: existingChat,
                                     customService: messagesService,
@@ -620,7 +620,7 @@ class ChatCreatorState extends State<ChatCreator> with ThemeHelpers {
                                   ConversationView(chat: newChat),
                                   (route) => route.isFirst,
                                   customRoute: PageRouteBuilder(
-                                    pageBuilder: (_, __, ___) => TitleBarWrapper(
+                                    pageBuilder: (_, _, _) => TitleBarWrapper(
                                       child: ConversationView(
                                         chat: newChat,
                                         fromChatCreator: true,

--- a/lib/app/layouts/conversation_details/material/material_chat_options.dart
+++ b/lib/app/layouts/conversation_details/material/material_chat_options.dart
@@ -8,7 +8,7 @@ import 'package:bluebubbles/app/layouts/settings/pages/storage/storage_analyzer_
 import 'package:bluebubbles/app/layouts/settings/pages/theming/theme_studio/theme_studio_panel.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/theming/avatar/avatar_crop.dart';
-import 'package:bluebubbles/app/layouts/settings/pages/theming/background/background_crop.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_page.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
@@ -125,45 +125,9 @@ class ExpressiveChatOptions extends StatelessWidget {
         enabled: !kIsWeb,
         build: (context) => M3EListTile(
           icon: Icons.wallpaper,
-          title: "Custom background",
-          supportingText: "Set or reset this chat's background",
-          onTap: () {
-            final backgroundPath = FilesystemSvc.getExistingChatBackgroundPath(chat.guid);
-            if (backgroundPath != null) {
-              showBBDialog(
-                context: context,
-                title: "Custom Background",
-                body: "You already have a custom background for this chat. What would you like to do?",
-                actions: [
-                  BBDialogAction(
-                    text: "Cancel",
-                    onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-                  ),
-                  BBDialogAction(
-                    text: "Remove",
-                    isDestructive: true,
-                    color: context.theme.colorScheme.error,
-                    onPressed: () async {
-                      final File bgFile = File(backgroundPath);
-                      if (await bgFile.exists()) bgFile.delete();
-                      await ChatsSvc.setChatCustomBackgroundPath(chat, null);
-                      if (context.mounted) Navigator.of(context, rootNavigator: true).pop();
-                    },
-                  ),
-                  BBDialogAction(
-                    text: "Set New",
-                    isDefault: true,
-                    onPressed: () {
-                      Navigator.of(context, rootNavigator: true).pop();
-                      Get.to(() => BackgroundCrop(chat: chat));
-                    },
-                  ),
-                ],
-              );
-            } else {
-              Get.to(() => BackgroundCrop(chat: chat));
-            }
-          },
+          title: "Wallpaper",
+          supportingText: "Set an image or animated wallpaper",
+          onTap: () => NavigationSvc.push(context, WallpaperPickerPage(chat: chat)),
         ),
       ),
       _OptionRow(

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_dynamic_wallpaper_config_body.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_dynamic_wallpaper_config_body.dart
@@ -1,0 +1,27 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/config_field_row.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+class CupertinoDynamicWallpaperConfigBody extends StatelessWidget {
+  final List<ConfigField> fields;
+
+  const CupertinoDynamicWallpaperConfigBody({super.key, required this.fields});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 24),
+      children: [
+        for (int i = 0; i < fields.length; i++) ...[
+          SettingsSection(
+            backgroundColor: context.tileColor,
+            children: [buildConfigFieldRow(context, fields[i], expressive: false)],
+          ),
+          const SizedBox(height: 8),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_wallpaper_picker.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_wallpaper_picker.dart
@@ -1,0 +1,61 @@
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_gallery_grid.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
+import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// iOS skin — Cupertino design language, no M3E (Material/Samsung only).
+class CupertinoWallpaperPicker extends StatelessWidget {
+  const CupertinoWallpaperPicker({super.key, required this.controller});
+
+  final WallpaperPickerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return BBScaffold(
+      appBar: BBAppBar(titleText: "Wallpaper", leading: buildBackButton(context)),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+        children: [
+          WallpaperCurrentPreview(chatState: controller.chatState, onRemove: controller.removeWallpaper),
+          const SizedBox(height: 16),
+          SettingsHeader(
+            iosSubtitle: context.iosSubtitle,
+            materialSubtitle: context.materialSubtitle,
+            text: "Choose an image",
+          ),
+          SettingsSection(
+            backgroundColor: context.tileColor,
+            children: [
+              SettingsTile(
+                leading: const SettingsLeadingIcon(
+                  iosIcon: CupertinoIcons.photo,
+                  materialIcon: Icons.photo_outlined,
+                  containerColor: Colors.deepPurple,
+                ),
+                title: "Pick From Photos",
+                subtitle: "Crop and blur a custom image",
+                onTap: () => controller.pickImage(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          SettingsHeader(
+            iosSubtitle: context.iosSubtitle,
+            materialSubtitle: context.materialSubtitle,
+            text: "Dynamic Wallpapers",
+          ),
+          const SizedBox(height: 8),
+          WallpaperGalleryGrid(
+            chatState: controller.chatState,
+            onSelect: (definition) => controller.openDynamicConfig(context, definition),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_wallpaper_picker.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_wallpaper_picker.dart
@@ -17,12 +17,16 @@ class CupertinoWallpaperPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBScaffold(
+      extendBodyBehindAppBar: false,
+      backgroundColor: context.headerColor,
       appBar: BBAppBar(titleText: "Wallpaper", leading: buildBackButton(context)),
       body: ListView(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+        padding: const EdgeInsets.only(top: 8, bottom: 24),
         children: [
-          WallpaperCurrentPreview(chatState: controller.chatState, onRemove: controller.removeWallpaper),
-          const SizedBox(height: 16),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: WallpaperCurrentPreview(chatState: controller.chatState, onRemove: controller.removeWallpaper),
+          ),
           SettingsHeader(
             iosSubtitle: context.iosSubtitle,
             materialSubtitle: context.materialSubtitle,
@@ -43,13 +47,11 @@ class CupertinoWallpaperPicker extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 16),
           SettingsHeader(
             iosSubtitle: context.iosSubtitle,
             materialSubtitle: context.materialSubtitle,
             text: "Dynamic Wallpapers",
           ),
-          const SizedBox(height: 8),
           WallpaperGalleryGrid(
             chatState: controller.chatState,
             onSelect: (definition) => controller.openDynamicConfig(context, definition),

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart
@@ -1,4 +1,5 @@
 import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/material/chat_detail_theme.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_dynamic_wallpaper_config_body.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/expressive_dynamic_wallpaper_config_body.dart';
 import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
@@ -37,15 +38,6 @@ class _DynamicWallpaperConfigPageState extends State<DynamicWallpaperConfigPage>
 
   Map<String, dynamic> get config => _config!;
 
-  // `defaultConfig` reads `context.theme`, which depends on the inherited
-  // `Theme` widget — not available yet in `initState()`, so it's computed
-  // here instead (called after `initState()`, with the widget tree mounted).
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _config ??= widget.initialConfig ?? widget.definition.defaultConfig(context, isIMessage: widget.chat.isIMessage);
-  }
-
   void _onConfigChanged(Map<String, dynamic> next) => setState(() => _config = next);
 
   Future<void> _apply() async {
@@ -57,48 +49,70 @@ class _DynamicWallpaperConfigPageState extends State<DynamicWallpaperConfigPage>
 
   @override
   Widget build(BuildContext context) {
-    final fields = widget.definition.buildConfigFields(context, config, _onConfigChanged);
+    // This page is reached via a separate pushed route rather than as a
+    // descendant of the conversation view's per-chat `Theme`, so without
+    // this override every color here (config screen color swatches, the
+    // live preview) would only ever reflect the global theme, ignoring a
+    // chat's own custom theme. `ChatDetailTheme.resolve` already falls back
+    // to the global theme when the chat has none of its own. `Builder` gets
+    // us a context *below* the override to read `context.theme` from --
+    // `defaultConfig`/`buildConfigFields` also need that seeded default
+    // computed here (not in `initState()`/`didChangeDependencies()`, which
+    // run before this subtree -- and its `Theme` -- exists).
+    return Obx(() {
+      final chatTheme = ChatDetailTheme.resolve(context, widget.chat);
+      return Theme(
+        data: chatTheme.theme,
+        child: Builder(
+          builder: (context) {
+            _config ??=
+                widget.initialConfig ?? widget.definition.defaultConfig(context, isIMessage: widget.chat.isIMessage);
+            final fields = widget.definition.buildConfigFields(context, config, _onConfigChanged);
 
-    return BBScaffold(
-      extendBodyBehindAppBar: false,
-      backgroundColor: context.headerColor,
-      appBar: BBAppBar(
-        titleText: widget.definition.displayName,
-        leading: buildBackButton(context),
-        actions: [
-          TextButton(
-            onPressed: _applying ? null : _apply,
-            child: Text(
-              "Apply",
-              style: context.theme.textTheme.bodyLarge!.copyWith(
-                color: _applying ? context.theme.colorScheme.outline : context.theme.colorScheme.primary,
+            return BBScaffold(
+              extendBodyBehindAppBar: false,
+              backgroundColor: context.headerColor,
+              appBar: BBAppBar(
+                titleText: widget.definition.displayName,
+                leading: buildBackButton(context),
+                actions: [
+                  TextButton(
+                    onPressed: _applying ? null : _apply,
+                    child: Text(
+                      "Apply",
+                      style: context.theme.textTheme.bodyLarge!.copyWith(
+                        color: _applying ? context.theme.colorScheme.outline : context.theme.colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(24),
-              child: SizedBox(
-                height: 220,
-                width: double.infinity,
-                child: DynamicWallpaperView(wallpaperId: widget.definition.id, config: config),
+              body: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(24),
+                      child: SizedBox(
+                        height: 220,
+                        width: double.infinity,
+                        child: DynamicWallpaperView(wallpaperId: widget.definition.id, config: config),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: ThemeSwitcher(
+                      iOSSkin: CupertinoDynamicWallpaperConfigBody(fields: fields),
+                      materialSkin: ExpressiveDynamicWallpaperConfigBody(fields: fields),
+                      samsungSkin: ExpressiveDynamicWallpaperConfigBody(fields: fields),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ),
-          Expanded(
-            child: ThemeSwitcher(
-              iOSSkin: CupertinoDynamicWallpaperConfigBody(fields: fields),
-              materialSkin: ExpressiveDynamicWallpaperConfigBody(fields: fields),
-              samsungSkin: ExpressiveDynamicWallpaperConfigBody(fields: fields),
-            ),
-          ),
-        ],
-      ),
-    );
+            );
+          },
+        ),
+      );
+    });
   }
 }

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart
@@ -1,0 +1,96 @@
+import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_dynamic_wallpaper_config_body.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/expressive_dynamic_wallpaper_config_body.dart';
+import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
+import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
+import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/material.dart';
+
+/// Config screen for a single dynamic wallpaper. Fully generic — it doesn't
+/// know anything about "wave" or "floating shapes" specifically, it just
+/// renders whatever [DynamicWallpaperDefinition.buildConfigFields] returns
+/// for the current config, live-previewing the result at the top. This is
+/// what makes new dynamic wallpaper types free of any UI work here.
+class DynamicWallpaperConfigPage extends StatefulWidget {
+  final Chat chat;
+  final DynamicWallpaperDefinition definition;
+  final Map<String, dynamic>? initialConfig;
+
+  const DynamicWallpaperConfigPage({
+    super.key,
+    required this.chat,
+    required this.definition,
+    this.initialConfig,
+  });
+
+  @override
+  State<DynamicWallpaperConfigPage> createState() => _DynamicWallpaperConfigPageState();
+}
+
+class _DynamicWallpaperConfigPageState extends State<DynamicWallpaperConfigPage> with ThemeHelpers {
+  late Map<String, dynamic> config;
+  bool _applying = false;
+
+  @override
+  void initState() {
+    super.initState();
+    config = widget.initialConfig ?? widget.definition.defaultConfig(context, isIMessage: widget.chat.isIMessage);
+  }
+
+  void _onConfigChanged(Map<String, dynamic> next) => setState(() => config = next);
+
+  Future<void> _apply() async {
+    if (_applying) return;
+    setState(() => _applying = true);
+    await ChatsSvc.setChatDynamicWallpaper(widget.chat, widget.definition.id, config);
+    if (mounted) Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fields = widget.definition.buildConfigFields(context, config, _onConfigChanged);
+
+    return BBScaffold(
+      appBar: BBAppBar(
+        titleText: widget.definition.displayName,
+        leading: buildBackButton(context),
+        actions: [
+          TextButton(
+            onPressed: _applying ? null : _apply,
+            child: Text(
+              "Apply",
+              style: context.theme.textTheme.bodyLarge!.copyWith(
+                color: _applying ? context.theme.colorScheme.outline : context.theme.colorScheme.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(24),
+              child: SizedBox(
+                height: 220,
+                width: double.infinity,
+                child: DynamicWallpaperView(wallpaperId: widget.definition.id, config: config),
+              ),
+            ),
+          ),
+          Expanded(
+            child: ThemeSwitcher(
+              iOSSkin: CupertinoDynamicWallpaperConfigBody(fields: fields),
+              materialSkin: ExpressiveDynamicWallpaperConfigBody(fields: fields),
+              samsungSkin: ExpressiveDynamicWallpaperConfigBody(fields: fields),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart
@@ -8,6 +8,7 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 /// Config screen for a single dynamic wallpaper. Fully generic — it doesn't
 /// know anything about "wave" or "floating shapes" specifically, it just
@@ -31,16 +32,21 @@ class DynamicWallpaperConfigPage extends StatefulWidget {
 }
 
 class _DynamicWallpaperConfigPageState extends State<DynamicWallpaperConfigPage> with ThemeHelpers {
-  late Map<String, dynamic> config;
+  Map<String, dynamic>? _config;
   bool _applying = false;
 
+  Map<String, dynamic> get config => _config!;
+
+  // `defaultConfig` reads `context.theme`, which depends on the inherited
+  // `Theme` widget — not available yet in `initState()`, so it's computed
+  // here instead (called after `initState()`, with the widget tree mounted).
   @override
-  void initState() {
-    super.initState();
-    config = widget.initialConfig ?? widget.definition.defaultConfig(context, isIMessage: widget.chat.isIMessage);
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _config ??= widget.initialConfig ?? widget.definition.defaultConfig(context, isIMessage: widget.chat.isIMessage);
   }
 
-  void _onConfigChanged(Map<String, dynamic> next) => setState(() => config = next);
+  void _onConfigChanged(Map<String, dynamic> next) => setState(() => _config = next);
 
   Future<void> _apply() async {
     if (_applying) return;
@@ -54,6 +60,8 @@ class _DynamicWallpaperConfigPageState extends State<DynamicWallpaperConfigPage>
     final fields = widget.definition.buildConfigFields(context, config, _onConfigChanged);
 
     return BBScaffold(
+      extendBodyBehindAppBar: false,
+      backgroundColor: context.headerColor,
       appBar: BBAppBar(
         titleText: widget.definition.displayName,
         leading: buildBackButton(context),
@@ -72,7 +80,7 @@ class _DynamicWallpaperConfigPageState extends State<DynamicWallpaperConfigPage>
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(24),
               child: SizedBox(

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/expressive_dynamic_wallpaper_config_body.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/expressive_dynamic_wallpaper_config_body.dart
@@ -1,0 +1,28 @@
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/config_field_row.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Material/Samsung M3E config body — same generic field rendering as the
+/// Cupertino body, wrapped in `M3ESection` tonal cards instead of
+/// `SettingsSection`.
+class ExpressiveDynamicWallpaperConfigBody extends StatelessWidget {
+  final List<ConfigField> fields;
+
+  const ExpressiveDynamicWallpaperConfigBody({super.key, required this.fields});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(0, 8, 0, 24),
+      children: [
+        for (final field in fields)
+          M3ESection(
+            backgroundColor: context.tileColor,
+            children: [buildConfigFieldRow(context, field, expressive: true)],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/material_wallpaper_picker.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/material_wallpaper_picker.dart
@@ -1,0 +1,21 @@
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_expressive_body.dart';
+import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
+import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Material M3 Expressive skin — built on `lib/app/components/m3e/`.
+class MaterialWallpaperPicker extends StatelessWidget {
+  const MaterialWallpaperPicker({super.key, required this.controller});
+
+  final WallpaperPickerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return BBScaffold(
+      appBar: BBAppBar(titleText: "Wallpaper", leading: buildBackButton(context)),
+      body: WallpaperExpressiveBody(controller: controller),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/material_wallpaper_picker.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/material_wallpaper_picker.dart
@@ -14,6 +14,8 @@ class MaterialWallpaperPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBScaffold(
+      extendBodyBehindAppBar: false,
+      backgroundColor: context.headerColor,
       appBar: BBAppBar(titleText: "Wallpaper", leading: buildBackButton(context)),
       body: WallpaperExpressiveBody(controller: controller),
     );

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/samsung_wallpaper_picker.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/samsung_wallpaper_picker.dart
@@ -15,6 +15,8 @@ class SamsungWallpaperPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBScaffold(
+      extendBodyBehindAppBar: false,
+      backgroundColor: context.headerColor,
       appBar: BBAppBar(titleText: "Wallpaper", leading: buildBackButton(context)),
       body: WallpaperExpressiveBody(controller: controller),
     );

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/samsung_wallpaper_picker.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/samsung_wallpaper_picker.dart
@@ -1,0 +1,22 @@
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_expressive_body.dart';
+import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
+import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Samsung M3 Expressive skin — identical structure to the Material skin;
+/// `BBAppBar`/theming already branch Samsung internally.
+class SamsungWallpaperPicker extends StatelessWidget {
+  const SamsungWallpaperPicker({super.key, required this.controller});
+
+  final WallpaperPickerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return BBScaffold(
+      appBar: BBAppBar(titleText: "Wallpaper", leading: buildBackButton(context)),
+      body: WallpaperExpressiveBody(controller: controller),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart
@@ -1,0 +1,46 @@
+import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/dynamic_wallpaper_config_page.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/theming/background/background_crop.dart';
+import 'package:bluebubbles/app/state/chat_state.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Shared controller for the wallpaper picker page — one instance drives all
+/// three skin variants (Cupertino/Material/Samsung), following the
+/// `ContactsManagementController` pattern.
+class WallpaperPickerController extends GetxController {
+  WallpaperPickerController(this.chat);
+
+  final Chat chat;
+
+  ChatState? get chatState => ChatsSvc.getChatState(chat.guid);
+
+  /// Opens the existing image-crop flow. `BackgroundCrop` persists the
+  /// result itself (via `ChatsSvc.setChatCustomBackgroundPath`), which also
+  /// flips `wallpaperType` to "image" — nothing further to do here.
+  Future<void> pickImage(BuildContext context) async {
+    await NavigationSvc.push(context, BackgroundCrop(chat: chat));
+  }
+
+  Future<void> removeWallpaper() async {
+    await ChatsSvc.clearChatWallpaper(chat);
+  }
+
+  /// Opens the config screen for [definition] — pre-filled with the chat's
+  /// current config when it's already the active dynamic wallpaper, or the
+  /// definition's defaults otherwise.
+  Future<void> openDynamicConfig(BuildContext context, DynamicWallpaperDefinition definition) async {
+    final state = chatState;
+    final isCurrent = state?.wallpaperType.value == ChatWallpaperType.dynamic && state?.dynamicWallpaperId.value == definition.id;
+    await NavigationSvc.push(
+      context,
+      DynamicWallpaperConfigPage(
+        chat: chat,
+        definition: definition,
+        initialConfig: isCurrent ? state?.dynamicWallpaperConfig.value : null,
+      ),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart
@@ -20,8 +20,8 @@ class WallpaperPickerController extends GetxController {
   /// Opens the existing image-crop flow. `BackgroundCrop` persists the
   /// result itself (via `ChatsSvc.setChatCustomBackgroundPath`), which also
   /// flips `wallpaperType` to "image" — nothing further to do here.
-  Future<void> pickImage(BuildContext context) async {
-    await NavigationSvc.push(context, BackgroundCrop(chat: chat));
+  void pickImage(BuildContext context) {
+    NavigationSvc.push(context, BackgroundCrop(chat: chat));
   }
 
   Future<void> removeWallpaper() async {
@@ -31,10 +31,10 @@ class WallpaperPickerController extends GetxController {
   /// Opens the config screen for [definition] — pre-filled with the chat's
   /// current config when it's already the active dynamic wallpaper, or the
   /// definition's defaults otherwise.
-  Future<void> openDynamicConfig(BuildContext context, DynamicWallpaperDefinition definition) async {
+  void openDynamicConfig(BuildContext context, DynamicWallpaperDefinition definition) {
     final state = chatState;
     final isCurrent = state?.wallpaperType.value == ChatWallpaperType.dynamic && state?.dynamicWallpaperId.value == definition.id;
-    await NavigationSvc.push(
+    NavigationSvc.push(
       context,
       DynamicWallpaperConfigPage(
         chat: chat,

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_page.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_page.dart
@@ -1,0 +1,42 @@
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_wallpaper_picker.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/material_wallpaper_picker.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/samsung_wallpaper_picker.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart';
+import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Entry point for the chat wallpaper picker — reached from "Custom
+/// Background" in conversation details. Shows the current wallpaper (with a
+/// remove action), an option to pick a static image, and a live-preview
+/// gallery of dynamic (animated) wallpapers.
+class WallpaperPickerPage extends StatefulWidget {
+  const WallpaperPickerPage({super.key, required this.chat});
+
+  final Chat chat;
+
+  @override
+  State<WallpaperPickerPage> createState() => _WallpaperPickerPageState();
+}
+
+class _WallpaperPickerPageState extends State<WallpaperPickerPage> {
+  late final controller = Get.isRegistered<WallpaperPickerController>(tag: widget.chat.guid)
+      ? Get.find<WallpaperPickerController>(tag: widget.chat.guid)
+      : Get.put(WallpaperPickerController(widget.chat), tag: widget.chat.guid);
+
+  @override
+  void dispose() {
+    Get.delete<WallpaperPickerController>(tag: widget.chat.guid);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ThemeSwitcher(
+      iOSSkin: CupertinoWallpaperPicker(controller: controller),
+      materialSkin: MaterialWallpaperPicker(controller: controller),
+      samsungSkin: SamsungWallpaperPicker(controller: controller),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_page.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_page.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/layouts/conversation_details/material/chat_detail_theme.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/cupertino_wallpaper_picker.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/material_wallpaper_picker.dart';
 import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/samsung_wallpaper_picker.dart';
@@ -33,10 +34,23 @@ class _WallpaperPickerPageState extends State<WallpaperPickerPage> {
 
   @override
   Widget build(BuildContext context) {
-    return ThemeSwitcher(
-      iOSSkin: CupertinoWallpaperPicker(controller: controller),
-      materialSkin: MaterialWallpaperPicker(controller: controller),
-      samsungSkin: SamsungWallpaperPicker(controller: controller),
-    );
+    // Colors throughout this page (the config screens' color swatches, the
+    // gallery preview tiles) are drawn from `context.theme` -- without this
+    // override they'd only ever see the global theme, ignoring a chat's own
+    // custom theme, since this page is reached via a separate pushed route
+    // rather than as a descendant of the conversation view's per-chat
+    // `Theme`. `ChatDetailTheme.resolve` already falls back to the global
+    // theme when the chat has none of its own.
+    return Obx(() {
+      final chatTheme = ChatDetailTheme.resolve(context, widget.chat);
+      return Theme(
+        data: chatTheme.theme,
+        child: ThemeSwitcher(
+          iOSSkin: CupertinoWallpaperPicker(controller: controller),
+          materialSkin: MaterialWallpaperPicker(controller: controller),
+          samsungSkin: SamsungWallpaperPicker(controller: controller),
+        ),
+      );
+    });
   }
 }

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/config_field_row.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/config_field_row.dart
@@ -1,0 +1,136 @@
+import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
+import 'package:bluebubbles/app/components/bb_switch.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Renders one [ConfigField] as a row. Shared by the Cupertino and
+/// Material/Samsung-expressive config bodies — [expressive] only changes
+/// label typography so it fits whichever section container it's dropped
+/// into (`SettingsSection` vs `M3ESection`).
+Widget buildConfigFieldRow(BuildContext context, ConfigField field, {required bool expressive}) {
+  final labelStyle = expressive
+      ? context.theme.textTheme.bodyLarge
+      : context.theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500);
+
+  Widget label() => Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+        child: Text(field.label, style: labelStyle),
+      );
+
+  return switch (field) {
+    ConfigSliderField f => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          label(),
+          SettingsSlider(
+            startingVal: f.value.clamp(f.min, f.max).toDouble(),
+            min: f.min,
+            max: f.max,
+            divisions: f.divisions,
+            formatValue: f.format,
+            update: f.onChanged,
+          ),
+        ],
+      ),
+    ConfigChoiceField f => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          label(),
+          SettingsOptions<String>(
+            title: "",
+            initial: f.value,
+            options: f.options.map((o) => o.value).toList(),
+            capitalize: false,
+            textProcessing: (v) => f.options.firstWhere((o) => o.value == v).label,
+            onChanged: (v) {
+              if (v != null) f.onChanged(v);
+            },
+          ),
+        ],
+      ),
+    ConfigToggleField f => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            Expanded(child: Text(f.label, style: labelStyle)),
+            BBSwitch(value: f.value, onChanged: f.onChanged),
+          ],
+        ),
+      ),
+    ConfigColorField f => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          label(),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+            child: _ColorSwatchPicker(field: f),
+          ),
+        ],
+      ),
+  };
+}
+
+class _ColorSwatchPicker extends StatelessWidget {
+  final ConfigColorField field;
+
+  const _ColorSwatchPicker({required this.field});
+
+  void _tap(Color color) {
+    final selected = List<Color>.from(field.selected);
+    final index = selected.indexWhere((c) => c.toARGB32() == color.toARGB32());
+
+    if (field.maxSelected <= 1) {
+      field.onChanged([color]);
+      return;
+    }
+
+    if (index != -1) {
+      // Keep at least one color selected.
+      if (selected.length > 1) selected.removeAt(index);
+    } else if (selected.length < field.maxSelected) {
+      selected.add(color);
+    } else {
+      selected
+        ..removeAt(0)
+        ..add(color);
+    }
+    field.onChanged(selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: field.palette.map((color) {
+        final selected = field.selected.any((c) => c.toARGB32() == color.toARGB32());
+        return GestureDetector(
+          onTap: () => _tap(color),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: selected ? context.theme.colorScheme.primary : Colors.transparent,
+                width: 3,
+              ),
+              boxShadow: [
+                BoxShadow(color: Colors.black.withValues(alpha: 0.15), blurRadius: 3, offset: const Offset(0, 1)),
+              ],
+            ),
+            child: selected
+                ? Icon(Icons.check, size: 16, color: color.computeLuminance() > 0.5 ? Colors.black87 : Colors.white)
+                : null,
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/config_field_row.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/config_field_row.dart
@@ -1,8 +1,9 @@
 import 'package:bluebubbles/app/components/wallpaper/dynamic_wallpaper_config_field.dart';
 import 'package:bluebubbles/app/components/bb_switch.dart';
+import 'package:bluebubbles/app/components/bb_vertical_select.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 /// Renders one [ConfigField] as a row. Shared by the Cupertino and
 /// Material/Samsung-expressive config bodies — [expressive] only changes
@@ -34,20 +35,33 @@ Widget buildConfigFieldRow(BuildContext context, ConfigField field, {required bo
           ),
         ],
       ),
+    // `BBVerticalSelect` only has an iOS implementation so far -- keep the
+    // Material/Samsung expressive body on the dropdown until it grows one.
+    // The dropdown puts its own title next to the trigger on one row (via
+    // `SettingsOptions`'s built-in `title`), so it skips the shared
+    // above-the-control `label()` that the other field types use.
+    ConfigChoiceField f when expressive => SettingsOptions<String>(
+        title: f.label,
+        initial: f.value,
+        options: f.options.map((o) => o.value).toList(),
+        capitalize: false,
+        useModernMenu: true,
+        textProcessing: (v) => f.options.firstWhere((o) => o.value == v).label,
+        onChanged: (v) {
+          if (v != null) f.onChanged(v);
+        },
+      ),
     ConfigChoiceField f => Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           label(),
-          SettingsOptions<String>(
-            title: "",
-            initial: f.value,
+          BBVerticalSelect<String>(
             options: f.options.map((o) => o.value).toList(),
-            capitalize: false,
-            textProcessing: (v) => f.options.firstWhere((o) => o.value == v).label,
-            onChanged: (v) {
-              if (v != null) f.onChanged(v);
-            },
+            value: f.value,
+            labelBuilder: (v) => f.options.firstWhere((o) => o.value == v).label,
+            iconBuilder: (v) => f.options.firstWhere((o) => o.value == v).icon,
+            onChanged: f.onChanged,
           ),
         ],
       ),
@@ -103,34 +117,42 @@ class _ColorSwatchPicker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 12,
-      runSpacing: 12,
-      children: field.palette.map((color) {
-        final selected = field.selected.any((c) => c.toARGB32() == color.toARGB32());
-        return GestureDetector(
-          onTap: () => _tap(color),
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 150),
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              color: color,
-              shape: BoxShape.circle,
-              border: Border.all(
-                color: selected ? context.theme.colorScheme.primary : Colors.transparent,
-                width: 3,
+    // A bare `Wrap` only claims as much width as its widest run needs, so
+    // the enclosing `SettingsSection`/`M3ESection` card shrinks to fit --
+    // inconsistent with every other field's card, which fills the row.
+    // Forcing this to full width keeps the card width consistent regardless
+    // of how many rows the swatches wrap onto.
+    return SizedBox(
+      width: double.infinity,
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        children: field.palette.map((color) {
+          final selected = field.selected.any((c) => c.toARGB32() == color.toARGB32());
+          return GestureDetector(
+            onTap: () => _tap(color),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 150),
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: color,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: selected ? context.theme.colorScheme.primary : Colors.transparent,
+                  width: 3,
+                ),
+                boxShadow: [
+                  BoxShadow(color: Colors.black.withValues(alpha: 0.15), blurRadius: 3, offset: const Offset(0, 1)),
+                ],
               ),
-              boxShadow: [
-                BoxShadow(color: Colors.black.withValues(alpha: 0.15), blurRadius: 3, offset: const Offset(0, 1)),
-              ],
+              child: selected
+                  ? Icon(Icons.check, size: 16, color: color.computeLuminance() > 0.5 ? Colors.black87 : Colors.white)
+                  : null,
             ),
-            child: selected
-                ? Icon(Icons.check, size: 16, color: color.computeLuminance() > 0.5 ? Colors.black87 : Colors.white)
-                : null,
-          ),
-        );
-      }).toList(),
+          );
+        }).toList(),
+      ),
     );
   }
 }

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart
@@ -1,0 +1,68 @@
+import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
+import 'package:bluebubbles/app/state/chat_state.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:universal_io/io.dart';
+
+/// Shows the chat's currently active wallpaper (static image or live dynamic
+/// preview) with a "Remove" action, or an empty placeholder when none is
+/// set. Visually the same on every skin — like `ContactAvatarWidget`, a
+/// media preview card doesn't need three different looks — the picker pages
+/// around it provide the skin-specific chrome.
+class WallpaperCurrentPreview extends StatelessWidget {
+  final ChatState? chatState;
+  final VoidCallback onRemove;
+
+  const WallpaperCurrentPreview({super.key, required this.chatState, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      final type = chatState?.wallpaperType.value ?? ChatWallpaperType.none;
+      final imagePath = chatState?.customBackgroundPath.value;
+
+      Widget preview;
+      if (type == ChatWallpaperType.dynamic) {
+        preview = DynamicWallpaperView(
+          wallpaperId: chatState?.dynamicWallpaperId.value,
+          config: chatState?.dynamicWallpaperConfig.value,
+        );
+      } else if (type == ChatWallpaperType.image && imagePath != null) {
+        preview = Image.file(File(imagePath), fit: BoxFit.cover, errorBuilder: (_, __, ___) => const SizedBox.shrink());
+      } else {
+        preview = Center(
+          child: Text(
+            "No wallpaper set",
+            style: context.theme.textTheme.bodyMedium?.copyWith(color: context.theme.colorScheme.onSurfaceVariant),
+          ),
+        );
+      }
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: Container(
+              height: 180,
+              color: context.theme.colorScheme.surfaceContainerHighest,
+              child: preview,
+            ),
+          ),
+          if (type != ChatWallpaperType.none) ...[
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: onRemove,
+                icon: Icon(Icons.delete_outline, color: context.theme.colorScheme.error, size: 18),
+                label: Text("Remove wallpaper", style: TextStyle(color: context.theme.colorScheme.error)),
+              ),
+            ),
+          ],
+        ],
+      );
+    });
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart
@@ -29,7 +29,12 @@ class WallpaperCurrentPreview extends StatelessWidget {
           config: chatState?.dynamicWallpaperConfig.value,
         );
       } else if (type == ChatWallpaperType.image && imagePath != null) {
-        preview = Image.file(File(imagePath), fit: BoxFit.cover, errorBuilder: (_, __, ___) => const SizedBox.shrink());
+        preview = Image.file(
+          File(imagePath),
+          fit: BoxFit.cover,
+          filterQuality: FilterQuality.high,
+          errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+        );
       } else {
         preview = Center(
           child: Text(

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart
@@ -33,7 +33,7 @@ class WallpaperCurrentPreview extends StatelessWidget {
           File(imagePath),
           fit: BoxFit.cover,
           filterQuality: FilterQuality.high,
-          errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          errorBuilder: (_, _, _) => const SizedBox.shrink(),
         );
       } else {
         preview = Center(
@@ -44,14 +44,21 @@ class WallpaperCurrentPreview extends StatelessWidget {
         );
       }
 
+      // Empty state reads as a settings tile (same fill + corner radius as
+      // `SettingsSection` on this skin) rather than the plain preview
+      // surface used once an actual wallpaper is set.
+      final isEmpty = type == ChatWallpaperType.none;
+      final borderRadius = isEmpty && context.iOS ? BorderRadius.circular(10) : BorderRadius.circular(20);
+      final boxColor = isEmpty && context.iOS ? context.tileColor : context.theme.colorScheme.surfaceContainerHighest;
+
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           ClipRRect(
-            borderRadius: BorderRadius.circular(20),
+            borderRadius: borderRadius,
             child: Container(
               height: 180,
-              color: context.theme.colorScheme.surfaceContainerHighest,
+              color: boxColor,
               child: preview,
             ),
           ),

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_expressive_body.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_expressive_body.dart
@@ -14,14 +14,15 @@ class WallpaperExpressiveBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      padding: const EdgeInsets.only(top: 8, bottom: 24),
       children: [
-        WallpaperCurrentPreview(chatState: controller.chatState, onRemove: controller.removeWallpaper),
-        const SizedBox(height: 16),
-        const M3ESectionHeader(label: "Choose an image", padding: EdgeInsets.only(left: 4, bottom: 8)),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: WallpaperCurrentPreview(chatState: controller.chatState, onRemove: controller.removeWallpaper),
+        ),
+        const M3ESectionHeader(label: "Choose an image"),
         M3ESection(
           backgroundColor: context.tileColor,
-          margin: EdgeInsets.zero,
           children: [
             M3EListTile(
               icon: Icons.photo_outlined,
@@ -31,8 +32,7 @@ class WallpaperExpressiveBody extends StatelessWidget {
             ),
           ],
         ),
-        const SizedBox(height: 16),
-        const M3ESectionHeader(label: "Dynamic wallpapers", padding: EdgeInsets.only(left: 4, bottom: 8)),
+        const M3ESectionHeader(label: "Dynamic wallpapers"),
         WallpaperGalleryGrid(
           chatState: controller.chatState,
           onSelect: (definition) => controller.openDynamicConfig(context, definition),

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_expressive_body.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_expressive_body.dart
@@ -1,0 +1,43 @@
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_controller.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_current_preview.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_gallery_grid.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+
+/// Body shared by the Material and Samsung M3E skins.
+class WallpaperExpressiveBody extends StatelessWidget {
+  final WallpaperPickerController controller;
+
+  const WallpaperExpressiveBody({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      children: [
+        WallpaperCurrentPreview(chatState: controller.chatState, onRemove: controller.removeWallpaper),
+        const SizedBox(height: 16),
+        const M3ESectionHeader(label: "Choose an image", padding: EdgeInsets.only(left: 4, bottom: 8)),
+        M3ESection(
+          backgroundColor: context.tileColor,
+          margin: EdgeInsets.zero,
+          children: [
+            M3EListTile(
+              icon: Icons.photo_outlined,
+              title: "Pick from photos",
+              supportingText: "Crop and blur a custom image",
+              onTap: () => controller.pickImage(context),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        const M3ESectionHeader(label: "Dynamic wallpapers", padding: EdgeInsets.only(left: 4, bottom: 8)),
+        WallpaperGalleryGrid(
+          chatState: controller.chatState,
+          onSelect: (definition) => controller.openDynamicConfig(context, definition),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_gallery_grid.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_gallery_grid.dart
@@ -1,6 +1,5 @@
 import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
 import 'package:bluebubbles/app/state/chat_state.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -54,67 +53,86 @@ class _GalleryTile extends StatelessWidget {
 
   const _GalleryTile({required this.definition, required this.selected, required this.onTap});
 
+  static final _radius = BorderRadius.circular(20);
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 150),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color: selected ? context.theme.colorScheme.primary : Colors.transparent,
-            width: 3,
-          ),
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            ColoredBox(
-              color: context.theme.colorScheme.surfaceContainerHighest,
-              child: DynamicWallpaperView(wallpaperId: definition.id, config: null),
-            ),
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [Colors.transparent, Colors.black.withValues(alpha: 0.55)],
-                  ),
+      child: Stack(
+        children: [
+          // Content is clipped by its own `ClipRRect` rather than relying on
+          // the border `Container`'s `clipBehavior` -- a `BoxDecoration`
+          // border paints *behind* its child, so a child filling the full
+          // box (as this one does) painted on top would cover the border
+          // right up to its edge, leaving the rounded corners looking
+          // unclipped/square. Painting the border as a separate layer on top
+          // avoids that entirely.
+          ClipRRect(
+            borderRadius: _radius,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                ColoredBox(
+                  color: context.theme.colorScheme.surfaceContainerHighest,
+                  child: DynamicWallpaperView(wallpaperId: definition.id, config: null),
                 ),
-                child: Row(
-                  children: [
-                    Icon(definition.icon, size: 16, color: Colors.white),
-                    const SizedBox(width: 6),
-                    Expanded(
-                      child: Text(
-                        definition.displayName,
-                        style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
-                        overflow: TextOverflow.ellipsis,
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [Colors.transparent, Colors.black.withValues(alpha: 0.55)],
                       ),
                     ),
-                  ],
+                    child: Row(
+                      children: [
+                        Icon(definition.icon, size: 16, color: Colors.white),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            definition.displayName,
+                            style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                if (selected)
+                  Positioned(
+                    top: 8,
+                    right: 8,
+                    child: Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: BoxDecoration(color: context.theme.colorScheme.primary, shape: BoxShape.circle),
+                      child: Icon(Icons.check, size: 14, color: context.theme.colorScheme.onPrimary),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Positioned.fill(
+            child: IgnorePointer(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                decoration: BoxDecoration(
+                  borderRadius: _radius,
+                  border: Border.all(
+                    color: selected ? context.theme.colorScheme.primary : Colors.transparent,
+                    width: 3,
+                  ),
                 ),
               ),
             ),
-            if (selected)
-              Positioned(
-                top: 8,
-                right: 8,
-                child: Container(
-                  padding: const EdgeInsets.all(4),
-                  decoration: BoxDecoration(color: context.theme.colorScheme.primary, shape: BoxShape.circle),
-                  child: Icon(Icons.check, size: 14, color: context.theme.colorScheme.onPrimary),
-                ),
-              ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_gallery_grid.dart
+++ b/lib/app/layouts/conversation_details/pages/wallpaper_picker/widgets/wallpaper_gallery_grid.dart
@@ -1,0 +1,121 @@
+import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
+import 'package:bluebubbles/app/state/chat_state.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Grid of every registered dynamic wallpaper, each tile live-previewing
+/// itself at default settings. New entries in [DynamicWallpaperRegistry]
+/// show up here automatically — nothing here is aware of "wave" or
+/// "floating" specifically.
+class WallpaperGalleryGrid extends StatelessWidget {
+  final ChatState? chatState;
+  final void Function(DynamicWallpaperDefinition definition) onSelect;
+
+  const WallpaperGalleryGrid({super.key, required this.chatState, required this.onSelect});
+
+  @override
+  Widget build(BuildContext context) {
+    final definitions = DynamicWallpaperRegistry.all;
+
+    return Obx(() {
+      final selectedId = chatState?.wallpaperType.value == ChatWallpaperType.dynamic
+          ? chatState?.dynamicWallpaperId.value
+          : null;
+
+      return GridView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          mainAxisSpacing: 12,
+          crossAxisSpacing: 12,
+          childAspectRatio: 0.82,
+        ),
+        itemCount: definitions.length,
+        itemBuilder: (context, index) {
+          final definition = definitions[index];
+          return _GalleryTile(
+            definition: definition,
+            selected: definition.id == selectedId,
+            onTap: () => onSelect(definition),
+          );
+        },
+      );
+    });
+  }
+}
+
+class _GalleryTile extends StatelessWidget {
+  final DynamicWallpaperDefinition definition;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _GalleryTile({required this.definition, required this.selected, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: selected ? context.theme.colorScheme.primary : Colors.transparent,
+            width: 3,
+          ),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            ColoredBox(
+              color: context.theme.colorScheme.surfaceContainerHighest,
+              child: DynamicWallpaperView(wallpaperId: definition.id, config: null),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [Colors.transparent, Colors.black.withValues(alpha: 0.55)],
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(definition.icon, size: 16, color: Colors.white),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        definition.displayName,
+                        style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (selected)
+              Positioned(
+                top: 8,
+                right: 8,
+                child: Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(color: context.theme.colorScheme.primary, shape: BoxShape.circle),
+                  child: Icon(Icons.check, size: 14, color: context.theme.colorScheme.onPrimary),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/layouts/conversation_details/widgets/chat_options.dart
+++ b/lib/app/layouts/conversation_details/widgets/chat_options.dart
@@ -9,7 +9,7 @@ import 'package:bluebubbles/app/layouts/settings/widgets/content/next_button.dar
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/theming/avatar/avatar_crop.dart';
-import 'package:bluebubbles/app/layouts/settings/pages/theming/background/background_crop.dart';
+import 'package:bluebubbles/app/layouts/conversation_details/pages/wallpaper_picker/wallpaper_picker_page.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/cupertino.dart';
@@ -133,47 +133,15 @@ class _ChatOptionsState extends State<ChatOptions> with ThemeHelpers {
       _OptionRow(
         enabled: !kIsWeb,
         build: (context) => SettingsTile(
-          title: "Custom Background",
-          subtitle: "Set or reset a custom background for this chat",
+          title: "Wallpaper",
+          subtitle: "Set an image or animated wallpaper for this chat",
           leading: const SettingsLeadingIcon(
             iosIcon: CupertinoIcons.photo_fill,
             materialIcon: Icons.wallpaper,
             containerColor: Colors.deepPurple,
           ),
-          onTap: () {
-            final backgroundPath = FilesystemSvc.getExistingChatBackgroundPath(chat.guid);
-            if (backgroundPath != null) {
-              showBBDialog(
-                context: context,
-                title: "Custom Background",
-                body: "You already have a custom background for this chat. What would you like to do?",
-                actions: [
-                  BBDialogAction(text: "Cancel", onPressed: () => Navigator.of(context, rootNavigator: true).pop()),
-                  BBDialogAction(
-                    text: "Remove",
-                    isDestructive: true,
-                    color: context.theme.colorScheme.error,
-                    onPressed: () async {
-                      final File bgFile = File(backgroundPath);
-                      if (await bgFile.exists()) bgFile.delete();
-                      await ChatsSvc.setChatCustomBackgroundPath(chat, null);
-                      if (context.mounted) Navigator.of(context, rootNavigator: true).pop();
-                    },
-                  ),
-                  BBDialogAction(
-                    text: "Set New",
-                    isDefault: true,
-                    onPressed: () {
-                      Navigator.of(context, rootNavigator: true).pop();
-                      Get.to(() => BackgroundCrop(chat: chat));
-                    },
-                  ),
-                ],
-              );
-            } else {
-              Get.to(() => BackgroundCrop(chat: chat));
-            }
-          },
+          trailing: const NextButton(),
+          onTap: () => NavigationSvc.push(context, WallpaperPickerPage(chat: chat)),
         ),
       ),
       _OptionRow(

--- a/lib/app/layouts/conversation_list/pages/conversation_list.dart
+++ b/lib/app/layouts/conversation_list/pages/conversation_list.dart
@@ -241,7 +241,7 @@ class _ConversationListState extends CustomState<ConversationList, void, Convers
                 NavigationSvc.maxWidthLeft = constraints.maxWidth;
                 return PopScope(
                   canPop: false,
-                  onPopInvokedWithResult: <T>(bool _, T? __) async {
+                  onPopInvokedWithResult: <T>(bool _, T? _) async {
                     Get.until((route) {
                       bool id2result = false;
                       // check if we should pop the left side first
@@ -287,7 +287,7 @@ class _ConversationListState extends CustomState<ConversationList, void, Convers
             NavigationSvc.maxWidthRight = constraints.maxWidth;
             return PopScope(
               canPop: false,
-              onPopInvokedWithResult: <T>(bool _, T? __) async {
+              onPopInvokedWithResult: <T>(bool _, T? _) async {
                 Get.back(id: 2);
               },
               child: Navigator(

--- a/lib/app/layouts/conversation_list/pages/cupertino_conversation_list.dart
+++ b/lib/app/layouts/conversation_list/pages/cupertino_conversation_list.dart
@@ -114,7 +114,10 @@ class CupertinoConversationListState extends State<CupertinoConversationList> wi
                       int _pageCount = (pinCount / maxOnPage).ceil();
 
                       return SliverPadding(
-                        padding: const EdgeInsets.only(top: 10),
+                        // Bottom padding guarantees visible separation from the regular chat list even if
+                        // totalHeight below slightly underestimates the tiles' real rendered height on a
+                        // given device (font metrics can vary enough to make the estimate come in short).
+                        padding: const EdgeInsets.only(top: 6, bottom: 2),
                         sliver: SliverToBoxAdapter(
                           child: LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
                             // Horizontal overhead per tile: margins (4+4) + padding (11+11) + extra gap
@@ -122,6 +125,9 @@ class CupertinoConversationListState extends State<CupertinoConversationList> wi
                             // Vertical overhead per tile: AnimatedContainer margins (top:1) + padding (4+2)
                             //   + ChatTitle fixed padding (top:6 + bottom:4)
                             const double tileVOverhead = 17.0;
+                            // Extra per-row safety margin so real-device font/DPI variance can't make the
+                            // estimate come in short and let the last row bleed into the space below it.
+                            const double tileVSafetyBuffer = 4.0;
                             // PageView horizontal padding (10 each side)
                             const double pageHPadding = 20.0;
 
@@ -134,7 +140,7 @@ class CupertinoConversationListState extends State<CupertinoConversationList> wi
 
                             final TextStyle style = context.theme.textTheme.bodyMedium!;
                             final double textHeight = (style.height ?? 1.2) * (style.fontSize ?? 14);
-                            final double tileHeight = avatarSize + textHeight + tileVOverhead;
+                            final double tileHeight = avatarSize + textHeight + tileVOverhead + tileVSafetyBuffer;
                             final double totalHeight = usedRowCount * tileHeight;
 
                             // avatar only

--- a/lib/app/layouts/conversation_list/widgets/initial_widget_right.dart
+++ b/lib/app/layouts/conversation_list/widgets/initial_widget_right.dart
@@ -20,7 +20,7 @@ class _InitialWidgetRightState extends State<InitialWidgetRight> {
             : context.theme.colorScheme.surface,
         extendBodyBehindAppBar: true,
         body: Center(
-          child: Container(child: Text("Select a chat from the list", style: context.theme.textTheme.bodyLarge)),
+          child: Text("Select a chat from the list", style: context.theme.textTheme.bodyLarge),
         ),
       ),
     );

--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -525,7 +525,7 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
         builder: (replyContext) {
           final theme = Theme.of(replyContext);
           final hasBackground =
-              ChatsSvc.getChatState(controller.chat.guid)?.customBackgroundPath.value?.isNotEmpty == true;
+              ChatsSvc.getChatState(controller.chat.guid)?.hasCustomWallpaper ?? false;
           return Container(
             margin: const EdgeInsets.all(5),
             decoration: hasBackground

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart
@@ -361,11 +361,11 @@ class _AttachmentHolderState extends State<AttachmentHolder> with ThemeHelpers {
         // ignore: unused_local_variable
         final _ = state.transferState.value;
         // ignore: unused_local_variable
-        final __ = state.resolvedFile.value;
+        final _ = state.resolvedFile.value;
         // ignore: unused_local_variable
-        final ___ = state.activeDownload.value;
+        final _ = state.activeDownload.value;
         // ignore: unused_local_variable
-        final ____ = state.hasError.value;
+        final _ = state.hasError.value;
 
         final hasError = state.hasError.value || message.error > 0;
         final hasPreview = state.resolvedFile.value != null ||

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/image_viewer.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/image_viewer.dart
@@ -419,9 +419,9 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
             Obx(
               () => !isPlayingLivePhoto.value
                   ? Positioned(
-                      top: 8,
-                      right: widget.isFromMe ? null : 8,
-                      left: widget.isFromMe ? 8 : null,
+                      top: 12,
+                      right: widget.isFromMe ? null : 10,
+                      left: widget.isFromMe ? 10 : null,
                       child: GestureDetector(
                         onTap: () {
                           if (!isDownloadingLivePhoto.value) {
@@ -429,7 +429,7 @@ class _ImageViewerState extends State<ImageViewer> with AutomaticKeepAliveClient
                           }
                         },
                         child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
                           decoration: BoxDecoration(
                             color: Colors.black.withValues(alpha: 0.6),
                             borderRadius: BorderRadius.circular(4),

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/message_image_gallery.dart
@@ -217,7 +217,7 @@ class _MessageImageGalleryState extends State<MessageImageGallery> with ThemeHel
           }
           stream.removeListener(listener);
         },
-        onError: (dynamic _, StackTrace? __) {
+        onError: (dynamic _, StackTrace? _) {
           if (!completer.isCompleted) completer.complete(null);
           stream.removeListener(listener);
         },

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/parts/downloading_content.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/parts/downloading_content.dart
@@ -144,7 +144,7 @@ class DownloadingContent extends StatelessWidget {
       // 10pt gives the tag some visual breathing room from the curved corner
       // instead of sitting exactly on the clip boundary.
       final basePadding = isInGallery ? 10.0 : (hasReservedSize ? 8.0 : 0);
-      final topPadding = hasReservedSize ? 14.0 : 4.0;
+      final topPadding = hasReservedSize ? 14.0 : isInGallery ? 10.0 : 4.0;
       final tailInset = showTail ? (hasReservedSize ? 14.0 : 0.0) : 0.0;
 
       return Stack(

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/video_player.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/video_player.dart
@@ -508,7 +508,9 @@ class _VideoPlayerState extends State<VideoPlayer> with AutomaticKeepAliveClient
                   isFromMe: widget.isFromMe),
               if (kIsDesktop) FullscreenButton(attachment: attachment, isFromMe: widget.isFromMe, muted: muted),
               if (!kIsDesktop && !kIsWeb && thumbnailFailed)
-                MediaCornerBadge(label: "Preview Unavailable", alignLeft: widget.isFromMe),
+                Obx(() => firstFrameReady.value
+                    ? const SizedBox.shrink()
+                    : MediaCornerBadge(label: "Preview Unavailable", alignLeft: widget.isFromMe)),
             ],
           ),
         ),

--- a/lib/app/layouts/conversation_view/widgets/message/chat_event/chat_event.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/chat_event/chat_event.dart
@@ -74,7 +74,7 @@ class ChatEvent extends StatelessWidget {
           },
           child: Obx(() {
             final chatState = ChatStateScope.maybeOf(context);
-            final hasBackground = chatState?.customBackgroundPath.value?.isNotEmpty == true;
+            final hasBackground = chatState?.hasCustomWallpaper ?? false;
             final senderName = state.senderDisplayName;
             final text = part.isUnsent
                 ? (message.isFromMe!

--- a/lib/app/layouts/conversation_view/widgets/message/interactive/cupertino_url_preview.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/interactive/cupertino_url_preview.dart
@@ -308,13 +308,13 @@ class CupertinoUrlPreview extends StatelessWidget {
                 File(iconImagePath),
                 gaplessPlayback: true,
                 filterQuality: FilterQuality.none,
-                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                errorBuilder: (_, _, _) => const SizedBox.shrink(),
               )
             : Image.network(
                 webIconUrl!,
                 gaplessPlayback: true,
                 filterQuality: FilterQuality.none,
-                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                errorBuilder: (_, _, _) => const SizedBox.shrink(),
               ),
       ),
     );
@@ -401,13 +401,13 @@ class CupertinoUrlPreview extends StatelessWidget {
               File(previewImagePath),
               gaplessPlayback: true,
               filterQuality: FilterQuality.none,
-              errorBuilder: (_, __, ___) => _imageErrorText(context),
+              errorBuilder: (_, _, _) => _imageErrorText(context),
             )
           : Image.network(
               webImageUrl ?? '',
               gaplessPlayback: true,
               filterQuality: FilterQuality.none,
-              errorBuilder: (_, __, ___) => _imageErrorText(context),
+              errorBuilder: (_, _, _) => _imageErrorText(context),
             ),
     );
 
@@ -484,7 +484,7 @@ class CupertinoUrlPreview extends StatelessWidget {
       controller.resolvedContent!.bytes!,
       gaplessPlayback: true,
       filterQuality: FilterQuality.none,
-      errorBuilder: (_, __, ___) => _imageErrorText(context),
+      errorBuilder: (_, _, _) => _imageErrorText(context),
     );
   }
 

--- a/lib/app/layouts/conversation_view/widgets/message/interactive/expressive_url_preview.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/interactive/expressive_url_preview.dart
@@ -97,7 +97,7 @@ class ExpressiveUrlPreview extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (header != null) header,
+        ?header,
         Padding(
           padding: inReply
               ? const EdgeInsets.all(M3ESpacing.md)
@@ -318,7 +318,7 @@ class ExpressiveUrlPreview extends StatelessWidget {
         File(previewImagePath),
         fit: BoxFit.cover,
         gaplessPlayback: true,
-        errorBuilder: (_, __, ___) => _imageFallback(context),
+        errorBuilder: (_, _, _) => _imageFallback(context),
       );
     } else if (webImageUrl != null) {
       animate = false;
@@ -326,7 +326,7 @@ class ExpressiveUrlPreview extends StatelessWidget {
         webImageUrl,
         fit: BoxFit.cover,
         gaplessPlayback: true,
-        errorBuilder: (_, __, ___) => _imageFallback(context),
+        errorBuilder: (_, _, _) => _imageFallback(context),
       );
     } else if (appleBytes != null) {
       animate = !controller.appleImageFromDisk.value;
@@ -334,7 +334,7 @@ class ExpressiveUrlPreview extends StatelessWidget {
         appleBytes,
         fit: BoxFit.cover,
         gaplessPlayback: true,
-        errorBuilder: (_, __, ___) => _imageFallback(context),
+        errorBuilder: (_, _, _) => _imageFallback(context),
       );
     } else if (appleFile != null) {
       animate = !controller.appleImageFromDisk.value;
@@ -342,7 +342,7 @@ class ExpressiveUrlPreview extends StatelessWidget {
         appleFile,
         fit: BoxFit.cover,
         gaplessPlayback: true,
-        errorBuilder: (_, __, ___) => _imageFallback(context),
+        errorBuilder: (_, _, _) => _imageFallback(context),
       );
     } else {
       return null;
@@ -406,14 +406,14 @@ class ExpressiveUrlPreview extends StatelessWidget {
                 fit: BoxFit.contain,
                 gaplessPlayback: true,
                 filterQuality: FilterQuality.medium,
-                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                errorBuilder: (_, _, _) => const SizedBox.shrink(),
               )
             : Image.network(
                 webIconUrl!,
                 fit: BoxFit.contain,
                 gaplessPlayback: true,
                 filterQuality: FilterQuality.medium,
-                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                errorBuilder: (_, _, _) => const SizedBox.shrink(),
               ),
       ),
     );

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder/reply_bubble_section.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder/reply_bubble_section.dart
@@ -68,7 +68,7 @@ class ReplyBubbleSection extends StatelessWidget {
       );
     } else {
       // Android/Material style - separate decorative box
-      final hasBackground = ChatStateScope.maybeOf(context)?.customBackgroundPath.value?.isNotEmpty == true;
+      final hasBackground = ChatStateScope.maybeOf(context)?.hasCustomWallpaper ?? false;
       return Padding(
         padding: showAvatar || alwaysShowAvatars
             ? const EdgeInsets.only(left: 45.0, right: 10)

--- a/lib/app/layouts/conversation_view/widgets/message/misc/message_sender.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/message_sender.dart
@@ -20,7 +20,7 @@ class MessageSender extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 25).add(const EdgeInsets.only(bottom: 3)),
       // Obx makes the sender name reactive: updates when contact data syncs.
       child: Obx(() {
-        final hasCustomBackground = chatState?.customBackgroundPath.value != null;
+        final hasCustomBackground = chatState?.hasCustomWallpaper ?? false;
         final text = Text(
           state.senderDisplayName,
           style: context.theme.textTheme.labelMedium!.copyWith(

--- a/lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart
@@ -59,7 +59,7 @@ class _ReplyBubbleState extends State<ReplyBubble> with ThemeHelpers {
   @override
   Widget build(BuildContext context) {
     final chatGuid = widget.cvController.chat.guid;
-    final hasBackground = ChatStateScope.maybeOf(context)?.customBackgroundPath.value?.isNotEmpty == true;
+    final hasBackground = ChatStateScope.maybeOf(context)?.hasCustomWallpaper ?? false;
     if (!iOS) {
       final messageText = controller.text.value;
       String text = Message(text: messageText, subject: controller.subject.value).getNotificationText();

--- a/lib/app/layouts/conversation_view/widgets/message/timestamp/timestamp_separator.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/timestamp/timestamp_separator.dart
@@ -45,7 +45,7 @@ class TimestampSeparator extends StatelessWidget {
   Widget build(BuildContext context) {
     final message = MessageStateScope.messageOf(context);
     final timestamp = buildTimeStamp(message);
-    final hasBackground = ChatStateScope.maybeOf(context)?.customBackgroundPath.value?.isNotEmpty == true;
+    final hasBackground = ChatStateScope.maybeOf(context)?.hasCustomWallpaper ?? false;
 
     if (timestamp == null) return const SizedBox.shrink();
 

--- a/lib/app/layouts/conversation_view/widgets/messages_view_components.dart
+++ b/lib/app/layouts/conversation_view/widgets/messages_view_components.dart
@@ -170,7 +170,7 @@ class SmartRepliesRow extends StatelessWidget {
   }
 
   Widget _buildReplyWidget(BuildContext context, String suggestion) {
-    final hasBackground = ChatsSvc.getChatState(controller.chat.guid)?.customBackgroundPath.value?.isNotEmpty == true;
+    final hasBackground = ChatsSvc.getChatState(controller.chat.guid)?.hasCustomWallpaper ?? false;
     return Container(
       margin: const EdgeInsets.all(5),
       decoration: hasBackground

--- a/lib/app/layouts/conversation_view/widgets/text_field/text_field_component.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/text_field_component.dart
@@ -165,7 +165,7 @@ class TextFieldComponentState extends State<TextFieldComponent> {
           valueListenable: isRecordingNotifier,
           builder: (context, isRecording, child) {
             final hasBackground = chat != null
-                ? (ChatsSvc.getChatState(chat!.guid)?.customBackgroundPath.value?.isNotEmpty == true)
+                ? (ChatsSvc.getChatState(chat!.guid)?.hasCustomWallpaper ?? false)
                 : false;
             return Container(
               // Border is placed in the foregroundDecoration so it paints on top of

--- a/lib/app/layouts/conversation_view/widgets/text_field/text_field_icon_bar.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/text_field_icon_bar.dart
@@ -59,7 +59,7 @@ class TextFieldIconBar extends StatelessWidget {
       };
 
   Widget _attachmentButton(BuildContext context) {
-    final hasBackground = ChatsSvc.getChatState(controller.chat.guid)?.customBackgroundPath.value?.isNotEmpty == true;
+    final hasBackground = ChatsSvc.getChatState(controller.chat.guid)?.hasCustomWallpaper ?? false;
     return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 10),
           child: IconButton(

--- a/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
@@ -27,7 +27,7 @@ class FindMyMapWidget extends StatelessWidget {
               initialCenter: controller.location.value == null
                   ? const LatLng(0, 0)
                   : LatLng(controller.location.value!.latitude, controller.location.value!.longitude),
-              onTap: (_, __) => controller.popupController.hideAllPopups(),
+              onTap: (_, _) => controller.popupController.hideAllPopups(),
               keepAlive: true,
               interactionOptions: InteractionOptions(
                 flags: InteractiveFlag.all & ~InteractiveFlag.rotate,

--- a/lib/app/layouts/settings/pages/contacts/contacts_management_helpers.dart
+++ b/lib/app/layouts/settings/pages/contacts/contacts_management_helpers.dart
@@ -32,8 +32,6 @@ mixin ContactsManagementHelpersMixin {
   /// Display label for an account row: `{'name': String, 'type': String, 'count': int}`.
   String accountLabel(Map<String, dynamic> account) => account['name'] as String? ?? 'Unknown account';
 
-  String accountSubtitle(Map<String, dynamic> account) => account['type'] as String? ?? '';
-
   int accountCount(Map<String, dynamic> account) => account['count'] as int? ?? 0;
 
   static const ContactAccountIcon _defaultAccountIcon = ContactAccountIcon(Icons.person_outline_rounded, Colors.blueGrey);

--- a/lib/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart
+++ b/lib/app/layouts/settings/pages/contacts/cupertino_contacts_management_panel.dart
@@ -155,7 +155,7 @@ class CupertinoContactsManagementPanel extends StatelessWidget with ContactsMana
                       containerColor: accountIcon(account).color,
                     ),
                     title: accountLabel(account),
-                    subtitle: "${accountSubtitle(account)} • ${accountCount(account)} contacts",
+                    subtitle: "${accountCount(account)} contacts",
                     trailing: controller.isAccountSelected(account)
                         ? const Icon(CupertinoIcons.check_mark, color: Colors.blueAccent)
                         : null,

--- a/lib/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart
+++ b/lib/app/layouts/settings/pages/contacts/widgets/contacts_expressive_body.dart
@@ -159,7 +159,7 @@ class ContactsExpressiveBody extends StatelessWidget with ContactsManagementHelp
                     icon: accountIcon(account).icon,
                     iconColor: accountIcon(account).color,
                     title: accountLabel(account),
-                    supportingText: "${accountSubtitle(account)} • ${accountCount(account)} contacts",
+                    supportingText: "${accountCount(account)} contacts",
                     trailing: controller.isAccountSelected(account)
                         ? Icon(Icons.check_rounded, color: context.theme.colorScheme.primary)
                         : null,

--- a/lib/app/layouts/settings/pages/desktop/desktop_panel.dart
+++ b/lib/app/layouts/settings/pages/desktop/desktop_panel.dart
@@ -382,152 +382,150 @@ class _DesktopPanelState extends State<DesktopPanel> with ThemeHelpers {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: <Widget>[
                             Expanded(
-                              child: Container(
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: <Widget>[
-                                    if (Platform.isWindows)
-                                      SettingsSwitch(
-                                        initialVal: SettingsSvc.settings.showReplyField.value,
-                                        onChanged: (value) async {
-                                          SettingsSvc.settings.showReplyField.value = value;
-                                          maxActions.value = value ? 4 : 5;
-                                          if (SettingsSvc.settings.selectedActionIndices.length > maxActions.value) {
-                                            SettingsSvc.settings.selectedActionIndices.removeLast();
-                                          }
-                                          await SettingsSvc.settings.saveOneAsync('showReplyField');
-                                        },
-                                        leading: const SettingsLeadingIcon(
-                                          iosIcon: CupertinoIcons.arrowshape_turn_up_left,
-                                          materialIcon: Icons.reply_outlined,
-                                          containerColor: Colors.orange,
-                                        ),
-                                        title: "Show Reply Field",
-                                        subtitle:
-                                            "Show a reply field in the notification. This counts as one of your actions.",
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: <Widget>[
+                                  if (Platform.isWindows)
+                                    SettingsSwitch(
+                                      initialVal: SettingsSvc.settings.showReplyField.value,
+                                      onChanged: (value) async {
+                                        SettingsSvc.settings.showReplyField.value = value;
+                                        maxActions.value = value ? 4 : 5;
+                                        if (SettingsSvc.settings.selectedActionIndices.length > maxActions.value) {
+                                          SettingsSvc.settings.selectedActionIndices.removeLast();
+                                        }
+                                        await SettingsSvc.settings.saveOneAsync('showReplyField');
+                                      },
+                                      leading: const SettingsLeadingIcon(
+                                        iosIcon: CupertinoIcons.arrowshape_turn_up_left,
+                                        materialIcon: Icons.reply_outlined,
+                                        containerColor: Colors.orange,
                                       ),
-                                    Padding(
-                                      padding: const EdgeInsets.all(15),
-                                      child: Center(
-                                        child: ReorderableWrap(
-                                          needsLongPressDraggable: false,
-                                          spacing: 10,
-                                          alignment: WrapAlignment.center,
-                                          buildDraggableFeedback: (context, constraints, child) => AnimatedScale(
-                                              duration: const Duration(milliseconds: 250), scale: 1.1, child: child),
-                                          onReorder: (int oldIndex, int newIndex) async {
-                                            List<String> selected = SettingsSvc.settings.selectedActionIndices
-                                                .map((index) => SettingsSvc.settings.actionList[index])
-                                                .toList();
-                                            String? temp = SettingsSvc.settings.actionList[oldIndex];
-                                            // If dragging to the right
-                                            for (int i = oldIndex; i <= newIndex - 1; i++) {
-                                              SettingsSvc.settings.actionList[i] =
-                                                  SettingsSvc.settings.actionList[i + 1];
-                                            }
-                                            // If dragging to the left
-                                            for (int i = oldIndex; i >= newIndex + 1; i--) {
-                                              SettingsSvc.settings.actionList[i] =
-                                                  SettingsSvc.settings.actionList[i - 1];
-                                            }
-                                            SettingsSvc.settings.actionList[newIndex] = temp;
-
-                                            List<int> selectedIndices = selected
-                                                .map((s) => SettingsSvc.settings.actionList.indexOf(s))
-                                                .toList();
-                                            selectedIndices.sort();
-                                            SettingsSvc.settings.selectedActionIndices.value = selectedIndices;
-                                            await SettingsSvc.settings.saveOneAsync('selectedActionIndices');
-                                          },
-                                          children: List.generate(
-                                            ReactionTypes.toList().length + 1,
-                                            (int index) => MouseRegion(
-                                              cursor: MouseCursor.defer,
-                                              onEnter: (event) => showButtons[index] = true,
-                                              onExit: (event) => showButtons[index] = false,
-                                              child: Obx(
-                                                () {
-                                                  bool selected =
-                                                      SettingsSvc.settings.selectedActionIndices.contains(index);
-
-                                                  String value = SettingsSvc.settings.actionList[index];
-
-                                                  bool disabled = (!SettingsSvc.settings.enablePrivateAPI.value &&
-                                                      value != "Mark Read");
-
-                                                  bool hardDisabled = (!selected &&
-                                                      (SettingsSvc.settings.selectedActionIndices.length ==
-                                                          maxActions.value));
-
-                                                  Color color = selected
-                                                      ? context.theme.colorScheme.primary
-                                                      : context.theme.colorScheme.surfaceContainerHighest
-                                                          .lightenOrDarken(10);
-
-                                                  return MouseRegion(
-                                                    cursor: hardDisabled ? SystemMouseCursors.basic : MouseCursor.defer,
-                                                    child: GestureDetector(
-                                                      behavior: HitTestBehavior.translucent,
-                                                      onTap: () async {
-                                                        if (hardDisabled) return;
-                                                        if (!SettingsSvc.settings.selectedActionIndices.remove(index)) {
-                                                          SettingsSvc.settings.selectedActionIndices.add(index);
-                                                          SettingsSvc.settings.selectedActionIndices.sort();
-                                                        }
-
-                                                        await SettingsSvc.settings
-                                                            .saveOneAsync('selectedActionIndices');
-                                                      },
-                                                      child: AnimatedContainer(
-                                                        margin: const EdgeInsets.symmetric(vertical: 5),
-                                                        height: 56,
-                                                        width: 90,
-                                                        padding: const EdgeInsets.symmetric(horizontal: 9),
-                                                        decoration: BoxDecoration(
-                                                          borderRadius: BorderRadius.circular(8),
-                                                          border: Border.all(
-                                                              color: color.withValues(alpha: selected ? 1 : 0.5),
-                                                              width: selected ? 1.5 : 1),
-                                                          color: color.withValues(
-                                                              alpha: disabled
-                                                                  ? 0.2
-                                                                  : selected
-                                                                      ? 0.8
-                                                                      : 0.7),
-                                                        ),
-                                                        foregroundDecoration: BoxDecoration(
-                                                          color: color.withValues(
-                                                              alpha: hardDisabled || disabled ? 0.7 : 0),
-                                                          borderRadius: BorderRadius.circular(8),
-                                                        ),
-                                                        curve: Curves.linear,
-                                                        duration: const Duration(milliseconds: 150),
-                                                        child: Center(
-                                                          child: Material(
-                                                            color: Colors.transparent,
-                                                            child: Text(
-                                                              ReactionTypes.reactionToEmoji[value] ?? "Mark Read",
-                                                              style: TextStyle(
-                                                                  fontSize: 16,
-                                                                  color: (hardDisabled && value == "Mark Read")
-                                                                      ? context.textTheme.titleMedium!.color
-                                                                      : null),
-                                                              textAlign: TextAlign.center,
-                                                            ),
+                                      title: "Show Reply Field",
+                                      subtitle:
+                                          "Show a reply field in the notification. This counts as one of your actions.",
+                                    ),
+                                  Padding(
+                                    padding: const EdgeInsets.all(15),
+                                    child: Center(
+                                      child: ReorderableWrap(
+                                        needsLongPressDraggable: false,
+                                        spacing: 10,
+                                        alignment: WrapAlignment.center,
+                                        buildDraggableFeedback: (context, constraints, child) => AnimatedScale(
+                                            duration: const Duration(milliseconds: 250), scale: 1.1, child: child),
+                                        onReorder: (int oldIndex, int newIndex) async {
+                                          List<String> selected = SettingsSvc.settings.selectedActionIndices
+                                              .map((index) => SettingsSvc.settings.actionList[index])
+                                              .toList();
+                                          String? temp = SettingsSvc.settings.actionList[oldIndex];
+                                          // If dragging to the right
+                                          for (int i = oldIndex; i <= newIndex - 1; i++) {
+                                            SettingsSvc.settings.actionList[i] =
+                                                SettingsSvc.settings.actionList[i + 1];
+                                          }
+                                          // If dragging to the left
+                                          for (int i = oldIndex; i >= newIndex + 1; i--) {
+                                            SettingsSvc.settings.actionList[i] =
+                                                SettingsSvc.settings.actionList[i - 1];
+                                          }
+                                          SettingsSvc.settings.actionList[newIndex] = temp;
+                              
+                                          List<int> selectedIndices = selected
+                                              .map((s) => SettingsSvc.settings.actionList.indexOf(s))
+                                              .toList();
+                                          selectedIndices.sort();
+                                          SettingsSvc.settings.selectedActionIndices.value = selectedIndices;
+                                          await SettingsSvc.settings.saveOneAsync('selectedActionIndices');
+                                        },
+                                        children: List.generate(
+                                          ReactionTypes.toList().length + 1,
+                                          (int index) => MouseRegion(
+                                            cursor: MouseCursor.defer,
+                                            onEnter: (event) => showButtons[index] = true,
+                                            onExit: (event) => showButtons[index] = false,
+                                            child: Obx(
+                                              () {
+                                                bool selected =
+                                                    SettingsSvc.settings.selectedActionIndices.contains(index);
+                              
+                                                String value = SettingsSvc.settings.actionList[index];
+                              
+                                                bool disabled = (!SettingsSvc.settings.enablePrivateAPI.value &&
+                                                    value != "Mark Read");
+                              
+                                                bool hardDisabled = (!selected &&
+                                                    (SettingsSvc.settings.selectedActionIndices.length ==
+                                                        maxActions.value));
+                              
+                                                Color color = selected
+                                                    ? context.theme.colorScheme.primary
+                                                    : context.theme.colorScheme.surfaceContainerHighest
+                                                        .lightenOrDarken(10);
+                              
+                                                return MouseRegion(
+                                                  cursor: hardDisabled ? SystemMouseCursors.basic : MouseCursor.defer,
+                                                  child: GestureDetector(
+                                                    behavior: HitTestBehavior.translucent,
+                                                    onTap: () async {
+                                                      if (hardDisabled) return;
+                                                      if (!SettingsSvc.settings.selectedActionIndices.remove(index)) {
+                                                        SettingsSvc.settings.selectedActionIndices.add(index);
+                                                        SettingsSvc.settings.selectedActionIndices.sort();
+                                                      }
+                              
+                                                      await SettingsSvc.settings
+                                                          .saveOneAsync('selectedActionIndices');
+                                                    },
+                                                    child: AnimatedContainer(
+                                                      margin: const EdgeInsets.symmetric(vertical: 5),
+                                                      height: 56,
+                                                      width: 90,
+                                                      padding: const EdgeInsets.symmetric(horizontal: 9),
+                                                      decoration: BoxDecoration(
+                                                        borderRadius: BorderRadius.circular(8),
+                                                        border: Border.all(
+                                                            color: color.withValues(alpha: selected ? 1 : 0.5),
+                                                            width: selected ? 1.5 : 1),
+                                                        color: color.withValues(
+                                                            alpha: disabled
+                                                                ? 0.2
+                                                                : selected
+                                                                    ? 0.8
+                                                                    : 0.7),
+                                                      ),
+                                                      foregroundDecoration: BoxDecoration(
+                                                        color: color.withValues(
+                                                            alpha: hardDisabled || disabled ? 0.7 : 0),
+                                                        borderRadius: BorderRadius.circular(8),
+                                                      ),
+                                                      curve: Curves.linear,
+                                                      duration: const Duration(milliseconds: 150),
+                                                      child: Center(
+                                                        child: Material(
+                                                          color: Colors.transparent,
+                                                          child: Text(
+                                                            ReactionTypes.reactionToEmoji[value] ?? "Mark Read",
+                                                            style: TextStyle(
+                                                                fontSize: 16,
+                                                                color: (hardDisabled && value == "Mark Read")
+                                                                    ? context.textTheme.titleMedium!.color
+                                                                    : null),
+                                                            textAlign: TextAlign.center,
                                                           ),
                                                         ),
                                                       ),
                                                     ),
-                                                  );
-                                                },
-                                              ),
+                                                  ),
+                                                );
+                                              },
                                             ),
                                           ),
                                         ),
                                       ),
                                     ),
-                                  ],
-                                ),
+                                  ),
+                                ],
                               ),
                             ),
                             if (Platform.isWindows)

--- a/lib/app/layouts/settings/pages/scheduling/cupertino_create_scheduled_panel.dart
+++ b/lib/app/layouts/settings/pages/scheduling/cupertino_create_scheduled_panel.dart
@@ -289,7 +289,7 @@ class _CupertinoCreateScheduledMessageState extends State<CupertinoCreateSchedul
                     padding: const EdgeInsets.all(15),
                     child: ValueListenableBuilder(
                       valueListenable: messageController,
-                      builder: (context, _, __) {
+                      builder: (context, _, _) {
                         if (error != null) return Text(error, style: const TextStyle(color: Colors.red));
                         final chat = ChatsSvc.findChatByGuid(selectedChat.value);
                         return Text(

--- a/lib/app/layouts/settings/pages/scheduling/material_create_scheduled_panel.dart
+++ b/lib/app/layouts/settings/pages/scheduling/material_create_scheduled_panel.dart
@@ -279,7 +279,7 @@ class _MaterialCreateScheduledMessageState extends State<MaterialCreateScheduled
                         padding: const EdgeInsets.all(15),
                         child: ValueListenableBuilder(
                           valueListenable: messageController,
-                          builder: (context, _, __) {
+                          builder: (context, _, _) {
                             if (error != null) return Text(error, style: const TextStyle(color: Colors.red));
                             final chat = ChatsSvc.findChatByGuid(selectedChat.value);
                             return Text(

--- a/lib/app/layouts/settings/pages/scheduling/samsung_create_scheduled_panel.dart
+++ b/lib/app/layouts/settings/pages/scheduling/samsung_create_scheduled_panel.dart
@@ -313,7 +313,7 @@ class _SamsungCreateScheduledMessageState extends State<SamsungCreateScheduledMe
                         padding: const EdgeInsets.all(15),
                         child: ValueListenableBuilder(
                           valueListenable: messageController,
-                          builder: (context, _, __) {
+                          builder: (context, _, _) {
                             if (error != null) return Text(error, style: const TextStyle(color: Colors.red));
                             final chat = ChatsSvc.findChatByGuid(selectedChat.value);
                             return Text(

--- a/lib/app/layouts/settings/pages/server/backup_restore_panel.dart
+++ b/lib/app/layouts/settings/pages/server/backup_restore_panel.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:bluebubbles/app/components/m3e/m3e.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/server/backup_restore_actions.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/server/backup_restore_dialogs.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/server/backup_restore_types.dart';
@@ -47,818 +48,724 @@ class _BackupRestorePanelState extends State<BackupRestorePanel> with ThemeHelpe
     fetching.value = ok ? false : null;
   }
 
-  void deleteSettings(String name) {
-    BackupRestoreActions.deleteSettings(settings: settings, name: name);
+  void refresh() {
+    fetching.value = true;
+    settings.clear();
+    themes.clear();
+    getBackups();
   }
 
-  void deleteTheme(String name) {
-    BackupRestoreActions.deleteTheme(themes: themes, name: name);
-  }
+  Future<String> defaultName() => BackupRestoreActions.defaultDeviceName();
 
-  Future<String> defaultName() async {
-    return BackupRestoreActions.defaultDeviceName();
-  }
-
-  Future<BackupDestination?> showMethodDialog() async {
-    return BackupRestoreDialogs.showBackupDestinationDialog(context);
-  }
+  Future<BackupDestination?> showMethodDialog() => BackupRestoreDialogs.showBackupDestinationDialog(context);
 
   @override
   Widget build(BuildContext context) {
     return Obx(() => SettingsScaffold(
-            title: "Backup and Restore",
-            initialHeader: fetching.value == false ? "Settings Backups" : null,
-            iosSubtitle: iosSubtitle,
-            materialSubtitle: materialSubtitle,
-            tileColor: tileColor,
-            headerColor: headerColor,
-            actions: [
-              IconButton(
-                icon: Icon(iOS ? CupertinoIcons.arrow_counterclockwise : Icons.refresh,
-                    color: context.theme.colorScheme.onSurface),
-                onPressed: () {
-                  fetching.value = true;
-                  settings.clear();
-                  themes.clear();
-                  getBackups();
-                },
-              ),
-            ],
-            bodySlivers: [
-              SliverList(
-                delegate: SliverChildListDelegate([
-                  if (fetching.value == null || fetching.value == true)
-                    Center(
-                      child: Padding(
-                        padding: const EdgeInsets.only(top: 100),
-                        child: Column(
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: Text(
-                                fetching.value == null ? "Something went wrong!" : "Getting backups...",
-                                style: context.theme.textTheme.labelLarge,
-                              ),
-                            ),
-                            if (fetching.value == true) buildProgressIndicator(context, size: 15),
-                          ],
-                        ),
-                      ),
-                    ),
-                  if (fetching == false)
-                    SettingsSection(
-                      backgroundColor: tileColor,
+        title: "Backup and Restore",
+        initialHeader: null,
+        iosSubtitle: iosSubtitle,
+        materialSubtitle: materialSubtitle,
+        tileColor: tileColor,
+        headerColor: headerColor,
+        minimalAppBar: true,
+        actions: [
+          IconButton(
+            icon: Icon(iOS ? CupertinoIcons.arrow_counterclockwise : Icons.refresh,
+                color: context.theme.colorScheme.onSurface),
+            onPressed: refresh,
+          ),
+        ],
+        bodySlivers: [
+          SliverList(
+            delegate: SliverChildListDelegate([
+              if (fetching.value == null || fetching.value == true)
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 100),
+                    child: Column(
                       children: [
-                        if (settings.isNotEmpty)
-                          Material(
-                            color: Colors.transparent,
-                            child: ListView.builder(
-                              physics: const NeverScrollableScrollPhysics(),
-                              shrinkWrap: true,
-                              findChildIndexCallback: (key) =>
-                                  findChildIndexByKey(settings, key, (item) => item["name"]),
-                              itemBuilder: (context, index) {
-                                final item = settings[index];
-                                return ListTile(
-                                  key: ValueKey(item["name"]),
-                                  contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
-                                  mouseCursor: MouseCursor.defer,
-                                  title: RichText(
-                                    text: TextSpan(
-                                      style: context.textTheme.titleMedium,
-                                      children: [
-                                        TextSpan(text: item["name"]),
-                                        const TextSpan(text: "\n"),
-                                        TextSpan(
-                                          text: (item["timestamp"] is int)
-                                              ? DateFormat("MMMM d, yyyy h:mm:ss a")
-                                                  .format(DateTime.fromMillisecondsSinceEpoch(item["timestamp"]))
-                                              : null,
-                                          style: context.textTheme.titleSmall!
-                                              .copyWith(color: context.theme.colorScheme.outline),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                  subtitle: !isNullOrEmpty(item["description"]) ? Text(item["description"]) : null,
-                                  trailing: Row(mainAxisSize: MainAxisSize.min, children: [
-                                    IconButton(
-                                        icon: Icon(iOS ? CupertinoIcons.arrow_2_circlepath : Icons.sync),
-                                        onPressed: () {
-                                          BackupRestoreDialogs.showConfirmation(
-                                            context: context,
-                                            title: "Overwrite Backup?",
-                                            content: const Text(
-                                              "Are you sure you want to replace this backup with your current Settings?",
-                                            ),
-                                            onYes: () async {
-                                              Map<String, dynamic> json = SettingsSvc.settings.toMap(includeAll: false);
-                                              json["description"] = item["description"];
-                                              json["timestamp"] = DateTime.now().millisecondsSinceEpoch;
-                                              json["pinnedChats"] = PinnedChatsBackup.exportList();
-                                              json["customGroups"] = await CustomGroupsBackup.exportList();
-                                              Response response = await HttpSvc.backup.setSettings(item["name"], json);
-                                              Navigator.of(context, rootNavigator: true).pop();
-                                              if (response.statusCode != 200) {
-                                                showSnackbar(
-                                                  "Error",
-                                                  "Somthing went wrong",
-                                                );
-                                              } else {
-                                                showSnackbar(
-                                                  "Success",
-                                                  "Settings exported successfully to server",
-                                                );
-                                              }
-                                              fetching.value = true;
-                                              settings.clear();
-                                              themes.clear();
-                                              getBackups();
-                                            },
-                                          );
-                                        }),
-                                    IconButton(
-                                        icon: Icon(iOS ? CupertinoIcons.trash : Icons.delete_outlined),
-                                        onPressed: () {
-                                          BackupRestoreDialogs.showConfirmation(
-                                            context: context,
-                                            title: "Delete Backup?",
-                                            content:
-                                                const Text("Are you sure you want to delete this settings backup?"),
-                                            onYes: () {
-                                              deleteSettings(item["name"]);
-                                              Navigator.of(context, rootNavigator: true).pop();
-                                            },
-                                          );
-                                        })
-                                  ]),
-                                  onTap: () {
-                                    BackupRestoreDialogs.showConfirmation(
-                                      context: context,
-                                      title: "Restore Backup?",
-                                      content: const Text(
-                                        "Are you sure you want to restore this backup, overwriting your current Settings?",
-                                      ),
-                                      onYes: () async {
-                                        Navigator.of(context, rootNavigator: true).pop();
-                                        try {
-                                          Settings.updateFromMap(item);
-                                          showSnackbar("Success", "Settings restored successfully");
-                                          final pinnedChats = item["pinnedChats"] as List<dynamic>?;
-                                          if (pinnedChats != null) {
-                                            final result = await PinnedChatsBackup.restore(pinnedChats);
-                                            if (result.skipped.isNotEmpty && context.mounted) {
-                                              BackupRestoreDialogs.showRestoreSummary(
-                                                context: context,
-                                                title: "Some Pinned Chats Couldn't Be Restored",
-                                                skipped: result.skipped,
-                                              );
-                                            }
-                                          }
-                                          final customGroups = item["customGroups"] as List<dynamic>?;
-                                          if (customGroups != null) {
-                                            final result = await CustomGroupsBackup.restore(customGroups);
-                                            if (result.skipped.isNotEmpty && context.mounted) {
-                                              BackupRestoreDialogs.showRestoreSummary(
-                                                context: context,
-                                                title: "Some Custom Group Chats Couldn't Be Restored",
-                                                skipped: result.skipped,
-                                              );
-                                            }
-                                          }
-                                        } catch (e, s) {
-                                          Logger.error("Failed to restore settings backup!", error: e, trace: s);
-                                          showSnackbar(
-                                              "Error", "Failed to restore settings backup! Error: ${e.toString()}");
-                                        }
-                                      },
-                                    );
-                                  },
-                                  onLongPress: () async {
-                                    const encoder = JsonEncoder.withIndent("     ");
-                                    final str = encoder.convert(item);
-                                    BackupRestoreDialogs.showJsonData(
-                                      context: context,
-                                      title: "Settings Data",
-                                      jsonText: str,
-                                    );
-                                  },
-                                  isThreeLine: !isNullOrEmpty(item["description"]),
-                                );
-                              },
-                              itemCount: settings.length,
-                            ),
-                          ),
-                        Material(
-                          color: Colors.transparent,
-                          child: ListTile(
-                            mouseCursor: MouseCursor.defer,
-                            title: Text("Create New",
-                                style: context.theme.textTheme.bodyLarge!
-                                    .copyWith(color: context.theme.colorScheme.primary)),
-                            leading: Container(
-                              width: 40 * SettingsSvc.settings.avatarScale.value,
-                              height: 40 * SettingsSvc.settings.avatarScale.value,
-                              decoration: BoxDecoration(
-                                  color:
-                                      !iOS ? null : context.theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
-                                  shape: BoxShape.circle,
-                                  border: iOS ? null : Border.all(color: context.theme.colorScheme.primary, width: 3)),
-                              child: Icon(
-                                Icons.add,
-                                color: context.theme.colorScheme.primary,
-                                size: 20,
-                              ),
-                            ),
-                            onTap: () async {
-                              final destination = await showMethodDialog();
-                              if (destination == null) return;
-                              final deviceName = await defaultName();
-                              final TextEditingController nameController = TextEditingController(text: deviceName);
-                              final TextEditingController descController = TextEditingController();
-
-                              void onDone(_context) async {
-                                String name = nameController.text;
-                                final desc = descController.text;
-                                if (name.isEmpty) {
-                                  return showSnackbar("Error", "Provide a name!");
-                                } else if (settings.firstWhereOrNull((s) => s["name"] == name) != null) {
-                                  bool yes = false;
-                                  await BackupRestoreDialogs.showConfirmation(
-                                    context: _context,
-                                    title: "Overwrite Backup?",
-                                    content: const Text(
-                                      "Are you sure you want to replace this backup with your current Settings?",
-                                    ),
-                                    onYes: () {
-                                      // Confirmation dialog is on the root navigator (showBBDialog uses
-                                      // useRootNavigator: true), so it must be popped from there.
-                                      Navigator.of(_context, rootNavigator: true).pop();
-                                      yes = true;
-                                    },
-                                  );
-                                  if (!yes) return;
-                                }
-                                // Dismiss the name-entry dialog (also on the root navigator) before
-                                // performing the backup. Using the non-root navigator here would pop
-                                // the settings page instead, leaving the dialog stuck open.
-                                Navigator.of(_context, rootNavigator: true).pop();
-                                Map<String, dynamic> json = SettingsSvc.settings.toMap(includeAll: false);
-                                if (desc.isNotEmpty) {
-                                  json["description"] = desc;
-                                }
-                                final timestamp = DateTime.now().millisecondsSinceEpoch;
-                                json["timestamp"] = timestamp;
-                                json["pinnedChats"] = PinnedChatsBackup.exportList();
-                                json["customGroups"] = await CustomGroupsBackup.exportList();
-                                if (destination.isCloud) {
-                                  var response = await HttpSvc.backup.setSettings(name, json);
-                                  if (response.statusCode != 200) {
-                                    showSnackbar(
-                                      "Error",
-                                      "Somthing went wrong",
-                                    );
-                                  } else {
-                                    showSnackbar(
-                                      "Success",
-                                      "Settings exported successfully to server",
-                                    );
-                                  }
-                                } else {
-                                  if (kIsWeb) {
-                                    final bytes = utf8.encode(jsonEncode(json));
-                                    final content = base64.encode(bytes);
-                                    html.AnchorElement(
-                                        href: "data:application/octet-stream;charset=utf-16le;base64,$content")
-                                      ..setAttribute("download", "BB-Settings-$name.json")
-                                      ..click();
-                                    return;
-                                  }
-                                  final downloadsDir = await FilesystemSvc.downloadsDirectory;
-                                  String filePath = join(downloadsDir, "BB-Settings-$name.json");
-                                  final String jsonString = jsonEncode(json);
-                                  if (kIsDesktop) {
-                                    // Let the portal write the file: passing bytes lands it at the
-                                    // real chosen location (sandbox-safe) so reveal opens the right
-                                    // folder, instead of a separate write to a non-granted path.
-                                    String? _filePath = await FilePicker.saveFile(
-                                      initialDirectory: downloadsDir,
-                                      dialogTitle: 'Choose a location to save this file',
-                                      fileName: "BB-Settings-$name.json",
-                                      type: FileType.custom,
-                                      allowedExtensions: ["json"],
-                                      bytes: utf8.encode(jsonString),
-                                    );
-                                    if (_filePath == null) {
-                                      return showSnackbar('Failed', 'You didn\'t select a file path!');
-                                    }
-                                    filePath = _filePath;
-                                  } else {
-                                    File file = File(filePath);
-                                    await file.create(recursive: true);
-                                    await file.writeAsString(jsonString);
-                                  }
-                                  showSnackbar(
-                                    "Success",
-                                    "Settings exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
-                                    durationMs: kIsDesktop ? 4000 : 2000,
-                                    button: TextButton(
-                                      style: TextButton.styleFrom(
-                                        backgroundColor: Get.theme.colorScheme.secondary,
-                                      ),
-                                      onPressed: () {
-                                        if (kIsDesktop) {
-                                          revealInFileManager(filePath);
-                                        }
-                                        Share.files([filePath]);
-                                      },
-                                      child: Text(kIsDesktop ? "OPEN FOLDER" : "SHARE",
-                                          style: TextStyle(color: context.theme.colorScheme.onSecondary)),
-                                    ),
-                                  );
-                                }
-                                fetching.value = true;
-                                settings.clear();
-                                themes.clear();
-                                getBackups();
-                              }
-
-                              showBBDialog(
-                                context: context,
-                                title: "Settings Backup Creation",
-                                content: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    Focus(
-                                      onKeyEvent: (node, event) {
-                                        if (event is KeyDownEvent &&
-                                            !HardwareKeyboard.instance.isShiftPressed &&
-                                            event.logicalKey == LogicalKeyboardKey.tab) {
-                                          node.nextFocus();
-                                          return KeyEventResult.handled;
-                                        }
-                                        return KeyEventResult.ignored;
-                                      },
-                                      child: TextField(
-                                        cursorColor: context.theme.colorScheme.primary,
-                                        autocorrect: true,
-                                        autofocus: true,
-                                        controller: nameController,
-                                        textInputAction: TextInputAction.next,
-                                        decoration: InputDecoration(
-                                          enabledBorder: OutlineInputBorder(
-                                              borderSide: BorderSide(color: context.theme.colorScheme.outline),
-                                              borderRadius: BorderRadius.circular(20)),
-                                          focusedBorder: OutlineInputBorder(
-                                              borderSide: BorderSide(color: context.theme.colorScheme.primary),
-                                              borderRadius: BorderRadius.circular(20)),
-                                          labelText: "Name",
-                                        ),
-                                      ),
-                                    ),
-                                    const SizedBox(height: 10),
-                                    Focus(
-                                      onKeyEvent: (node, event) {
-                                        if (event is KeyDownEvent &&
-                                            HardwareKeyboard.instance.isShiftPressed &&
-                                            event.logicalKey == LogicalKeyboardKey.tab) {
-                                          node.previousFocus();
-                                          node.previousFocus(); // This is intentional. Should probably figure out why it's needed
-                                          return KeyEventResult.handled;
-                                        }
-                                        return KeyEventResult.ignored;
-                                      },
-                                      child: TextField(
-                                        cursorColor: context.theme.colorScheme.primary,
-                                        autocorrect: true,
-                                        autofocus: false,
-                                        controller: descController,
-                                        textInputAction: TextInputAction.next,
-                                        onSubmitted: (_) {
-                                          onDone.call(context);
-                                        },
-                                        decoration: InputDecoration(
-                                          enabledBorder: OutlineInputBorder(
-                                              borderSide: BorderSide(color: context.theme.colorScheme.outline),
-                                              borderRadius: BorderRadius.circular(20)),
-                                          focusedBorder: OutlineInputBorder(
-                                              borderSide: BorderSide(color: context.theme.colorScheme.primary),
-                                              borderRadius: BorderRadius.circular(20)),
-                                          labelText: "Description (Optional)",
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                actions: [
-                                  BBDialogAction(
-                                    text: "Cancel",
-                                    onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-                                  ),
-                                  BBDialogAction(
-                                    text: "OK",
-                                    isDefault: true,
-                                    onPressed: () => onDone.call(context),
-                                  ),
-                                ],
-                              );
-                            },
+                        Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(
+                            fetching.value == null ? "Something went wrong!" : "Getting backups...",
+                            style: context.theme.textTheme.labelLarge,
                           ),
                         ),
-                        Material(
-                          color: Colors.transparent,
-                          child: ListTile(
-                            mouseCursor: MouseCursor.defer,
-                            title: Text("Restore Local",
-                                style: context.theme.textTheme.bodyLarge!
-                                    .copyWith(color: context.theme.colorScheme.primary)),
-                            leading: Container(
-                              width: 40 * SettingsSvc.settings.avatarScale.value,
-                              height: 40 * SettingsSvc.settings.avatarScale.value,
-                              decoration: BoxDecoration(
-                                  color:
-                                      !iOS ? null : context.theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
-                                  shape: BoxShape.circle,
-                                  border: iOS ? null : Border.all(color: context.theme.colorScheme.primary, width: 3)),
-                              child: Icon(
-                                Icons.upload,
-                                color: context.theme.colorScheme.primary,
-                                size: 20,
-                              ),
-                            ),
-                            onTap: () async {
-                              final res = await FilePicker.pickFiles(
-                                  withData: true, type: FileType.custom, allowedExtensions: ["json"]);
-                              if (res == null || res.files.isEmpty || res.files.first.bytes == null) return;
-                              BackupRestoreDialogs.showConfirmation(
-                                context: context,
-                                title: "Restore Settings?",
-                                content: const Text(
-                                  "Are you sure you want to restore this backup, overwriting your current Settings?",
-                                ),
-                                onYes: () async {
-                                  Navigator.of(context, rootNavigator: true).pop();
-                                  try {
-                                    String jsonString = const Utf8Decoder().convert(res.files.first.bytes!);
-                                    Map<String, dynamic> json = jsonDecode(jsonString);
-                                    Settings.updateFromMap(json);
-                                    showSnackbar("Success", "Settings restored successfully");
-                                    final pinnedChats = json["pinnedChats"] as List<dynamic>?;
-                                    if (pinnedChats != null) {
-                                      final result = await PinnedChatsBackup.restore(pinnedChats);
-                                      if (result.skipped.isNotEmpty && context.mounted) {
-                                        BackupRestoreDialogs.showRestoreSummary(
-                                          context: context,
-                                          title: "Some Pinned Chats Couldn't Be Restored",
-                                          skipped: result.skipped,
-                                        );
-                                      }
-                                    }
-                                    final customGroups = json["customGroups"] as List<dynamic>?;
-                                    if (customGroups != null) {
-                                      final result = await CustomGroupsBackup.restore(customGroups);
-                                      if (result.skipped.isNotEmpty && context.mounted) {
-                                        BackupRestoreDialogs.showRestoreSummary(
-                                          context: context,
-                                          title: "Some Custom Group Chats Couldn't Be Restored",
-                                          skipped: result.skipped,
-                                        );
-                                      }
-                                    }
-                                  } catch (e, s) {
-                                    Logger.error("Failed to restore settings backup!", error: e, trace: s);
-                                    showSnackbar("Error", "Failed to restore settings backup! Error: ${e.toString()}");
-                                  }
-                                },
-                              );
-                            },
-                          ),
-                        ),
+                        if (fetching.value == true) buildProgressIndicator(context, size: 15),
                       ],
                     ),
-                  if (fetching == false)
-                    SettingsHeader(
-                      iosSubtitle: iosSubtitle,
-                      materialSubtitle: materialSubtitle,
-                      text: "Theme Backups",
-                    ),
-                  if (fetching == false)
-                    SettingsSection(
-                      backgroundColor: tileColor,
-                      children: [
-                        if (themes.isNotEmpty)
-                          Material(
-                            color: Colors.transparent,
-                            child: ListView.builder(
-                              physics: const NeverScrollableScrollPhysics(),
-                              shrinkWrap: true,
-                              findChildIndexCallback: (key) => findChildIndexByKey(themes, key, (item) => item['name']),
-                              itemBuilder: (context, index) {
-                                final item = themes[index];
-                                final data = item["data"];
-                                return ListTile(
-                                  key: ValueKey(item["name"]),
-                                  mouseCursor: MouseCursor.defer,
-                                  title: Text(item["name"]),
-                                  subtitle: !item.containsKey('data')
-                                      ? Text("Incompatible backup!",
-                                          style: context.theme.textTheme.bodyMedium!
-                                              .copyWith(color: context.theme.colorScheme.error))
-                                      : Text(
-                                          "${Brightness.values[data["colorScheme"]["brightness"]].name.capitalizeFirst!} theme"),
-                                  leading: !item.containsKey('data')
-                                      ? null
-                                      : Column(
-                                          mainAxisSize: MainAxisSize.min,
-                                          mainAxisAlignment: MainAxisAlignment.center,
-                                          children: <Widget>[
-                                            Row(
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: <Widget>[
-                                                Padding(
-                                                  padding: const EdgeInsets.all(3),
-                                                  child: Container(
-                                                    height: 12,
-                                                    width: 12,
-                                                    decoration: BoxDecoration(
-                                                      color: Color(data["colorScheme"]["primary"]),
-                                                      borderRadius: const BorderRadius.all(Radius.circular(4)),
-                                                    ),
-                                                  ),
-                                                ),
-                                                Padding(
-                                                  padding: const EdgeInsets.all(3),
-                                                  child: Container(
-                                                    height: 12,
-                                                    width: 12,
-                                                    decoration: BoxDecoration(
-                                                      color: Color(data["colorScheme"]["secondary"]),
-                                                      borderRadius: const BorderRadius.all(Radius.circular(4)),
-                                                    ),
-                                                  ),
-                                                ),
-                                              ],
-                                            ),
-                                            Row(
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: <Widget>[
-                                                Padding(
-                                                  padding: const EdgeInsets.all(3),
-                                                  child: Container(
-                                                    height: 12,
-                                                    width: 12,
-                                                    decoration: BoxDecoration(
-                                                      color: Color(data["colorScheme"]["primaryContainer"]),
-                                                      borderRadius: const BorderRadius.all(Radius.circular(4)),
-                                                    ),
-                                                  ),
-                                                ),
-                                                Padding(
-                                                  padding: const EdgeInsets.all(3),
-                                                  child: Container(
-                                                    height: 12,
-                                                    width: 12,
-                                                    decoration: BoxDecoration(
-                                                      color: Color(data["colorScheme"]["tertiary"]),
-                                                      borderRadius: const BorderRadius.all(Radius.circular(4)),
-                                                    ),
-                                                  ),
-                                                ),
-                                              ],
-                                            ),
-                                          ],
-                                        ),
-                                  trailing: IconButton(
-                                    icon: Icon(iOS ? CupertinoIcons.trash : Icons.delete_outlined),
-                                    onPressed: () {
-                                      BackupRestoreDialogs.showConfirmation(
-                                        context: context,
-                                        title: "Delete Backup?",
-                                        content: const Text("Are you sure you want to delete this theme backup?"),
-                                        onYes: () {
-                                          deleteTheme(item["name"]);
-                                          Navigator.of(context, rootNavigator: true).pop();
-                                        },
-                                      );
-                                    },
-                                  ),
-                                  onTap: () async {
-                                    if (!item.containsKey('data')) {
-                                      return showSnackbar("Error",
-                                          "This theme was created on the old theming engine and cannot be restored");
-                                    }
-                                    BackupRestoreDialogs.showConfirmation(
-                                      context: context,
-                                      title: "Restore Backup?",
-                                      content: const Text(
-                                        "Are you sure you want to restore this backup, overwriting your current theme?",
-                                      ),
-                                      onYes: () {
-                                        Navigator.of(context, rootNavigator: true).pop();
-                                        try {
-                                          ThemeStruct object = ThemeStruct.fromMap(item);
-                                          object.id = null;
-                                          object.save();
-                                          showSnackbar("Success", "Theme restored successfully");
-                                        } catch (e, s) {
-                                          Logger.error("Failed to restore theme backup!", error: e, trace: s);
-                                          showSnackbar(
-                                              "Error", "Failed to restore theme backup! Error: ${e.toString()}");
-                                        }
-                                      },
-                                    );
-                                  },
-                                  onLongPress: () async {
-                                    const encoder = JsonEncoder.withIndent("     ");
-                                    final str = encoder.convert(item);
-                                    BackupRestoreDialogs.showJsonData(
-                                      context: context,
-                                      title: "Theme Data",
-                                      jsonText: str,
-                                    );
-                                  },
-                                );
-                              },
-                              itemCount: themes.length,
-                            ),
-                          ),
-                        Material(
-                          color: Colors.transparent,
-                          child: ListTile(
-                            mouseCursor: MouseCursor.defer,
-                            title: Text("Create New",
-                                style: context.theme.textTheme.bodyLarge!
-                                    .copyWith(color: context.theme.colorScheme.primary)),
-                            leading: Container(
-                              width: 40 * SettingsSvc.settings.avatarScale.value,
-                              height: 40 * SettingsSvc.settings.avatarScale.value,
-                              decoration: BoxDecoration(
-                                  color:
-                                      !iOS ? null : context.theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
-                                  shape: BoxShape.circle,
-                                  border: iOS ? null : Border.all(color: context.theme.colorScheme.primary, width: 3)),
-                              child: Icon(
-                                Icons.add,
-                                color: context.theme.colorScheme.primary,
-                                size: 20,
-                              ),
-                            ),
-                            onTap: () async {
-                              final destination = await showMethodDialog();
-                              if (destination == null) return;
-                              List<ThemeStruct> allThemes =
-                                  ThemeStruct.getThemes().where((element) => !element.isPreset).toList();
-                              if (allThemes.isEmpty) {
-                                return showSnackbar(
-                                  "Notice",
-                                  "No custom themes found!",
-                                );
-                              }
-                              if (destination.isCloud) {
-                                bool errored = false;
-                                for (ThemeStruct e in allThemes) {
-                                  var response =
-                                      await HttpSvc.backup.setTheme(e.name.characters.take(50).string, e.toMap());
-                                  if (response.statusCode != 200) {
-                                    errored = true;
-                                  }
-                                }
-                                if (errored) {
-                                  showSnackbar(
-                                    "Error",
-                                    "Somthing went wrong",
-                                  );
-                                } else {
-                                  showSnackbar(
-                                    "Success",
-                                    "Themes exported successfully to server",
-                                  );
-                                }
-                              } else {
-                                final List<Map<String, dynamic>> themeData = [];
-                                for (ThemeStruct e in allThemes) {
-                                  themeData.add(e.toMap());
-                                }
-                                String jsonStr = jsonEncode(themeData);
-                                DateTime now = DateTime.now().toLocal();
-                                final themeFilename =
-                                    "BlueBubbles-theming-${now.year}${now.month}${now.day}_${now.hour}${now.minute}${now.second}.json";
-                                if (kIsWeb) {
-                                  final bytes = utf8.encode(jsonStr);
-                                  final content = base64.encode(bytes);
-                                  html.AnchorElement(
-                                      href: "data:application/octet-stream;charset=utf-16le;base64,$content")
-                                    ..setAttribute("download", themeFilename)
-                                    ..click();
-                                  return;
-                                }
-                                final downloadsDir = await FilesystemSvc.downloadsDirectory;
-                                String filePath = join(downloadsDir, themeFilename);
-                                if (kIsDesktop) {
-                                  // Let the portal write the file: passing bytes lands it at the
-                                  // real chosen location (sandbox-safe) so reveal opens the right
-                                  // folder, instead of a separate write to a non-granted path.
-                                  String? _filePath = await FilePicker.saveFile(
-                                    initialDirectory: downloadsDir,
-                                    dialogTitle: 'Choose a location to save this file',
-                                    fileName: themeFilename,
-                                    type: FileType.custom,
-                                    allowedExtensions: ["json"],
-                                    bytes: utf8.encode(jsonStr),
-                                  );
-                                  if (_filePath == null) {
-                                    return showSnackbar('Failed', 'You didn\'t select a file path!');
-                                  }
-                                  filePath = _filePath;
-                                } else {
-                                  File file = File(filePath);
-                                  await file.create(recursive: true);
-                                  await file.writeAsString(jsonStr);
-                                }
-                                showSnackbar(
-                                  "Success",
-                                  "Theming exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
-                                  durationMs: kIsDesktop ? 4000 : 2000,
-                                  button: TextButton(
-                                    style: TextButton.styleFrom(
-                                      backgroundColor: Get.theme.colorScheme.secondary,
-                                    ),
-                                    onPressed: () {
-                                      if (kIsDesktop) {
-                                        revealInFileManager(filePath);
-                                        return;
-                                      }
-                                      Share.files([filePath]);
-                                    },
-                                    child: Text(kIsDesktop ? "OPEN FOLDER" : "SHARE",
-                                        style: TextStyle(color: context.theme.colorScheme.onSecondary)),
-                                  ),
-                                );
-                              }
-                              fetching.value = true;
-                              settings.clear();
-                              themes.clear();
-                              getBackups();
-                            },
-                          ),
-                        ),
-                        Material(
-                          color: Colors.transparent,
-                          child: ListTile(
-                            mouseCursor: MouseCursor.defer,
-                            title: Text("Restore Local",
-                                style: context.theme.textTheme.bodyLarge!
-                                    .copyWith(color: context.theme.colorScheme.primary)),
-                            leading: Container(
-                              width: 40 * SettingsSvc.settings.avatarScale.value,
-                              height: 40 * SettingsSvc.settings.avatarScale.value,
-                              decoration: BoxDecoration(
-                                  color:
-                                      !iOS ? null : context.theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
-                                  shape: BoxShape.circle,
-                                  border: iOS ? null : Border.all(color: context.theme.colorScheme.primary, width: 3)),
-                              child: Icon(
-                                Icons.upload,
-                                color: context.theme.colorScheme.primary,
-                                size: 20,
-                              ),
-                            ),
-                            onTap: () async {
-                              final res = await FilePicker.pickFiles(
-                                  withData: true, type: FileType.custom, allowedExtensions: ["json"]);
-                              if (res == null || res.files.isEmpty || res.files.first.bytes == null) return;
-
-                              BackupRestoreDialogs.showConfirmation(
-                                context: context,
-                                title: "Restore Backup?",
-                                content: const Text(
-                                  "Are you sure you want to restore this backup, overwriting your current theme?",
-                                ),
-                                onYes: () {
-                                  Navigator.of(context, rootNavigator: true).pop();
-                                  try {
-                                    String jsonString = const Utf8Decoder().convert(res.files.first.bytes!);
-                                    List<dynamic> json = jsonDecode(jsonString);
-                                    for (var e in json) {
-                                      ThemeStruct object = ThemeStruct.fromMap(e);
-                                      if (object.isPreset) continue;
-                                      object.id = null;
-                                      object.save();
-                                    }
-                                    showSnackbar("Success", "Theming restored successfully");
-                                  } catch (e, s) {
-                                    Logger.error("Failed to restore theme backup!", error: e, trace: s);
-                                    showSnackbar("Error", "Failed to restore theme backup! Error: ${e.toString()}");
-                                  }
-                                },
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                ]),
-              ),
-            ]));
+                  ),
+                ),
+              if (fetching.value == false) _buildSectionHeader("Settings Backups"),
+              if (fetching.value == false) _buildBackupSection(BackupKind.settings),
+              if (fetching.value == false) _buildSectionHeader("Theme Backups"),
+              if (fetching.value == false) _buildBackupSection(BackupKind.theme),
+            ]),
+          ),
+        ]));
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // Section / row building
+  // ---------------------------------------------------------------------------------------------
+
+  // SettingsHeader renders as a blank spacer on Samsung skin (by design elsewhere in the app,
+  // where Samsung's hero app bar carries the section title instead). This page wants an explicit
+  // label on every skin, so Material/Samsung get the M3E section label primitive instead.
+  Widget _buildSectionHeader(String text) {
+    if (iOS) {
+      return SettingsHeader(iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: text);
+    }
+    return M3ESectionHeader(label: text);
+  }
+
+  Widget _buildBackupSection(BackupKind kind) {
+    final items = kind == BackupKind.settings ? settings : themes;
+    return SettingsSection(
+      backgroundColor: tileColor,
+      children: [
+        if (items.isEmpty) _buildEmptyState(kind),
+        for (int i = 0; i < items.length; i++) ...[
+          if (i > 0) const SettingsDivider(),
+          _buildBackupTile(kind, items[i]),
+        ],
+        const SettingsDivider(),
+        _buildActionsRow(kind),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(BackupKind kind) {
+    final isSettings = kind == BackupKind.settings;
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        child: Column(
+          children: [
+            Icon(
+              isSettings
+                  ? (iOS ? CupertinoIcons.doc_text : Icons.description_outlined)
+                  : (iOS ? CupertinoIcons.paintbrush : Icons.palette_outlined),
+              color: context.theme.colorScheme.outline.withValues(alpha: 0.5),
+              size: 32,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              isSettings ? "No settings backups yet" : "No theme backups yet",
+              textAlign: TextAlign.center,
+              style: context.theme.textTheme.bodyMedium!
+                  .copyWith(color: context.theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.75)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBackupTile(BackupKind kind, Map<String, dynamic> item) {
+    if (kind == BackupKind.settings) {
+      final hasDescription = !isNullOrEmpty(item["description"]);
+      final timestamp = (item["timestamp"] is int)
+          ? DateFormat("MMMM d, yyyy h:mm:ss a").format(DateTime.fromMillisecondsSinceEpoch(item["timestamp"]))
+          : null;
+      return SettingsTile(
+        key: ValueKey(item["name"]),
+        backgroundColor: tileColor,
+        title: item["name"],
+        subtitle: hasDescription ? "$timestamp\n${item["description"]}" : timestamp,
+        isThreeLine: hasDescription,
+        leading: const SettingsLeadingIcon(
+          iosIcon: CupertinoIcons.doc_text,
+          materialIcon: Icons.description_outlined,
+          containerColor: Colors.blueAccent,
+        ),
+        trailing: Row(mainAxisSize: MainAxisSize.min, children: [
+          IconButton(
+            icon: Icon(iOS ? CupertinoIcons.arrow_2_circlepath : Icons.sync),
+            onPressed: () => _syncSettingsBackup(item),
+          ),
+          IconButton(
+            icon: Icon(iOS ? CupertinoIcons.trash : Icons.delete_outlined),
+            onPressed: () => _confirmDeleteSettingsBackup(item),
+          ),
+        ]),
+        onTap: () => _confirmRestoreSettingsBackup(item),
+        onLongPress: () => _showJson(title: "Settings Data", item: item),
+      );
+    }
+
+    final hasData = item.containsKey('data');
+    final data = item["data"];
+    return SettingsTile(
+      key: ValueKey(item["name"]),
+      backgroundColor: tileColor,
+      title: item["name"],
+      subtitle: !hasData
+          ? "Incompatible backup!"
+          : "${Brightness.values[data["colorScheme"]["brightness"]].name.capitalizeFirst!} theme",
+      leading: !hasData ? null : _buildThemeSwatchLeading(data),
+      trailing: IconButton(
+        icon: Icon(iOS ? CupertinoIcons.trash : Icons.delete_outlined),
+        onPressed: () => _confirmDeleteThemeBackup(item),
+      ),
+      onTap: () => _confirmRestoreThemeBackup(item),
+      onLongPress: () => _showJson(title: "Theme Data", item: item),
+    );
+  }
+
+  Widget _buildThemeSwatchLeading(Map<String, dynamic> data) {
+    Widget swatch(int color) => Padding(
+          padding: const EdgeInsets.all(3),
+          child: Container(
+            height: 12,
+            width: 12,
+            decoration: BoxDecoration(
+              color: Color(color),
+              borderRadius: const BorderRadius.all(Radius.circular(4)),
+            ),
+          ),
+        );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Row(mainAxisSize: MainAxisSize.min, children: [
+          swatch(data["colorScheme"]["primary"]),
+          swatch(data["colorScheme"]["secondary"]),
+        ]),
+        Row(mainAxisSize: MainAxisSize.min, children: [
+          swatch(data["colorScheme"]["primaryContainer"]),
+          swatch(data["colorScheme"]["tertiary"]),
+        ]),
+      ],
+    );
+  }
+
+  Widget _buildActionsRow(BackupKind kind) {
+    const createLabel = "Create New";
+    const restoreLabel = "Restore Local";
+    final onCreate = () => _onCreateNew(kind);
+    final onRestore = () => _onRestoreLocal(kind);
+
+    if (iOS) {
+      return Column(children: [
+        SettingsTile(
+          backgroundColor: tileColor,
+          title: createLabel,
+          leading: SettingsLeadingIcon(
+            iosIcon: CupertinoIcons.add,
+            materialIcon: Icons.add,
+            containerColor: context.theme.colorScheme.primary,
+          ),
+          onTap: onCreate,
+        ),
+        const SettingsDivider(),
+        SettingsTile(
+          backgroundColor: tileColor,
+          title: restoreLabel,
+          leading: SettingsLeadingIcon(
+            iosIcon: CupertinoIcons.arrow_up_doc,
+            materialIcon: Icons.upload_outlined,
+            containerColor: context.theme.colorScheme.primary,
+          ),
+          onTap: onRestore,
+        ),
+      ]);
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: M3EButtonGroup(items: [
+        M3EButtonGroupItem(icon: Icons.add, label: createLabel, onPressed: onCreate),
+        M3EButtonGroupItem(icon: Icons.upload_outlined, label: restoreLabel, onPressed: onRestore),
+      ]),
+    );
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Settings backups — actions
+  // ---------------------------------------------------------------------------------------------
+
+  void _syncSettingsBackup(Map<String, dynamic> item) {
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Overwrite Backup?",
+      content: const Text(
+        "Are you sure you want to replace this backup with your current Settings?",
+      ),
+      onYes: () async {
+        Map<String, dynamic> json = SettingsSvc.settings.toMap(includeAll: false);
+        json["description"] = item["description"];
+        json["timestamp"] = DateTime.now().millisecondsSinceEpoch;
+        json["pinnedChats"] = PinnedChatsBackup.exportList();
+        json["customGroups"] = await CustomGroupsBackup.exportList();
+        Response response = await HttpSvc.backup.setSettings(item["name"], json);
+        if (!context.mounted) return;
+        Navigator.of(context, rootNavigator: true).pop();
+        if (response.statusCode != 200) {
+          showSnackbar("Error", "Somthing went wrong");
+        } else {
+          showSnackbar("Success", "Settings exported successfully to server");
+        }
+        refresh();
+      },
+    );
+  }
+
+  void _confirmDeleteSettingsBackup(Map<String, dynamic> item) {
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Delete Backup?",
+      content: const Text("Are you sure you want to delete this settings backup?"),
+      onYes: () {
+        BackupRestoreActions.deleteSettings(settings: settings, name: item["name"]);
+        Navigator.of(context, rootNavigator: true).pop();
+      },
+    );
+  }
+
+  void _confirmRestoreSettingsBackup(Map<String, dynamic> item) {
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Restore Backup?",
+      content: const Text(
+        "Are you sure you want to restore this backup, overwriting your current Settings?",
+      ),
+      onYes: () async {
+        Navigator.of(context, rootNavigator: true).pop();
+        try {
+          Settings.updateFromMap(item);
+          showSnackbar("Success", "Settings restored successfully");
+          final pinnedChats = item["pinnedChats"] as List<dynamic>?;
+          if (pinnedChats != null) {
+            final result = await PinnedChatsBackup.restore(pinnedChats);
+            if (result.skipped.isNotEmpty && context.mounted) {
+              BackupRestoreDialogs.showRestoreSummary(
+                context: context,
+                title: "Some Pinned Chats Couldn't Be Restored",
+                skipped: result.skipped,
+              );
+            }
+          }
+          final customGroups = item["customGroups"] as List<dynamic>?;
+          if (customGroups != null) {
+            final result = await CustomGroupsBackup.restore(customGroups);
+            if (result.skipped.isNotEmpty && context.mounted) {
+              BackupRestoreDialogs.showRestoreSummary(
+                context: context,
+                title: "Some Custom Group Chats Couldn't Be Restored",
+                skipped: result.skipped,
+              );
+            }
+          }
+        } catch (e, s) {
+          Logger.error("Failed to restore settings backup!", error: e, trace: s);
+          showSnackbar("Error", "Failed to restore settings backup! Error: ${e.toString()}");
+        }
+      },
+    );
+  }
+
+  Future<void> _createSettingsBackup() async {
+    final destination = await showMethodDialog();
+    if (destination == null || !context.mounted) return;
+    final deviceName = await defaultName();
+    final TextEditingController nameController = TextEditingController(text: deviceName);
+    final TextEditingController descController = TextEditingController();
+
+    void onDone(BuildContext _context) async {
+      String name = nameController.text;
+      final desc = descController.text;
+      if (name.isEmpty) {
+        return showSnackbar("Error", "Provide a name!");
+      } else if (settings.firstWhereOrNull((s) => s["name"] == name) != null) {
+        bool yes = false;
+        await BackupRestoreDialogs.showConfirmation(
+          context: _context,
+          title: "Overwrite Backup?",
+          content: const Text(
+            "Are you sure you want to replace this backup with your current Settings?",
+          ),
+          onYes: () {
+            // Confirmation dialog is on the root navigator (showBBDialog uses
+            // useRootNavigator: true), so it must be popped from there.
+            Navigator.of(_context, rootNavigator: true).pop();
+            yes = true;
+          },
+        );
+        if (!yes) return;
+      }
+      // Dismiss the name-entry dialog (also on the root navigator) before
+      // performing the backup. Using the non-root navigator here would pop
+      // the settings page instead, leaving the dialog stuck open.
+      Navigator.of(_context, rootNavigator: true).pop();
+      Map<String, dynamic> json = SettingsSvc.settings.toMap(includeAll: false);
+      if (desc.isNotEmpty) {
+        json["description"] = desc;
+      }
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      json["timestamp"] = timestamp;
+      json["pinnedChats"] = PinnedChatsBackup.exportList();
+      json["customGroups"] = await CustomGroupsBackup.exportList();
+      if (destination.isCloud) {
+        var response = await HttpSvc.backup.setSettings(name, json);
+        if (response.statusCode != 200) {
+          showSnackbar("Error", "Somthing went wrong");
+        } else {
+          showSnackbar("Success", "Settings exported successfully to server");
+        }
+      } else {
+        if (kIsWeb) {
+          final bytes = utf8.encode(jsonEncode(json));
+          final content = base64.encode(bytes);
+          html.AnchorElement(href: "data:application/octet-stream;charset=utf-16le;base64,$content")
+            ..setAttribute("download", "BB-Settings-$name.json")
+            ..click();
+          return;
+        }
+        final downloadsDir = await FilesystemSvc.downloadsDirectory;
+        String filePath = join(downloadsDir, "BB-Settings-$name.json");
+        final String jsonString = jsonEncode(json);
+        if (kIsDesktop) {
+          // Let the portal write the file: passing bytes lands it at the
+          // real chosen location (sandbox-safe) so reveal opens the right
+          // folder, instead of a separate write to a non-granted path.
+          String? _filePath = await FilePicker.saveFile(
+            initialDirectory: downloadsDir,
+            dialogTitle: 'Choose a location to save this file',
+            fileName: "BB-Settings-$name.json",
+            type: FileType.custom,
+            allowedExtensions: ["json"],
+            bytes: utf8.encode(jsonString),
+          );
+          if (_filePath == null) {
+            return showSnackbar('Failed', 'You didn\'t select a file path!');
+          }
+          filePath = _filePath;
+        } else {
+          File file = File(filePath);
+          await file.create(recursive: true);
+          await file.writeAsString(jsonString);
+        }
+        showSnackbar(
+          "Success",
+          "Settings exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
+          durationMs: kIsDesktop ? 4000 : 2000,
+          button: TextButton(
+            style: TextButton.styleFrom(backgroundColor: Get.theme.colorScheme.secondary),
+            onPressed: () {
+              if (kIsDesktop) {
+                revealInFileManager(filePath);
+              }
+              Share.files([filePath]);
+            },
+            child: Text(kIsDesktop ? "OPEN FOLDER" : "SHARE",
+                style: TextStyle(color: context.theme.colorScheme.onSecondary)),
+          ),
+        );
+      }
+      refresh();
+    }
+
+    if (!context.mounted) return;
+    showBBDialog(
+      context: context,
+      title: "Settings Backup Creation",
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Focus(
+            onKeyEvent: (node, event) {
+              if (event is KeyDownEvent &&
+                  !HardwareKeyboard.instance.isShiftPressed &&
+                  event.logicalKey == LogicalKeyboardKey.tab) {
+                node.nextFocus();
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: TextField(
+              cursorColor: context.theme.colorScheme.primary,
+              autocorrect: true,
+              autofocus: true,
+              controller: nameController,
+              textInputAction: TextInputAction.next,
+              decoration: InputDecoration(
+                enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: context.theme.colorScheme.outline),
+                    borderRadius: BorderRadius.circular(20)),
+                focusedBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: context.theme.colorScheme.primary),
+                    borderRadius: BorderRadius.circular(20)),
+                labelText: "Name",
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Focus(
+            onKeyEvent: (node, event) {
+              if (event is KeyDownEvent &&
+                  HardwareKeyboard.instance.isShiftPressed &&
+                  event.logicalKey == LogicalKeyboardKey.tab) {
+                node.previousFocus();
+                node.previousFocus(); // This is intentional. Should probably figure out why it's needed
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: TextField(
+              cursorColor: context.theme.colorScheme.primary,
+              autocorrect: true,
+              autofocus: false,
+              controller: descController,
+              textInputAction: TextInputAction.next,
+              onSubmitted: (_) => onDone.call(context),
+              decoration: InputDecoration(
+                enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: context.theme.colorScheme.outline),
+                    borderRadius: BorderRadius.circular(20)),
+                focusedBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: context.theme.colorScheme.primary),
+                    borderRadius: BorderRadius.circular(20)),
+                labelText: "Description (Optional)",
+              ),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        BBDialogAction(
+          text: "Cancel",
+          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+        ),
+        BBDialogAction(
+          text: "OK",
+          isDefault: true,
+          onPressed: () => onDone.call(context),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _restoreSettingsFromFile() async {
+    final res = await FilePicker.pickFiles(withData: true, type: FileType.custom, allowedExtensions: ["json"]);
+    if (res == null || res.files.isEmpty || res.files.first.bytes == null || !context.mounted) return;
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Restore Settings?",
+      content: const Text(
+        "Are you sure you want to restore this backup, overwriting your current Settings?",
+      ),
+      onYes: () async {
+        Navigator.of(context, rootNavigator: true).pop();
+        try {
+          String jsonString = const Utf8Decoder().convert(res.files.first.bytes!);
+          Map<String, dynamic> json = jsonDecode(jsonString);
+          Settings.updateFromMap(json);
+          showSnackbar("Success", "Settings restored successfully");
+          final pinnedChats = json["pinnedChats"] as List<dynamic>?;
+          if (pinnedChats != null) {
+            final result = await PinnedChatsBackup.restore(pinnedChats);
+            if (result.skipped.isNotEmpty && context.mounted) {
+              BackupRestoreDialogs.showRestoreSummary(
+                context: context,
+                title: "Some Pinned Chats Couldn't Be Restored",
+                skipped: result.skipped,
+              );
+            }
+          }
+          final customGroups = json["customGroups"] as List<dynamic>?;
+          if (customGroups != null) {
+            final result = await CustomGroupsBackup.restore(customGroups);
+            if (result.skipped.isNotEmpty && context.mounted) {
+              BackupRestoreDialogs.showRestoreSummary(
+                context: context,
+                title: "Some Custom Group Chats Couldn't Be Restored",
+                skipped: result.skipped,
+              );
+            }
+          }
+        } catch (e, s) {
+          Logger.error("Failed to restore settings backup!", error: e, trace: s);
+          showSnackbar("Error", "Failed to restore settings backup! Error: ${e.toString()}");
+        }
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Theme backups — actions
+  // ---------------------------------------------------------------------------------------------
+
+  void _confirmDeleteThemeBackup(Map<String, dynamic> item) {
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Delete Backup?",
+      content: const Text("Are you sure you want to delete this theme backup?"),
+      onYes: () {
+        BackupRestoreActions.deleteTheme(themes: themes, name: item["name"]);
+        Navigator.of(context, rootNavigator: true).pop();
+      },
+    );
+  }
+
+  void _confirmRestoreThemeBackup(Map<String, dynamic> item) {
+    if (!item.containsKey('data')) {
+      showSnackbar("Error", "This theme was created on the old theming engine and cannot be restored");
+      return;
+    }
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Restore Backup?",
+      content: const Text(
+        "Are you sure you want to restore this backup, overwriting your current theme?",
+      ),
+      onYes: () {
+        Navigator.of(context, rootNavigator: true).pop();
+        try {
+          ThemeStruct object = ThemeStruct.fromMap(item);
+          object.id = null;
+          object.save();
+          showSnackbar("Success", "Theme restored successfully");
+        } catch (e, s) {
+          Logger.error("Failed to restore theme backup!", error: e, trace: s);
+          showSnackbar("Error", "Failed to restore theme backup! Error: ${e.toString()}");
+        }
+      },
+    );
+  }
+
+  Future<void> _createThemeBackup() async {
+    final destination = await showMethodDialog();
+    if (destination == null || !context.mounted) return;
+    List<ThemeStruct> allThemes = ThemeStruct.getThemes().where((element) => !element.isPreset).toList();
+    if (allThemes.isEmpty) {
+      return showSnackbar("Notice", "No custom themes found!");
+    }
+    if (destination.isCloud) {
+      bool errored = false;
+      for (ThemeStruct e in allThemes) {
+        var response = await HttpSvc.backup.setTheme(e.name.characters.take(50).string, e.toMap());
+        if (response.statusCode != 200) {
+          errored = true;
+        }
+      }
+      if (errored) {
+        showSnackbar("Error", "Somthing went wrong");
+      } else {
+        showSnackbar("Success", "Themes exported successfully to server");
+      }
+    } else {
+      final List<Map<String, dynamic>> themeData = [];
+      for (ThemeStruct e in allThemes) {
+        themeData.add(e.toMap());
+      }
+      String jsonStr = jsonEncode(themeData);
+      DateTime now = DateTime.now().toLocal();
+      final themeFilename =
+          "BlueBubbles-theming-${now.year}${now.month}${now.day}_${now.hour}${now.minute}${now.second}.json";
+      if (kIsWeb) {
+        final bytes = utf8.encode(jsonStr);
+        final content = base64.encode(bytes);
+        html.AnchorElement(href: "data:application/octet-stream;charset=utf-16le;base64,$content")
+          ..setAttribute("download", themeFilename)
+          ..click();
+        refresh();
+        return;
+      }
+      final downloadsDir = await FilesystemSvc.downloadsDirectory;
+      String filePath = join(downloadsDir, themeFilename);
+      if (kIsDesktop) {
+        // Let the portal write the file: passing bytes lands it at the
+        // real chosen location (sandbox-safe) so reveal opens the right
+        // folder, instead of a separate write to a non-granted path.
+        String? _filePath = await FilePicker.saveFile(
+          initialDirectory: downloadsDir,
+          dialogTitle: 'Choose a location to save this file',
+          fileName: themeFilename,
+          type: FileType.custom,
+          allowedExtensions: ["json"],
+          bytes: utf8.encode(jsonStr),
+        );
+        if (_filePath == null) {
+          return showSnackbar('Failed', 'You didn\'t select a file path!');
+        }
+        filePath = _filePath;
+      } else {
+        File file = File(filePath);
+        await file.create(recursive: true);
+        await file.writeAsString(jsonStr);
+      }
+      showSnackbar(
+        "Success",
+        "Theming exported successfully to ${kIsDesktop ? filePath : "downloads folder"}",
+        durationMs: kIsDesktop ? 4000 : 2000,
+        button: TextButton(
+          style: TextButton.styleFrom(backgroundColor: Get.theme.colorScheme.secondary),
+          onPressed: () {
+            if (kIsDesktop) {
+              revealInFileManager(filePath);
+              return;
+            }
+            Share.files([filePath]);
+          },
+          child: Text(kIsDesktop ? "OPEN FOLDER" : "SHARE",
+              style: TextStyle(color: context.theme.colorScheme.onSecondary)),
+        ),
+      );
+    }
+    refresh();
+  }
+
+  Future<void> _restoreThemesFromFile() async {
+    final res = await FilePicker.pickFiles(withData: true, type: FileType.custom, allowedExtensions: ["json"]);
+    if (res == null || res.files.isEmpty || res.files.first.bytes == null || !context.mounted) return;
+
+    BackupRestoreDialogs.showConfirmation(
+      context: context,
+      title: "Restore Backup?",
+      content: const Text(
+        "Are you sure you want to restore this backup, overwriting your current theme?",
+      ),
+      onYes: () {
+        Navigator.of(context, rootNavigator: true).pop();
+        try {
+          String jsonString = const Utf8Decoder().convert(res.files.first.bytes!);
+          List<dynamic> json = jsonDecode(jsonString);
+          for (var e in json) {
+            ThemeStruct object = ThemeStruct.fromMap(e);
+            if (object.isPreset) continue;
+            object.id = null;
+            object.save();
+          }
+          showSnackbar("Success", "Theming restored successfully");
+        } catch (e, s) {
+          Logger.error("Failed to restore theme backup!", error: e, trace: s);
+          showSnackbar("Error", "Failed to restore theme backup! Error: ${e.toString()}");
+        }
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Shared
+  // ---------------------------------------------------------------------------------------------
+
+  void _showJson({required String title, required Map<String, dynamic> item}) {
+    const encoder = JsonEncoder.withIndent("     ");
+    final str = encoder.convert(item);
+    BackupRestoreDialogs.showJsonData(
+      context: context,
+      title: title,
+      jsonText: str,
+    );
+  }
+
+  Future<void> _onCreateNew(BackupKind kind) =>
+      kind == BackupKind.settings ? _createSettingsBackup() : _createThemeBackup();
+
+  Future<void> _onRestoreLocal(BackupKind kind) =>
+      kind == BackupKind.settings ? _restoreSettingsFromFile() : _restoreThemesFromFile();
 }

--- a/lib/app/layouts/settings/pages/server/connection_panel/connection_panel_helpers.dart
+++ b/lib/app/layouts/settings/pages/server/connection_panel/connection_panel_helpers.dart
@@ -593,7 +593,7 @@ mixin ConnectionPanelHelpersMixin {
                   await SettingsSvc.settings.saveOneAsync('useLocalIpv6');
                   NetworkTasks.detectLocalhost(createSnackbar: true);
                 },
-                leading: SettingsLeadingIcon(
+                leading: const SettingsLeadingIcon(
                   iosIcon: CupertinoIcons.globe,
                   materialIcon: Icons.network_check_outlined,
                   containerColor: Colors.blue,
@@ -628,7 +628,7 @@ mixin ConnectionPanelHelpersMixin {
                           ? "Tap to fetch logs"
                           : "Disconnected, cannot fetch logs"),
                   backgroundColor: tileColor,
-                  leading: SettingsLeadingIcon(
+                  leading: const SettingsLeadingIcon(
                     iosIcon: CupertinoIcons.doc_plaintext,
                     materialIcon: Icons.article,
                     containerColor: Colors.lightBlue,

--- a/lib/app/layouts/settings/pages/server/connection_panel/cupertino_connection_panel.dart
+++ b/lib/app/layouts/settings/pages/server/connection_panel/cupertino_connection_panel.dart
@@ -135,7 +135,7 @@ class _CupertinoConnectionPanelState
       tileColor: tileColor,
       headerColor: headerColor,
       actions: [
-        if (qrAction != null) qrAction,
+        ?qrAction,
       ],
       bodySlivers: [
         SliverToBoxAdapter(

--- a/lib/app/layouts/settings/pages/server/connection_panel/material_connection_panel.dart
+++ b/lib/app/layouts/settings/pages/server/connection_panel/material_connection_panel.dart
@@ -119,7 +119,7 @@ class _MaterialConnectionPanelState extends CustomState<MaterialConnectionPanel,
       tileColor: tileColor,
       headerColor: headerColor,
       actions: [
-        if (qrAction != null) qrAction,
+        ?qrAction,
       ],
       bodySlivers: [
         SliverToBoxAdapter(

--- a/lib/app/layouts/settings/pages/server/connection_panel/samsung_connection_panel.dart
+++ b/lib/app/layouts/settings/pages/server/connection_panel/samsung_connection_panel.dart
@@ -134,7 +134,7 @@ class _SamsungConnectionPanelState extends CustomState<SamsungConnectionPanel, v
       tileColor: tileColor,
       headerColor: headerColor,
       actions: [
-        if (qrAction != null) qrAction,
+        ?qrAction,
       ],
       bodySlivers: [
         SliverToBoxAdapter(

--- a/lib/app/layouts/settings/pages/storage/storage_analyzer_controller.dart
+++ b/lib/app/layouts/settings/pages/storage/storage_analyzer_controller.dart
@@ -63,7 +63,7 @@ class StorageAnalyzerController extends GetxController {
     // priority in the UI while `stage != null`, but clearing this too means
     // a failed refresh can't fall through and silently re-show stale numbers.
     result.value = null;
-    progress.value = StorageAnalysisProgress(
+    progress.value = const StorageAnalysisProgress(
       stage: StorageAnalysisStage.indexing,
       processed: 0,
       total: 0,

--- a/lib/app/layouts/settings/pages/storage/widgets/storage_expressive_results_section.dart
+++ b/lib/app/layouts/settings/pages/storage/widgets/storage_expressive_results_section.dart
@@ -69,7 +69,7 @@ class StorageExpressiveResultsSection extends StatelessWidget with StorageAnalyz
             ),
           if (visibleSegments.isNotEmpty) ...[
             const SizedBox(height: 24),
-            M3ESectionHeader(label: "Breakdown"),
+            const M3ESectionHeader(label: "Breakdown"),
             Obx(() => M3ESection(
                   backgroundColor: context.tileColor,
                   margin: EdgeInsets.zero,

--- a/lib/app/layouts/settings/pages/theming/avatar/custom_avatar_color_panel.dart
+++ b/lib/app/layouts/settings/pages/theming/avatar/custom_avatar_color_panel.dart
@@ -17,7 +17,7 @@ class CustomAvatarColorPanelController extends StatefulController {
     getCustomHandles();
   }
 
-  Future<void> getCustomHandles({force = false}) async {
+  Future<void> getCustomHandles({bool force = false}) async {
     List<Handle> handles = Handle.find();
     if (isNullOrEmpty(handles)) return;
 

--- a/lib/app/layouts/settings/pages/theming/background/background_crop.dart
+++ b/lib/app/layouts/settings/pages/theming/background/background_crop.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 
+import 'package:bluebubbles/app/components/bb_slider.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/wrappers/bb_app_bar.dart';
 import 'package:bluebubbles/app/wrappers/bb_scaffold.dart';
@@ -315,7 +316,7 @@ class _BackgroundCropState extends State<BackgroundCrop> with ThemeHelpers {
               color: context.theme.colorScheme.onSurfaceVariant,
             ),
             Expanded(
-              child: Slider(
+              child: BBSlider(
                 min: 0,
                 max: 10,
                 value: _blurSigma,

--- a/lib/app/layouts/settings/pages/theming/background/background_crop.dart
+++ b/lib/app/layouts/settings/pages/theming/background/background_crop.dart
@@ -12,6 +12,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:image/image.dart' as img;
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:universal_io/io.dart';
@@ -28,6 +29,17 @@ class BackgroundCrop extends StatefulWidget {
 }
 
 class _BackgroundCropState extends State<BackgroundCrop> with ThemeHelpers {
+  /// Longest-side cap for the saved background, in pixels. `BoxFit.cover`
+  /// never shows more detail than the display can — this is still well
+  /// above a 4K screen's effective resolution for a background layer, so
+  /// there's no visible cost, only a much smaller file on disk.
+  static const int _maxBackgroundDimension = 2560;
+
+  /// JPEG quality for the final saved file. Photos don't benefit from PNG's
+  /// losslessness the way graphics do; this is visually indistinguishable
+  /// from the source while being a fraction of the size.
+  static const int _jpegQuality = 92;
+
   final _cropController = CropController();
   _EditStep _currentStep = _EditStep.selectImage;
   Uint8List? _imageData;
@@ -37,6 +49,32 @@ class _BackgroundCropState extends State<BackgroundCrop> with ThemeHelpers {
   double _blurSigma = 0.0;
 
   Chat get chat => widget.chat;
+
+  /// Downscales [bytes] to [_maxBackgroundDimension] (if larger) using box
+  /// averaging rather than the `image` package's default nearest-neighbor
+  /// interpolation, which aliases badly on a large downscale (see
+  /// `ImageActions.generatePreview` for the same fix applied to attachment
+  /// previews). No-op (returns [bytes] unchanged) when already within the cap.
+  Uint8List _capResolution(Uint8List bytes) {
+    final image = img.decodeImage(bytes);
+    if (image == null) return bytes;
+
+    final longestSide = image.width > image.height ? image.width : image.height;
+    if (longestSide <= _maxBackgroundDimension) return bytes;
+
+    final resized = image.width >= image.height
+        ? img.copyResize(image, width: _maxBackgroundDimension, interpolation: img.Interpolation.average)
+        : img.copyResize(image, height: _maxBackgroundDimension, interpolation: img.Interpolation.average);
+    return Uint8List.fromList(img.encodePng(resized));
+  }
+
+  /// Re-encodes [bytes] as a high-quality JPEG for a reasonable file size.
+  /// Falls back to the original (PNG) bytes if decoding fails for any reason.
+  Uint8List _encodeFinal(Uint8List bytes) {
+    final image = img.decodeImage(bytes);
+    if (image == null) return bytes;
+    return Uint8List.fromList(img.encodeJpg(image, quality: _jpegQuality));
+  }
 
   Future<Uint8List> _applyBlurToImage(Uint8List bytes, double sigma) async {
     if (sigma == 0) return bytes;
@@ -77,18 +115,25 @@ class _BackgroundCropState extends State<BackgroundCrop> with ThemeHelpers {
 
   Future<void> _saveImage() async {
     _showSavingDialog();
-    final Uint8List finalData = await _applyBlurToImage(_croppedData!, _blurSigma);
+    final Uint8List capped = _capResolution(_croppedData!);
+    final Uint8List blurred = await _applyBlurToImage(capped, _blurSigma);
+    final Uint8List finalData = _encodeFinal(blurred);
     final String sanitizedGuid = FilesystemService.sanitizeGuid(chat.guid);
     final File file =
-        File(p.join(FilesystemSvc.customBackgroundsPath, sanitizedGuid, "background-${finalData.length}.png"));
+        File(p.join(FilesystemSvc.customBackgroundsPath, sanitizedGuid, "background-${finalData.length}.jpg"));
 
     if (!(await file.exists())) {
       await file.create(recursive: true);
     }
 
-    // Delete the old background file if one exists
-    if (chat.customBackgroundPath != null) {
-      final File oldFile = File(chat.customBackgroundPath!);
+    // Delete the old background file if one exists. `Chat.customBackgroundPath`
+    // is never populated for a locally-set background (only by server-synced
+    // data) -- the filesystem scan is the actual source of truth everywhere
+    // else in the app, so it's what's used here too, or every save just
+    // leaves the previous file orphaned on disk.
+    final existingPath = FilesystemSvc.getExistingChatBackgroundPath(chat.guid);
+    if (existingPath != null) {
+      final File oldFile = File(existingPath);
       if (await oldFile.exists()) {
         await oldFile.delete();
       }
@@ -263,6 +308,7 @@ class _BackgroundCropState extends State<BackgroundCrop> with ThemeHelpers {
                   aspectRatio: _isLocked ? screenAspectRatio : null,
                   baseColor: context.theme.colorScheme.surface,
                   maskColor: context.theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                  filterQuality: FilterQuality.high,
                 ),
               ),
               if (_isLoading)

--- a/lib/app/layouts/settings/settings_page.dart
+++ b/lib/app/layouts/settings/settings_page.dart
@@ -221,7 +221,7 @@ class _SettingsPageState extends State<SettingsPage> with ThemeHelpers {
                     NavigationSvc.maxWidthSettings = constraints.maxWidth;
                     return PopScope(
                       canPop: false,
-                      onPopInvokedWithResult: <T>(bool _, T? __) async {
+                      onPopInvokedWithResult: <T>(bool _, T? _) async {
                         Get.until((route) {
                           if (route.settings.name == "initial") {
                             Get.back();

--- a/lib/app/layouts/settings/widgets/content/CLAUDE.md
+++ b/lib/app/layouts/settings/widgets/content/CLAUDE.md
@@ -9,7 +9,7 @@ These are the **primary building blocks** for all settings pages. Assemble setti
 | `SettingsTile` | `settings_tile.dart` | Base row: title, subtitle, leading icon, trailing widget, onTap |
 | `SettingsSwitch` | `settings_switch.dart` | Toggle row with a `BBSwitch` (skin-aware — `lib/app/components/bb_switch.dart`); tap toggles |
 | `SettingsOptions<T>` | `settings_dropdown.dart` | Dropdown selector (Material) or segmented control (iOS) |
-| `SettingsSlider` | `settings_slider.dart` | Slider input row |
+| `SettingsSlider` | `settings_slider.dart` | Slider input row with a `BBSlider` (skin-aware — `lib/app/components/bb_slider.dart`) |
 | `SettingsLeadingIcon` | `settings_leading_icon.dart` | Styled leading icon (colored rounded square) |
 | `SettingsSubtitle` | `settings_subtitle.dart` | Section subtitle / description text |
 | `NextButton` | `next_button.dart` | Navigation arrow button for settings flows |

--- a/lib/app/layouts/settings/widgets/content/settings_dropdown.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_dropdown.dart
@@ -170,7 +170,7 @@ class SettingsOptions<T extends Object> extends StatelessWidget {
                     constraints: BoxConstraints(
                         maxWidth: leading != null
                             ? NavigationSvc.width(context) * 2 / 5 - 80 // Account for leading icon space
-                            : NavigationSvc.width(context) * 2 / 5 - 47),
+                            : NavigationSvc.width(context) * 2 / 5 - 20),
                     child: widget,
                   );
                 } else {

--- a/lib/app/layouts/settings/widgets/content/settings_slider.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_slider.dart
@@ -1,5 +1,4 @@
 import 'package:bluebubbles/app/components/bb_slider.dart';
-import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 

--- a/lib/app/layouts/settings/widgets/content/settings_slider.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_slider.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/components/bb_slider.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -38,11 +39,7 @@ class SettingsSlider extends StatelessWidget {
       leading: leading,
       trailing: Text(value, style: context.theme.textTheme.bodyLarge),
       minLeadingWidth: leadingMinWidth,
-      title: Slider(
-        activeColor: context.theme.colorScheme.primary.oppositeLightenOrDarken(20),
-        secondaryActiveColor: context.theme.colorScheme.primary.withValues(alpha: 0.6),
-        thumbColor: context.theme.colorScheme.primary,
-        inactiveColor: context.theme.colorScheme.primary.withValues(alpha: 0.2),
+      title: BBSlider(
         value: startingVal,
         onChanged: update,
         onChangeEnd: onChangeEnd,
@@ -50,7 +47,6 @@ class SettingsSlider extends StatelessWidget {
         divisions: divisions,
         min: min,
         max: max,
-        mouseCursor: MouseCursor.defer,
       ),
     );
   }

--- a/lib/app/layouts/settings/widgets/content/settings_tile.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_tile.dart
@@ -16,7 +16,7 @@ class SettingsTile extends StatelessWidget {
     this.subtitle,
     this.backgroundColor,
     this.isThreeLine = false,
-    this.minVerticalPadding = 6,
+    this.minVerticalPadding,
   });
 
   final Function? onTap;
@@ -27,7 +27,7 @@ class SettingsTile extends StatelessWidget {
   final Widget? leading;
   final Color? backgroundColor;
   final bool isThreeLine;
-  final double minVerticalPadding;
+  final double? minVerticalPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -48,9 +48,9 @@ class SettingsTile extends StatelessWidget {
           child: ListTile(
             mouseCursor: MouseCursor.defer,
             enableFeedback: true,
-            minVerticalPadding: minVerticalPadding,
+            minVerticalPadding: minVerticalPadding ?? (SettingsSvc.settings.skin.value == Skins.iOS ? 14 : 6),
             horizontalTitleGap: 10,
-            dense: SettingsSvc.settings.skin.value == Skins.iOS ? true : false,
+            dense: false,
             leading: leading == null
                 ? null
                 : Padding(

--- a/lib/app/layouts/settings/widgets/content/settings_tile.dart
+++ b/lib/app/layouts/settings/widgets/content/settings_tile.dart
@@ -16,7 +16,7 @@ class SettingsTile extends StatelessWidget {
     this.subtitle,
     this.backgroundColor,
     this.isThreeLine = false,
-    this.minVerticalPadding = 14,
+    this.minVerticalPadding = 6,
   });
 
   final Function? onTap;

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -681,12 +681,12 @@ List<Widget> buildSettingItemList({
         ),
 
         // About & Links Section
-        SearchableSettingItem(
+        const SearchableSettingItem(
           title: "Leave Us a Review", // Title to search
           child: SettingsTile(
             title: "Leave Us a Review",
             onTap: SettingsItemsActions.openStoreReview,
-            leading: const SettingsLeadingIcon(
+            leading: SettingsLeadingIcon(
               iosIcon: CupertinoIcons.star_fill,
               materialIcon: Icons.star,
               containerColor: Colors.blue,

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -76,6 +76,7 @@ List<Widget> buildSettingItemList({
               size: 50,
             ),
             trailing: const NextButton(),
+            minVerticalPadding: 20,
           ),
         ],
       ),

--- a/lib/app/layouts/setup/pages/page_template.dart
+++ b/lib/app/layouts/setup/pages/page_template.dart
@@ -70,7 +70,7 @@ class SetupPageTemplate extends StatelessWidget {
                     subtitleWrapper: subtitleWrapper,
                     contentWrapper: contentWrapper,
                   ),
-                  if (customMiddle != null) customMiddle!,
+                  ?customMiddle,
                   if (buttonWrapper != null) buttonWrapper!.call(buttons),
                   if (buttonWrapper == null) buttons,
                 ],
@@ -141,13 +141,13 @@ class PageContent extends StatelessWidget {
         );
     final content = Column(
       children: [
-        if (aboveTitle != null) aboveTitle!,
+        ?aboveTitle,
         if (aboveTitle != null) const SizedBox(height: 10),
         if (titleWrapper != null) titleWrapper!.call(titleW),
         if (titleWrapper == null) titleW,
         if (subtitleWrapper != null) subtitleWrapper!.call(subtitleW),
         if (subtitleWrapper == null) subtitleW,
-        if (belowSubtitle != null) belowSubtitle!,
+        ?belowSubtitle,
       ],
     );
     if (contentWrapper != null) {

--- a/lib/app/layouts/setup/pages/sync/sync_settings.dart
+++ b/lib/app/layouts/setup/pages/sync/sync_settings.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/components/bb_slider.dart';
 import 'package:bluebubbles/helpers/ui/theme_helpers.dart';
 import 'package:bluebubbles/app/layouts/setup/pages/page_template.dart';
 import 'package:bluebubbles/app/layouts/setup/setup_view.dart';
@@ -251,7 +252,7 @@ class _NumberOfMessagesSliderState extends CustomState<NumberOfMessagesSlider, i
           ),
         ),
         const SizedBox(height: 10),
-        Slider(
+        BBSlider(
           value: numberOfMessages,
           onChanged: (double value) {
             controller.updateNumberToDownload(value.toInt());

--- a/lib/app/layouts/startup/splash_screen.dart
+++ b/lib/app/layouts/startup/splash_screen.dart
@@ -22,7 +22,7 @@ class _SplashScreenState extends State<SplashScreen> {
       Navigator.of(context).pushAndRemoveUntil(
           PageRouteBuilder(
               transitionDuration: const Duration(seconds: 1),
-              pageBuilder: (_, __, ___) => const TitleBarWrapper(child: SetupView())),
+              pageBuilder: (_, _, _) => const TitleBarWrapper(child: SetupView())),
           (route) => route.isFirst);
     }
   }

--- a/lib/app/state/chat_state.dart
+++ b/lib/app/state/chat_state.dart
@@ -1,5 +1,7 @@
 import 'dart:async' show unawaited;
 
+import 'package:bluebubbles/app/components/wallpaper/chat_wallpaper_type.dart';
+import 'package:bluebubbles/app/components/wallpaper/wallpaper_config_codec.dart';
 import 'package:bluebubbles/app/state/handle_state.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -43,6 +45,12 @@ class ChatState {
   final RxnString customThemeLight;
   final RxnString customThemeDark;
   final RxInt themeVersion;
+
+  /// Wallpaper selection. [wallpaperType] governs which of [customBackgroundPath]
+  /// (image) or [dynamicWallpaperId] + [dynamicWallpaperConfig] (dynamic) is active.
+  final Rx<ChatWallpaperType> wallpaperType;
+  final RxnString dynamicWallpaperId;
+  final Rx<Map<String, dynamic>?> dynamicWallpaperConfig;
 
   /// The delivery/read status of the latest outgoing message.  Updated any
   /// time [updateLatestMessageInternal] is called, even when the GUID has not
@@ -103,6 +111,12 @@ class ChatState {
         customThemeLight = RxnString(chat.customThemeLight),
         customThemeDark = RxnString(chat.customThemeDark),
         themeVersion = 0.obs,
+        wallpaperType = Rx<ChatWallpaperType>(ChatWallpaperType.resolve(
+          chat.wallpaperType,
+          FilesystemSvc.getExistingChatBackgroundPath(chat.guid),
+        )),
+        dynamicWallpaperId = RxnString(chat.dynamicWallpaperId),
+        dynamicWallpaperConfig = Rx<Map<String, dynamic>?>(WallpaperConfigCodec.decode(chat.dynamicWallpaperConfig)),
         isActive = false.obs,
         isAlive = false.obs,
         shouldHideAttachments =
@@ -240,6 +254,26 @@ class ChatState {
   void bumpThemeVersion() {
     themeVersion.value++;
   }
+
+  void updateWallpaperTypeInternal(ChatWallpaperType value) {
+    if (wallpaperType.value != value) {
+      wallpaperType.value = value;
+    }
+  }
+
+  void updateDynamicWallpaperInternal(String? id, Map<String, dynamic>? config) {
+    if (dynamicWallpaperId.value != id) {
+      dynamicWallpaperId.value = id;
+    }
+    dynamicWallpaperConfig.value = config;
+  }
+
+  /// True whenever the chat background isn't the default app-wide
+  /// background — a custom image or an animated dynamic wallpaper. Widgets
+  /// that adjust bubble/text contrast for a busy background should check
+  /// this instead of reading [customBackgroundPath] directly.
+  bool get hasCustomWallpaper =>
+      (customBackgroundPath.value?.isNotEmpty ?? false) || wallpaperType.value == ChatWallpaperType.dynamic;
 
   Future<void> _refreshAdaptiveCustomThemes(String imagePath) async {
     await ThemesService.upsertAdaptiveBackgroundThemesFromImage(
@@ -408,6 +442,14 @@ class ChatState {
     updateCustomBackgroundPathInternal(FilesystemSvc.getExistingChatBackgroundPath(updatedChat.guid));
     updateCustomThemeLightInternal(updatedChat.customThemeLight);
     updateCustomThemeDarkInternal(updatedChat.customThemeDark);
+    updateWallpaperTypeInternal(ChatWallpaperType.resolve(
+      updatedChat.wallpaperType,
+      FilesystemSvc.getExistingChatBackgroundPath(updatedChat.guid),
+    ));
+    updateDynamicWallpaperInternal(
+      updatedChat.dynamicWallpaperId,
+      WallpaperConfigCodec.decode(updatedChat.dynamicWallpaperConfig),
+    );
     // Rebuild participants from the fresh DB handles on the incoming chat object so
     // we never read the stale cached ToMany on the original ChatState.chat.
     _updateParticipantsInternal(updatedChat.handles.toList());
@@ -457,6 +499,9 @@ class ChatState {
     chat.customAvatarPath = updatedChat.customAvatarPath;
     chat.customThemeLight = updatedChat.customThemeLight;
     chat.customThemeDark = updatedChat.customThemeDark;
+    chat.wallpaperType = updatedChat.wallpaperType;
+    chat.dynamicWallpaperId = updatedChat.dynamicWallpaperId;
+    chat.dynamicWallpaperConfig = updatedChat.dynamicWallpaperConfig;
     chat.autoSendReadReceipts = updatedChat.autoSendReadReceipts;
     chat.autoSendTypingIndicators = updatedChat.autoSendTypingIndicators;
     chat.lockChatName = updatedChat.lockChatName;

--- a/lib/app/wrappers/gradient_background_wrapper.dart
+++ b/lib/app/wrappers/gradient_background_wrapper.dart
@@ -64,7 +64,7 @@ class _GradientBackgroundState extends CustomState<GradientBackground, void, Con
                     image: FileImage(File(bgPath)),
                     fit: BoxFit.cover,
                     filterQuality: FilterQuality.high,
-                    onError: (_, __) {},
+                    onError: (_, _) {},
                   ),
                 ),
               );

--- a/lib/app/wrappers/gradient_background_wrapper.dart
+++ b/lib/app/wrappers/gradient_background_wrapper.dart
@@ -1,3 +1,4 @@
+import 'package:bluebubbles/app/components/wallpaper/wallpaper.dart';
 import 'package:bluebubbles/app/state/chat_state.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -47,6 +48,13 @@ class _GradientBackgroundState extends CustomState<GradientBackground, void, Con
       children: [
         Positioned.fill(
           child: Obx(() {
+            if (_chatState?.wallpaperType.value == ChatWallpaperType.dynamic) {
+              return DynamicWallpaperView(
+                wallpaperId: _chatState?.dynamicWallpaperId.value,
+                config: _chatState?.dynamicWallpaperConfig.value,
+              );
+            }
+
             final String? bgPath = _chatState?.customBackgroundPath.value;
 
             if (bgPath != null) {

--- a/lib/app/wrappers/gradient_background_wrapper.dart
+++ b/lib/app/wrappers/gradient_background_wrapper.dart
@@ -63,6 +63,7 @@ class _GradientBackgroundState extends CustomState<GradientBackground, void, Con
                   image: DecorationImage(
                     image: FileImage(File(bgPath)),
                     fit: BoxFit.cover,
+                    filterQuality: FilterQuality.high,
                     onError: (_, __) {},
                   ),
                 ),

--- a/lib/app/wrappers/gradient_background_wrapper.dart
+++ b/lib/app/wrappers/gradient_background_wrapper.dart
@@ -49,9 +49,31 @@ class _GradientBackgroundState extends CustomState<GradientBackground, void, Con
         Positioned.fill(
           child: Obx(() {
             if (_chatState?.wallpaperType.value == ChatWallpaperType.dynamic) {
-              return DynamicWallpaperView(
-                wallpaperId: _chatState?.dynamicWallpaperId.value,
-                config: _chatState?.dynamicWallpaperConfig.value,
+              // The conversation Scaffold shrinks its body to avoid the
+              // keyboard, and some dynamic wallpapers (e.g. the
+              // `flutter_moving_background`-backed one) reset their entire
+              // animation state whenever the space they're laid out in
+              // resizes -- so every keyboard show/hide was visibly
+              // glitching the wallpaper. Pin its height to the full window
+              // instead of the space actually available (which shrinks for
+              // the keyboard) so it never sees that as a resize; the
+              // ancestor `Stack`'s default clip keeps the overflow
+              // invisible.
+              return LayoutBuilder(
+                builder: (context, constraints) {
+                  return OverflowBox(
+                    alignment: Alignment.topCenter,
+                    minHeight: MediaQuery.sizeOf(context).height,
+                    maxHeight: MediaQuery.sizeOf(context).height,
+                    child: SizedBox(
+                      width: constraints.maxWidth,
+                      child: DynamicWallpaperView(
+                        wallpaperId: _chatState?.dynamicWallpaperId.value,
+                        config: _chatState?.dynamicWallpaperConfig.value,
+                      ),
+                    ),
+                  );
+                },
               );
             }
 

--- a/lib/database/html/attachment.dart
+++ b/lib/database/html/attachment.dart
@@ -115,7 +115,7 @@ class Attachment {
   /// Delete an attachment and remove all instances of that attachment in the DB
   static void delete(String guid) {}
 
-  String getFriendlySize({decimals = 2}) {
+  String getFriendlySize({int decimals = 2}) {
     return (totalBytes ?? 0.0).toDouble().getFriendlySize();
   }
 

--- a/lib/database/html/handle.dart
+++ b/lib/database/html/handle.dart
@@ -70,7 +70,7 @@ class Handle {
         defaultPhone: json['defaultPhone'],
       );
 
-  Handle save({updateColor = false}) {
+  Handle save({bool updateColor = false}) {
     return this;
   }
 

--- a/lib/database/html/objectbox.dart
+++ b/lib/database/html/objectbox.dart
@@ -98,7 +98,7 @@ class Store {
 
   dynamic get reference => throw Exception('Unsupported Platform');
 
-  Store.fromReference(dynamic _, dynamic __);
+  Store.fromReference(dynamic _, dynamic _);
 
   Store.attach(dynamic _, String? directoryPath, {bool queriesCaseSensitiveDefault = true});
 }

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -60,6 +60,20 @@ class Chat {
   String? customThemeLight;
   String? customThemeDark;
 
+  /// [ChatWallpaperType.name] — "none" (default/absent), "image", or "dynamic".
+  /// Read via `ChatWallpaperType.fromName(chat.wallpaperType)`.
+  @Property(uid: 699362128358203439)
+  String? wallpaperType;
+
+  /// [DynamicWallpaperDefinition.id] of the selected dynamic wallpaper, when
+  /// [wallpaperType] is "dynamic". Null otherwise.
+  @Property(uid: 3728602269935984680)
+  String? dynamicWallpaperId;
+
+  /// JSON-encoded config map for [dynamicWallpaperId], via [WallpaperConfigCodec].
+  @Property(uid: 738307263391205523)
+  String? dynamicWallpaperConfig;
+
   final RxnString _customAvatarPath = RxnString();
   String? get customAvatarPath => _customAvatarPath.value;
   set customAvatarPath(String? s) => _customAvatarPath.value = s;
@@ -126,6 +140,9 @@ class Chat {
     this.lastReadMessageGuid,
     this.customThemeLight,
     this.customThemeDark,
+    this.wallpaperType,
+    this.dynamicWallpaperId,
+    this.dynamicWallpaperConfig,
   }) {
     customAvatarPath = customAvatar;
     customBackgroundPath = customBackground;
@@ -161,6 +178,9 @@ class Chat {
       lastReadMessageGuid: json["lastReadMessageGuid"],
       customThemeLight: json["customThemeLight"],
       customThemeDark: json["customThemeDark"],
+      wallpaperType: json["wallpaperType"],
+      dynamicWallpaperId: json["dynamicWallpaperId"],
+      dynamicWallpaperConfig: json["dynamicWallpaperConfig"],
       textFieldText: json["textFieldText"],
       textFieldAttachments: (json["textFieldAttachments"] as List?)?.cast<String>() ?? const [],
     );
@@ -187,6 +207,7 @@ class Chat {
     bool updateLastReadMessageGuid = false,
     bool updateLatestMessage = false,
     bool updateCustomThemes = false,
+    bool updateWallpaperSettings = false,
   }) async {
     if (kIsWeb) return this;
 
@@ -213,6 +234,7 @@ class Chat {
         'updateLastReadMessageGuid': updateLastReadMessageGuid,
         'updateLatestMessage': updateLatestMessage,
         'updateCustomThemes': updateCustomThemes,
+        'updateWallpaperSettings': updateWallpaperSettings,
       },
     );
 
@@ -791,6 +813,9 @@ class Chat {
     muteArgs ??= other.muteArgs;
     dateDeleted ??= other.dateDeleted;
     style ??= other.style;
+    wallpaperType ??= other.wallpaperType;
+    dynamicWallpaperId ??= other.dynamicWallpaperId;
+    dynamicWallpaperConfig ??= other.dynamicWallpaperConfig;
     return this;
   }
 
@@ -870,6 +895,9 @@ class Chat {
       "lastReadMessageGuid": lastReadMessageGuid,
       "customThemeLight": customThemeLight,
       "customThemeDark": customThemeDark,
+      "wallpaperType": wallpaperType,
+      "dynamicWallpaperId": dynamicWallpaperId,
+      "dynamicWallpaperConfig": dynamicWallpaperConfig,
       "textFieldText": textFieldText,
       "textFieldAttachments": textFieldAttachments,
       "dbOnlyLatestMessageDate": dbOnlyLatestMessageDate?.millisecondsSinceEpoch,

--- a/lib/generated/objectbox-model.json
+++ b/lib/generated/objectbox-model.json
@@ -104,7 +104,7 @@
     },
     {
       "id": "3:9017250848141753702",
-      "lastPropertyId": "36:2775254966591031179",
+      "lastPropertyId": "39:738307263391205523",
       "name": "Chat",
       "properties": [
         {
@@ -236,6 +236,21 @@
         {
           "id": "36:2775254966591031179",
           "name": "customThemeDark",
+          "type": 9
+        },
+        {
+          "id": "37:699362128358203439",
+          "name": "wallpaperType",
+          "type": 9
+        },
+        {
+          "id": "38:3728602269935984680",
+          "name": "dynamicWallpaperId",
+          "type": 9
+        },
+        {
+          "id": "39:738307263391205523",
+          "name": "dynamicWallpaperConfig",
           "type": 9
         }
       ],

--- a/lib/generated/objectbox.g.dart
+++ b/lib/generated/objectbox.g.dart
@@ -1456,11 +1456,14 @@ obx_int.ModelDefinition getObjectBoxModel() {
         final customThemeDarkOffset = object.customThemeDark == null
             ? null
             : fbb.writeString(object.customThemeDark!);
-        final wallpaperTypeOffset =
-            object.wallpaperType == null ? null : fbb.writeString(object.wallpaperType!);
-        final dynamicWallpaperIdOffset =
-            object.dynamicWallpaperId == null ? null : fbb.writeString(object.dynamicWallpaperId!);
-        final dynamicWallpaperConfigOffset = object.dynamicWallpaperConfig == null
+        final wallpaperTypeOffset = object.wallpaperType == null
+            ? null
+            : fbb.writeString(object.wallpaperType!);
+        final dynamicWallpaperIdOffset = object.dynamicWallpaperId == null
+            ? null
+            : fbb.writeString(object.dynamicWallpaperId!);
+        final dynamicWallpaperConfigOffset =
+            object.dynamicWallpaperConfig == null
             ? null
             : fbb.writeString(object.dynamicWallpaperConfig!);
         fbb.startTable(40);

--- a/lib/generated/objectbox.g.dart
+++ b/lib/generated/objectbox.g.dart
@@ -147,7 +147,7 @@ final _entities = <obx_int.ModelEntity>[
   obx_int.ModelEntity(
     id: const obx_int.IdUid(3, 9017250848141753702),
     name: 'Chat',
-    lastPropertyId: const obx_int.IdUid(36, 2775254966591031179),
+    lastPropertyId: const obx_int.IdUid(39, 738307263391205523),
     flags: 0,
     properties: <obx_int.ModelProperty>[
       obx_int.ModelProperty(
@@ -301,6 +301,24 @@ final _entities = <obx_int.ModelEntity>[
       obx_int.ModelProperty(
         id: const obx_int.IdUid(36, 2775254966591031179),
         name: 'customThemeDark',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(37, 699362128358203439),
+        name: 'wallpaperType',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(38, 3728602269935984680),
+        name: 'dynamicWallpaperId',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(39, 738307263391205523),
+        name: 'dynamicWallpaperConfig',
         type: 9,
         flags: 0,
       ),
@@ -1438,7 +1456,14 @@ obx_int.ModelDefinition getObjectBoxModel() {
         final customThemeDarkOffset = object.customThemeDark == null
             ? null
             : fbb.writeString(object.customThemeDark!);
-        fbb.startTable(37);
+        final wallpaperTypeOffset =
+            object.wallpaperType == null ? null : fbb.writeString(object.wallpaperType!);
+        final dynamicWallpaperIdOffset =
+            object.dynamicWallpaperId == null ? null : fbb.writeString(object.dynamicWallpaperId!);
+        final dynamicWallpaperConfigOffset = object.dynamicWallpaperConfig == null
+            ? null
+            : fbb.writeString(object.dynamicWallpaperConfig!);
+        fbb.startTable(40);
         fbb.addInt64(0, object.id ?? 0);
         fbb.addOffset(2, guidOffset);
         fbb.addOffset(4, chatIdentifierOffset);
@@ -1467,6 +1492,9 @@ obx_int.ModelDefinition getObjectBoxModel() {
         fbb.addInt64(29, object.dbLatestMessage.targetId);
         fbb.addOffset(34, customThemeLightOffset);
         fbb.addOffset(35, customThemeDarkOffset);
+        fbb.addOffset(36, wallpaperTypeOffset);
+        fbb.addOffset(37, dynamicWallpaperIdOffset);
+        fbb.addOffset(38, dynamicWallpaperConfigOffset);
         fbb.finish(fbb.endTable());
         return object.id ?? 0;
       },
@@ -1555,6 +1583,15 @@ obx_int.ModelDefinition getObjectBoxModel() {
         final customThemeDarkParam = const fb.StringReader(
           asciiOptimization: true,
         ).vTableGetNullable(buffer, rootOffset, 74);
+        final wallpaperTypeParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 76);
+        final dynamicWallpaperIdParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 78);
+        final dynamicWallpaperConfigParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 80);
         final object =
             Chat(
                 id: idParam,
@@ -1577,6 +1614,9 @@ obx_int.ModelDefinition getObjectBoxModel() {
                 lastReadMessageGuid: lastReadMessageGuidParam,
                 customThemeLight: customThemeLightParam,
                 customThemeDark: customThemeDarkParam,
+                wallpaperType: wallpaperTypeParam,
+                dynamicWallpaperId: dynamicWallpaperIdParam,
+                dynamicWallpaperConfig: dynamicWallpaperConfigParam,
               )
               ..dbOnlyLatestMessageDate = dbOnlyLatestMessageDateValue == null
                   ? null
@@ -2814,6 +2854,21 @@ class Chat_ {
   /// See [Chat.customThemeDark].
   static final customThemeDark = obx.QueryStringProperty<Chat>(
     _entities[1].properties[24],
+  );
+
+  /// See [Chat.wallpaperType].
+  static final wallpaperType = obx.QueryStringProperty<Chat>(
+    _entities[1].properties[25],
+  );
+
+  /// See [Chat.dynamicWallpaperId].
+  static final dynamicWallpaperId = obx.QueryStringProperty<Chat>(
+    _entities[1].properties[26],
+  );
+
+  /// See [Chat.dynamicWallpaperConfig].
+  static final dynamicWallpaperConfig = obx.QueryStringProperty<Chat>(
+    _entities[1].properties[27],
   );
 
   /// see [Chat.handles]

--- a/lib/helpers/network/network_tasks.dart
+++ b/lib/helpers/network/network_tasks.dart
@@ -134,7 +134,7 @@ class NetworkTasks {
         }
         completer.complete();
       },
-      onError: (_, __) {
+      onError: (_, _) {
         setOriginOverride(null);
         completer.complete();
       },

--- a/lib/services/backend/actions/chat_actions.dart
+++ b/lib/services/backend/actions/chat_actions.dart
@@ -137,6 +137,11 @@ class ChatActions {
         chat.customThemeLight = inputChat.customThemeLight;
         chat.customThemeDark = inputChat.customThemeDark;
       }
+      if (updateFlags['updateWallpaperSettings'] == true) {
+        chat.wallpaperType = inputChat.wallpaperType;
+        chat.dynamicWallpaperId = inputChat.dynamicWallpaperId;
+        chat.dynamicWallpaperConfig = inputChat.dynamicWallpaperConfig;
+      }
       if (updateFlags['updateLatestMessage'] == true) {
         final latestMessageId = chatData['dbLatestMessageId'] as int?;
         final latestMessageDateMs = chatData['dbOnlyLatestMessageDate'] as int?;

--- a/lib/services/backend/actions/contact_v2_actions.dart
+++ b/lib/services/backend/actions/contact_v2_actions.dart
@@ -319,7 +319,7 @@ class ContactV2Actions {
             }
             for (final email in rawContact.emails) {
               final label =
-                  email.label == fc.EmailLabel.custom ? email.label.customLabel ?? '' : email.label.label.name;
+                  email.label.label == fc.EmailLabel.custom ? email.label.customLabel ?? '' : email.label.label.name;
               contactEmails.add(ContactEmail(address: email.address, label: label));
             }
           } else if (rawContact is ContactV2) {
@@ -491,7 +491,7 @@ class ContactV2Actions {
           error: e, trace: stack);
 
       // Complete the completer with an empty result on error
-      final stats = _ContactSyncStats(affectedHandleIds: const [], deviceContactCount: 0, matchedContactCount: 0);
+      const stats = _ContactSyncStats(affectedHandleIds: [], deviceContactCount: 0, matchedContactCount: 0);
       _syncCompleter?.complete(stats);
       return stats;
     }

--- a/lib/services/network/method_channel_actions.dart
+++ b/lib/services/network/method_channel_actions.dart
@@ -67,7 +67,7 @@ class MethodChannelActions {
   Future<void> deleteNotification({required int notificationId, String? tag}) async {
     await service.invokeMethod('delete-notification', {
       'notification_id': notificationId,
-      if (tag != null) 'tag': tag,
+      'tag': ?tag,
     });
   }
 

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -553,11 +553,6 @@ class AttachmentsService extends GetxService {
 
   Future<String?> _resolveLinuxFfmpeg() {
     return _linuxFfmpegPath ??= () async {
-      // A copy shipped next to the runner wins, so the release tarball can be made
-      // self-contained without depending on what the user's distro has installed.
-      final bundled = join(dirname(Platform.resolvedExecutable), 'ffmpeg');
-      if (await File(bundled).exists()) return bundled;
-
       // Otherwise take it from PATH: the snap stages ffmpeg into $SNAP/usr/bin and the flatpak
       // builds it into /app/bin -- neither sandbox can see the host's copy, so each ships its
       // own, and both directories are already on PATH. A plain tarball install falls through to

--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:app_links/app_links.dart';
+import 'package:bluebubbles/app/components/wallpaper/chat_wallpaper_type.dart';
+import 'package:bluebubbles/app/components/wallpaper/wallpaper_config_codec.dart';
 import 'package:bluebubbles/app/layouts/chat_creator/chat_creator.dart';
 import 'package:bluebubbles/app/layouts/chat_creator/new_chat_creator.dart';
 import 'package:bluebubbles/app/layouts/conversation_list/widgets/filters/chat_list_filters.dart';
@@ -1406,12 +1408,19 @@ class ChatsService {
     }
   }
 
-  /// Set chat custom background path
+  /// Set chat custom background path. Also updates [Chat.wallpaperType] to
+  /// "image" (a path was set) or "none" (cleared) — use
+  /// [setChatDynamicWallpaper] to switch to an animated wallpaper instead.
   Future<void> setChatCustomBackgroundPath(Chat chat, String? value) async {
     final state = getChatState(chat.guid);
     final resolvedPath = value ?? FilesystemSvc.getExistingChatBackgroundPath(chat.guid);
     final oldPath = state?.customBackgroundPath.value ?? FilesystemSvc.getExistingChatBackgroundPath(chat.guid);
-    if (state != null && state.customBackgroundPath.value == resolvedPath) return;
+    final newWallpaperType = resolvedPath != null ? ChatWallpaperType.image : ChatWallpaperType.none;
+    if (state != null &&
+        state.customBackgroundPath.value == resolvedPath &&
+        state.wallpaperType.value == newWallpaperType) {
+      return;
+    }
 
     if (oldPath != null && oldPath != resolvedPath) {
       ThemesService.clearAdaptiveThemeCache(oldPath);
@@ -1427,6 +1436,61 @@ class ChatsService {
     }
 
     state?.updateCustomBackgroundPathInternal(resolvedPath);
+    state?.updateWallpaperTypeInternal(newWallpaperType);
+    if (newWallpaperType == ChatWallpaperType.image) {
+      state?.updateDynamicWallpaperInternal(null, null);
+    }
+
+    final chatToUpdate = state?.chat ?? chat;
+    chatToUpdate.wallpaperType = newWallpaperType == ChatWallpaperType.none ? null : newWallpaperType.name;
+    if (newWallpaperType == ChatWallpaperType.image) {
+      chatToUpdate.dynamicWallpaperId = null;
+      chatToUpdate.dynamicWallpaperConfig = null;
+    }
+    await chatToUpdate.saveAsync(updateWallpaperSettings: true);
+  }
+
+  /// Selects a dynamic (animated) wallpaper for [chat] — sets
+  /// [Chat.wallpaperType] to "dynamic" and stores [wallpaperId] +
+  /// JSON-encoded [config]. Leaves any existing custom background image file
+  /// on disk untouched (switching back to "image" reuses it).
+  Future<void> setChatDynamicWallpaper(Chat chat, String wallpaperId, Map<String, dynamic> config) async {
+    final state = getChatState(chat.guid);
+
+    state?.updateWallpaperTypeInternal(ChatWallpaperType.dynamic);
+    state?.updateDynamicWallpaperInternal(wallpaperId, config);
+
+    final chatToUpdate = state?.chat ?? chat;
+    chatToUpdate.wallpaperType = ChatWallpaperType.dynamic.name;
+    chatToUpdate.dynamicWallpaperId = wallpaperId;
+    chatToUpdate.dynamicWallpaperConfig = WallpaperConfigCodec.encode(config);
+    await chatToUpdate.saveAsync(updateWallpaperSettings: true);
+  }
+
+  /// Clears any wallpaper (image or dynamic) back to the default app-wide
+  /// background. Deletes the on-disk custom background file, if any.
+  Future<void> clearChatWallpaper(Chat chat) async {
+    final state = getChatState(chat.guid);
+    final existingImagePath =
+        state?.customBackgroundPath.value ?? FilesystemSvc.getExistingChatBackgroundPath(chat.guid);
+
+    if (existingImagePath != null) {
+      ThemesService.clearAdaptiveThemeCache(existingImagePath);
+      final file = File(existingImagePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+
+    state?.updateCustomBackgroundPathInternal(null);
+    state?.updateWallpaperTypeInternal(ChatWallpaperType.none);
+    state?.updateDynamicWallpaperInternal(null, null);
+
+    final chatToUpdate = state?.chat ?? chat;
+    chatToUpdate.wallpaperType = null;
+    chatToUpdate.dynamicWallpaperId = null;
+    chatToUpdate.dynamicWallpaperConfig = null;
+    await chatToUpdate.saveAsync(updateWallpaperSettings: true);
   }
 
   /// Set the custom light and dark themes for a specific chat.

--- a/lib/utils/share.dart
+++ b/lib/utils/share.dart
@@ -164,10 +164,10 @@ class Share {
                           url!,
                           gaplessPlayback: true,
                           filterQuality: FilterQuality.none,
-                          errorBuilder: (_, __, ___) {
+                          errorBuilder: (_, _, _) {
                             return const SizedBox.shrink();
                           },
-                          frameBuilder: (_, child, frame, __) {
+                          frameBuilder: (_, child, frame, _) {
                             if (frame == null) {
                               return Center(
                                 heightFactor: 1,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -854,6 +854,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
+  floating_animation:
+    dependency: "direct main"
+    description:
+      name: floating_animation
+      sha256: "090747c3aba98133b61a7cbb804fb6e2c157331a8df9a3898396921ca2dcca25"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -1077,6 +1085,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.7"
+  flutter_moving_background:
+    dependency: "direct main"
+    description:
+      name: flutter_moving_background
+      sha256: bcb6a5360a579e8415000622b2dd4215db8c8a8ebe26e616648cf2769e05366c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -2124,10 +2140,10 @@ packages:
     dependency: "direct main"
     description:
       name: particles_flutter
-      sha256: "74057830f0526902cc36325b5feefbbeda88b5f8f9958cf8f24ec98eeeab36c2"
+      sha256: "9d592a19327bb4e1a8e865e45e42ef71c3788f6dd3ac95bd93b34a6ef1e0e98e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "3.2.0"
   passkit:
     dependency: "direct main"
     description:
@@ -3326,6 +3342,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  wave:
+    dependency: "direct main"
+    description:
+      name: wave
+      sha256: "3a22d3122de63888e70c88920bdf686e360e5ec3e3bdb037d4da228d68d3556e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dependencies:
   flutter_local_notifications: ^22.0.1
   flutter_map_marker_popup: ^8.1.0
   flutter_markdown_plus: ^1.0.7
+  flutter_moving_background: ^0.4.0
   flutter_slidable: ^4.0.1
   flutter_sliding_up_panel: ^2.1.1
   flutter_staggered_grid_view: ^0.7.0
@@ -134,7 +135,7 @@ dependencies:
   on_exit: ^1.0.0
   open_filex: ^4.7.0
   package_info_plus: ^9.0.1
-  particles_flutter: ^2.0.2
+  particles_flutter: ^3.2.0
   pasteboard: ^0.5.0
   path_provider: ^2.1.5 # no web support
   path_provider_linux: ^2.2.1 # desktop shared_preferences store path resolution

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   ffmpeg_kit_flutter_new_min: ^3.6.2
   flutter_contacts: ^2.0.2  # mobile only
   file_picker: ^11.0.2
+  floating_animation: ^1.1.0
   firebase_dart:
     git:
       url: https://github.com/appsup-dart/firebase_dart.git
@@ -177,6 +178,7 @@ dependencies:
   vcf_dart: ^1.0.2
   version: ^3.0.2
   video_player: ^2.10.0
+  wave: ^0.2.5
   win32: ^5.10.1
   window_manager: ^0.5.1
   windows_taskbar: ^1.1.2


### PR DESCRIPTION
Sliders across settings pages were plain Material widgets even under the
iOS skin, unlike BBSwitch/BBChip which already skin themselves. BBSlider
renders CupertinoSlider on iOS and a Material 3 Expressive-styled Slider
(via the new m3e/m3e_slider.dart theme helper) on Material/Samsung, with
divisions/steps supported on both. SettingsSlider now delegates to it
internally, and the background-crop blur slider and sync-setup message
count slider are migrated directly.