### PR TITLE
fix: open the keyboard when launching straight into a chat

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
@@ -21,6 +21,7 @@ import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' hide context;
@@ -75,12 +76,14 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
     // Save state
     localController.oldTextFieldSelection.value = controller.textController.selection;
 
+    // Let callers that don't rebuild this widget (re-entering an already-open chat,
+    // app resume) drive the keyboard through the same retry-until-visible path.
+    controller.ensureComposerKeyboard = focusComposerAndShowKeyboard;
+
     if (controller.fromChatCreator) {
       controller.focusNode.requestFocus();
     } else if (SettingsSvc.settings.autoOpenKeyboard.value && !controller.fromSearchResult) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        controller.focusNode.requestFocus();
-      });
+      _autoFocusWhenSettled();
     }
 
     controller.focusNode.addListener(() => focusListener(false));
@@ -311,8 +314,72 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
     }
   }
 
+  /// Focuses the composer and makes sure the keyboard actually appears.
+  ///
+  /// `requestFocus()` alone is enough when the user taps a chat from the list, but not
+  /// when the app is launched straight into a conversation from a launcher shortcut or
+  /// an `imessage://` URI. In that case the node does take focus, yet the platform
+  /// never raises the keyboard: the engine's input connection is still being set up
+  /// (and is restarted during startup), which swallows the show request without
+  /// telling the framework — the same engine behaviour the resume path works around in
+  /// [StartupTasks], see https://github.com/flutter/flutter/issues/52599.
+  ///
+  /// So ask for the keyboard explicitly once the connection has settled.
+  void _autoFocusWhenSettled() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      focusComposerAndShowKeyboard();
+    });
+  }
+
+  /// Focuses the message field and drives the keyboard up, retrying until it is
+  /// actually visible. Exposed on the controller for callers that re-enter an
+  /// already-open conversation, where this widget is never rebuilt.
+  void focusComposerAndShowKeyboard() {
+    if (!mounted) return;
+    controller.focusNode.requestFocus();
+    unawaited(_ensureKeyboardShown());
+  }
+
+  /// Keeps asking the platform for the keyboard until it is actually on screen.
+  ///
+  /// A single show request is unreliable during startup: the engine tears down and
+  /// re-creates its input connection several times, and a request that lands in one
+  /// of those gaps is dropped without any error. Retrying blindly a fixed number of
+  /// times still loses the race intermittently, so poll until the keyboard reports
+  /// itself visible via the bottom view inset and stop as soon as it does.
+  Future<void> _ensureKeyboardShown() async {
+    const interval = Duration(milliseconds: 400);
+    const maxAttempts = 12; // ~5s, well past the startup churn
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      await Future.delayed(interval);
+      if (!mounted) return;
+
+      // Stop if the composer no longer owns focus — the user may have navigated
+      // away, or an overlay/sub-route may have taken over. Continuing here would
+      // fight whatever took over.
+      if (!controller.focusNode.hasFocus) return;
+      if (controller.showingOverlays || controller.showingSubRoute) return;
+
+      if (MediaQuery.of(context).viewInsets.bottom > 0) {
+        Logger.debug('Composer keyboard visible after $attempt attempt(s)', tag: 'ConversationTextField');
+        return;
+      }
+
+      SystemChannels.textInput.invokeMethod('TextInput.show');
+    }
+
+    Logger.warn('Composer keyboard never appeared after $maxAttempts attempts', tag: 'ConversationTextField');
+  }
+
   @override
   void dispose() {
+    // Only clear the hook if it still points at this instance — a replacement
+    // composer may already have registered itself during a rebuild.
+    if (identical(controller.ensureComposerKeyboard, focusComposerAndShowKeyboard)) {
+      controller.ensureComposerKeyboard = null;
+    }
+
     final draftText = controller.textController.text.trim().isNotEmpty ? controller.textController.text : '';
     final draftAttachments = controller.pickedAttachments.where((e) => e.path != null).map((e) => e.path!).toList();
     // Update ChatState synchronously and fire DB save in the background.

--- a/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
@@ -351,6 +351,12 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
     const interval = Duration(milliseconds: 400);
     const maxAttempts = 12; // ~5s, well past the startup churn
 
+    // Once the keyboard has been up even once, we must NOT keep re-showing it: the user
+    // pressing Back hides the IME but leaves the field focused, so re-issuing the show
+    // would fight them and the keyboard would "keep coming back". So only retry the show
+    // until it first appears; after that, stop for good.
+    bool everShown = false;
+
     for (int attempt = 1; attempt <= maxAttempts; attempt++) {
       await Future.delayed(interval);
       if (!mounted) return;
@@ -361,15 +367,24 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
       if (!controller.focusNode.hasFocus) return;
       if (controller.showingOverlays || controller.showingSubRoute) return;
 
-      if (MediaQuery.of(context).viewInsets.bottom > 0) {
-        Logger.debug('Composer keyboard visible after $attempt attempt(s)', tag: 'ConversationTextField');
-        return;
+      final keyboardUp = MediaQuery.of(context).viewInsets.bottom > 0;
+      if (keyboardUp) {
+        if (!everShown) {
+          Logger.debug('Composer keyboard visible after $attempt attempt(s)', tag: 'ConversationTextField');
+        }
+        everShown = true;
+        // Keep observing (cheaply) so we can detect a user dismissal below, but never
+        // force it back up once it has appeared.
+        continue;
       }
+
+      // Insets are zero. If the keyboard had already come up, the user just dismissed
+      // it (e.g. Back) — respect that and stop. Only force a show while it has never
+      // appeared yet (the cold-start engine race this method exists for).
+      if (everShown) return;
 
       SystemChannels.textInput.invokeMethod('TextInput.show');
     }
-
-    Logger.warn('Composer keyboard never appeared after $maxAttempts attempts', tag: 'ConversationTextField');
   }
 
   @override

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -477,6 +477,14 @@ class StartupTasks {
         if (!_cvc.showingOverlays && !_cvc.showingSubRoute && _cvc.editing.isEmpty) {
           if (kIsDesktop || SettingsSvc.settings.autoOpenKeyboard.value) {
             _cvc.lastFocusedNode.requestFocus();
+            // Focus alone frequently fails to raise the keyboard on Android (the
+            // engine's input-connection restart swallows the show request), so drive
+            // it through the composer's retry-until-visible path when available.
+            // Skip when the subject field was the last focused one — the composer
+            // helper focuses the message field and would move focus off the subject.
+            if (!kIsDesktop && identical(_cvc.lastFocusedNode, _cvc.focusNode)) {
+              _cvc.ensureComposerKeyboard?.call();
+            }
           } else if (_cvc.lastFocusedNode.hasFocus) {
             // The field keeps its focus across a background/resume cycle, but
             // the Android engine fails to restore the keyboard on resume: the

--- a/lib/services/backend/java_dart_interop/intents_service.dart
+++ b/lib/services/backend/java_dart_interop/intents_service.dart
@@ -270,6 +270,13 @@ class IntentsService {
       } else {
         Logger.debug("Chat is already open, not navigating", tag: "IntentsService");
         setPickedAttachments();
+
+        // No navigation means the composer is never rebuilt, so its own auto-focus
+        // never runs. Re-opening a chat the user had dismissed the keyboard in should
+        // still bring it back, exactly as if the view had been pushed fresh.
+        if (SettingsSvc.settings.autoOpenKeyboard.value) {
+          cvc(chat).ensureComposerKeyboard?.call();
+        }
       }
     }
   }

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -67,6 +67,16 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   /// True while any route is pushed on top of the conversation view route (e.g.
   /// ConversationDetails). Used by onAppResume to skip keyboard auto-focus on mobile.
   bool showingSubRoute = false;
+
+  /// Set by the composer while it is mounted. Focuses the message field and keeps
+  /// asking the platform for the keyboard until it is actually on screen.
+  ///
+  /// Needed because a plain `requestFocus()` is not enough to raise the keyboard in
+  /// several situations (cold start, engine input-connection churn), and because
+  /// callers that re-enter an already-open conversation never rebuild the composer,
+  /// so its own initState-time handling does not run for them.
+  void Function()? ensureComposerKeyboard;
+
   bool _subjectWasLastFocused = false; // If this is false, then message field was last focused (default)
 
   FocusNode get lastFocusedNode => _subjectWasLastFocused ? subjectFocusNode : focusNode;


### PR DESCRIPTION
## Problem

With **auto open keyboard** enabled, the keyboard does not appear when the app is launched directly into a conversation:

- from a launcher shortcut
- from an `imessage://` URI
- when re-entering a chat that is already open with the keyboard dismissed

Opening a chat normally from the chat list works, which is why this is easy to miss.

## Cause

The composer *does* take focus in all of those cases — this is not a focus bug. Verified on a physical device (Galaxy Z Fold, One UI 8) with `dumpsys` right after a cold start into a chat:

```
mCurrentFocus=Window{... com.bluebubbles.messaging/.MainActivity}   <- window focused
mServedView=io.flutter.embedding.android.FlutterView                <- IME bound to Flutter
mServedInputConnection=RemoteInputConnectionImpl{connection=
    io.flutter.plugin.editing.InputConnectionAdaptor@...}           <- a field IS focused
mInputShown=false                                                   <- keyboard not shown
```

The engine tears down and re-creates its input connection several times while the app is still starting. A show request that lands in one of those gaps is dropped silently, with nothing reported back to the framework. `StartupTasks` already works around the same engine behaviour on the resume path — see [flutter#52599](https://github.com/flutter/flutter/issues/52599).

Opening a chat from the list is unaffected because the app is already settled by then.

## Fix

Ask for the keyboard explicitly, and keep asking until it is actually on screen.

A single `TextInput.show`, and even a fixed set of retries, still loses the race intermittently — measured **2 of 3** cold starts with three fixed retries. So poll instead, and stop as soon as `MediaQuery.viewInsets.bottom` confirms the keyboard is up (bounded to ~5s). It bails out early if the composer loses focus or an overlay/sub-route takes over, so it can never fight the user or a navigation.

Two callers never rebuild the composer, so its `initState` handling cannot help them:

- `IntentsService.openChat` takes its `chatIsOpen` branch and does not navigate — this is the "re-enter an already-open chat" case
- the app-resume path in `StartupTasks` called `requestFocus()` with no show follow-up when `autoOpenKeyboard` was set, so it had the same latent gap

Both now drive the same routine through a new `ensureComposerKeyboard` hook on `ConversationViewController`, registered by the composer while mounted. The resume path skips it when the subject field was the last focused one, so focus is never yanked off the subject line.

## Verification

Reproduced and verified on device by cold-starting straight into a conversation (`am force-stop` then `am start` with the shortcut's intent) and reading `mInputShown` from `dumpsys input_method`, plus manual testing of the shortcut, URI, already-open-chat, and open-from-list paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)