### PR TITLE
fix: deliver notification replies when the app has been killed

### DIFF
--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
@@ -19,7 +19,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 object DartWorkManager {
-    fun createWorker(context: Context, method: String, arguments: HashMap<String, Any?>, callback: () -> (Unit)) {
+    /// [callback] receives whether the Dart work actually SUCCEEDED. Callers must not
+    /// treat completion as success: WorkManager also reaches a finished state on FAILED
+    /// and CANCELLED, which is exactly what happens when a cold engine boot fails while
+    /// the app is killed. Reporting those as success makes the UI claim work was done
+    /// that never happened (e.g. a notification reply that was never sent).
+    fun createWorker(context: Context, method: String, arguments: HashMap<String, Any?>, callback: (Boolean) -> (Unit)) {
         PersistentLog.d(context, Constants.logTag, "Creating new ${Constants.dartWorkerTag} for method $method")
         val gson = GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
@@ -58,9 +63,13 @@ object DartWorkManager {
                         PersistentLog.w(context, Constants.logTag, "Work record for method $method was pruned before completion was observed")
                         return@Observer
                     }
+                    val succeeded = workInfo.state == WorkInfo.State.SUCCEEDED
+                    if (!succeeded) {
+                        PersistentLog.e(context, Constants.logTag, "Worker for method $method finished unsuccessfully (state: ${workInfo.state})")
+                    }
                     PersistentLog.d(context, Constants.logTag, "Running callback after worker with method $method completed (state: ${workInfo.state})")
                     try {
-                        callback()
+                        callback(succeeded)
                     } catch (e: Exception) {
                         PersistentLog.e(context, Constants.logTag, "Error running callback for worker $method", e)
                     }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
@@ -136,8 +136,18 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
                     suspendCancellableCoroutine { cont ->
                         MethodChannel(engineToUse.dartExecutor.binaryMessenger, Constants.methodChannel).invokeMethod(method, gson.fromJson(data, TypeToken.getParameterized(HashMap::class.java, String::class.java, Any::class.java).type), object : MethodChannel.Result {
                             override fun success(result: Any?) {
-                                PersistentLog.d(applicationContext, Constants.logTag, "Worker with method $method completed successfully")
-                                if (cont.isActive) cont.resume(Result.success())
+                                // A handler that returns false is asking to be retried (see
+                                // MethodChannelService._callHandler). That is still a *successful*
+                                // method-channel call, so it arrives here rather than in error() —
+                                // ignoring the value silently converted every "retry me" into
+                                // "done", permanently dropping the event.
+                                if (result == false) {
+                                    PersistentLog.w(applicationContext, Constants.logTag, "Worker with method $method asked to be retried")
+                                    if (cont.isActive) cont.resume(retryOrFail(method, "Dart requested a retry"))
+                                } else {
+                                    PersistentLog.d(applicationContext, Constants.logTag, "Worker with method $method completed successfully")
+                                    if (cont.isActive) cont.resume(Result.success())
+                                }
                                 closeEngineIfNeeded()
                             }
 

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/InternalIntentReceiver.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/intents/InternalIntentReceiver.kt
@@ -50,7 +50,7 @@ class InternalIntentReceiver: BroadcastReceiver() {
                 val messageGuid: String? = intent.getStringExtra("messageGuid")
                 val replyText = RemoteInput.getResultsFromIntent(intent)?.getString("text_reply") ?: return
 
-                DartWorkManager.createWorker(context, intent.type!!, hashMapOf("chatGuid" to chatGuid, "messageGuid" to messageGuid, "text" to replyText)) {
+                DartWorkManager.createWorker(context, intent.type!!, hashMapOf("chatGuid" to chatGuid, "messageGuid" to messageGuid, "text" to replyText)) { succeeded ->
                     val notificationManager = context.getSystemService(NotificationManager::class.java)
                     // this is used to copy the style, since the notification already exists
                     PersistentLog.d(context, Constants.logTag, "Fetching existing notification values")
@@ -99,8 +99,11 @@ class InternalIntentReceiver: BroadcastReceiver() {
                             e.printStackTrace()
                         }
                     }
+                    // Render the reply as undelivered when the Dart work did not succeed.
+                    // Showing it as a normal sent message would tell the user their reply
+                    // went through when it never left the device — silent message loss.
                     messagingStyle.addMessage(Notification.MessagingStyle.Message(
-                        replyText,
+                        if (succeeded) replyText else "⚠ Not sent: $replyText",
                         System.currentTimeMillis(),
                         sender.build()
                     ))

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -378,6 +378,16 @@ class StartupTasks {
       dispose: (svc) => svc.dispose(),
     );
 
+    // Required for any send initiated while the app is killed — notably replying
+    // from a notification, which routes through OutgoingMsgHandler.queue(). Without
+    // it the send throws "OutgoingMessageHandler is not registered inside GetIt"
+    // and the reply is silently lost.
+    Logger.info("Registering OutgoingMessageHandler...");
+    GetIt.I.registerSingleton<OutgoingMessageHandler>(
+      OutgoingMessageHandler(),
+      dispose: (svc) => svc.dispose(),
+    );
+
     await _waitForInterop(methodChannel: true);
 
     Logger.info("Background isolate services initialization complete");

--- a/lib/services/backend/java_dart_interop/method_channel_handlers.dart
+++ b/lib/services/backend/java_dart_interop/method_channel_handlers.dart
@@ -245,37 +245,64 @@ class MethodChannelHandlers {
     final Map<String, dynamic>? data = arguments;
     if (data == null) return _ok();
 
+    // Guards against the same reply being delivered twice (e.g. WorkManager
+    // redelivering the event). This is a duplicate, not a failure — return _ok() so
+    // the worker stops, rather than _retry() which would burn the retry budget
+    // re-discovering the same duplicate.
     final recentReply = PrefsSvc.messaging.getRecentReply();
     final recentReplyGuid = recentReply?.messageGuid;
     final recentReplyText = recentReply?.text;
-    if (recentReplyGuid == data['messageGuid'] && recentReplyText == data['text']) return _retry();
-
-    await PrefsSvc.messaging.setRecentReply(
-      messageGuid: data['messageGuid'],
-      text: data['text'],
-    );
-    Logger.info('Updated recent reply cache to ${PrefsSvc.messaging.getRecentReplyRaw()}');
+    if (recentReplyGuid == data['messageGuid'] && recentReplyText == data['text']) {
+      Logger.info('Ignoring duplicate reply for message ${data['messageGuid']}');
+      return _ok();
+    }
 
     final Chat? chat = Chat.findOne(guid: data['chatGuid']);
     if (chat == null) return _retry();
+
+    // Held so the temp GUID assigned during queueing can be used to check the
+    // send outcome below.
+    final replyMessage = Message(
+      text: data['text'],
+      dateCreated: DateTime.now(),
+      hasAttachments: false,
+      isFromMe: true,
+      handleId: 0,
+    );
 
     final Completer<void> completer = Completer();
     OutgoingMsgHandler.queue(
       OutgoingMessage(
         completer: completer,
         chat: chat,
-        message: Message(
-          text: data['text'],
-          dateCreated: DateTime.now(),
-          hasAttachments: false,
-          isFromMe: true,
-          handleId: 0,
-        ),
+        message: replyMessage,
         clearNotificationsIfFromMe: false,
       ),
     );
 
     await completer.future;
+
+    // A failed send is finalized inside the handler — the message is persisted with
+    // an error code — and the completer still completes *normally*, so waiting on it
+    // says nothing about success. Re-read the queued message to find out. On success
+    // the temp GUID is swapped for the real one and this lookup finds nothing.
+    final tempGuid = replyMessage.guid;
+    final sent = tempGuid == null ? null : Message.findOne(guid: tempGuid);
+    if (sent != null && sent.error != 0) {
+      Logger.error('Reply failed to send (error ${sent.error}); requesting retry');
+      return _retry();
+    }
+
+    // Only now that the send has actually resolved is it safe to record this reply
+    // as "recent". Writing it earlier meant a failed send poisoned its own retry:
+    // the retry saw the cache entry, treated itself as a duplicate, and dropped the
+    // message while reporting success.
+    await PrefsSvc.messaging.setRecentReply(
+      messageGuid: data['messageGuid'],
+      text: data['text'],
+    );
+    Logger.info('Updated recent reply cache to ${PrefsSvc.messaging.getRecentReplyRaw()}');
+
     return _ok();
   }
 


### PR DESCRIPTION
## Problem

Replying from a notification while the app is killed silently drops the message. The notification renders the reply as if it were sent, but nothing is ever delivered.

Three separate bugs stack up to produce this.

### 1. `OutgoingMessageHandler` is never registered in the DartWorker isolate

`initBackgroundIsolate` registers `IncomingMessageHandler` but not its outgoing counterpart, so the send throws before it reaches the network:

```
Worker with method ReplyChat failed! (error: Bad state: GetIt: Object/factory with
type OutgoingMessageHandler is not registered inside GetIt. Did you forget to register it?)
```

The whole handler ran in **2ms** — it never got as far as an HTTP request.

### 2. The recent-reply cache is written before the send resolves

`_handleReplyChat` wrote the dedupe cache up front, then attempted the send. WorkManager correctly retried after the failure above, but the retry found the cache entry, concluded it was a duplicate, and dropped the message.

### 3. `DartWorker` discards the value passed to `MethodChannel.Result.success()`

Returning `false` from a Dart handler means "retry me" (documented in `MethodChannelService._callHandler`), but returning `false` is still a *successful* method-channel call, so it lands in `success()` rather than `error()`. The value was ignored and the work resumed `Result.success()`, converting every retry request into "done" and permanently dropping the event.

**This one is not specific to replies** — it silently discarded `_retry()` from every handler, including `_handleNewMessage` and `_handleNewServerUrl`.

## Also fixed

A failed send is finalized inside `_finalizeOutgoingFailure`, which persists the message with an error code but still completes the item's completer *normally*. Awaiting the completer therefore said nothing about the outcome. The reply handler now re-reads the queued message and requests a retry when it carries an error, and `DartWorkManager` passes the real terminal state to its callback so a reply that did not send renders as "Not sent" instead of appearing delivered.

## Verification

Reproduced and verified on a physical device (Galaxy Z Fold, One UI 8 / Android 17) by killing the app, receiving a message, and replying from the notification.

Before:

```
Received reply to message from Kotlin
Worker with method ReplyChat failed! (Bad state: GetIt ... OutgoingMessageHandler ...)
Worker result RETRY
  -> retry deduped itself against the prematurely-written cache
  -> reported SUCCEEDED, notification showed the reply as sent, nothing delivered
```

After:

```
11:08:42.847  Received reply to message from Kotlin
11:08:43.008  [POST] /api/v1/message/text
11:08:44.246  Updated recent reply cache
11:08:44.248  Worker with method ReplyChat completed successfully
```

Message delivered. Also confirmed that a genuinely failing send (server misconfigured, request timing out) now surfaces as a failure and retries, rather than reporting success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)