### PR TITLE
fix: stop flashing an FCM registration error toast on transient startup failures

### DIFF
--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -383,6 +383,33 @@ class StartupTasks {
     Logger.info("Background isolate services initialization complete");
   }
 
+  /// Registers this device with FCM, retrying transient failures before bothering the
+  /// user. The old code showed a "Failed to register FCM device!" error toast on the
+  /// first failure, so a momentary network hiccup during startup (server briefly
+  /// unreachable, token not ready) flashed the toast on nearly every launch even though
+  /// registration is not user-actionable and usually succeeds on a retry. Only surface it
+  /// if it keeps failing across the whole backoff.
+  static Future<void> _registerFcmDeviceWithRetry() async {
+    const backoff = [Duration(seconds: 3), Duration(seconds: 10), Duration(seconds: 30)];
+    for (int attempt = 0; attempt <= backoff.length; attempt++) {
+      try {
+        await FirebaseSvc.registerDevice();
+        if (attempt > 0) {
+          Logger.info("FCM device registered after ${attempt + 1} attempt(s)");
+        }
+        return;
+      } catch (e, s) {
+        final lastAttempt = attempt == backoff.length;
+        Logger.warn("Failed to register FCM device on startup (attempt ${attempt + 1})", error: e, trace: s);
+        if (lastAttempt) {
+          showToast("Failed to register FCM device!", isError: true);
+          return;
+        }
+        await Future.delayed(backoff[attempt]);
+      }
+    }
+  }
+
   static Future<void> onStartup() async {
     Logger.info("Running onStartup tasks...");
 
@@ -405,11 +432,7 @@ class StartupTasks {
     // Only register FCM device on startup
     // Don't await. Let this happen in background
     Logger.info("Registering FCM device in background...");
-    FirebaseSvc.registerDevice().catchError((e, s) {
-      Logger.warn("Failed to register FCM device on startup!", error: e, trace: s);
-      showToast("Failed to register FCM device!", isError: true);
-      return null; // Return null on error
-    });
+    unawaited(_registerFcmDeviceWithRetry());
 
     // We don't need to check for updates immediately, so delay it so other
     // code has a chance to run and we don't block the UI thread.


### PR DESCRIPTION
## Problem

On startup, `StartupTasks` fires `FirebaseSvc.registerDevice()` in the background and shows an error toast on the **first** failure:

```dart
FirebaseSvc.registerDevice().catchError((e, s) {
  Logger.warn("Failed to register FCM device on startup!", error: e, trace: s);
  showToast("Failed to register FCM device!", isError: true);   // fires on ANY error
});
```

Because registration races network readiness during startup, a momentary hiccup — server briefly unreachable, FCM token not ready yet, transient auth timeout — throws and flashes the toast. In practice this shows up **intermittently on nearly every launch**, for something the user can't act on and that normally succeeds on its own shortly after.

## Fix

Retry the registration with backoff (3s / 10s / 30s) and only surface the toast if it still fails across the whole sequence. Transient startup failures resolve silently; a genuinely persistent failure is still reported.

No behavior change beyond the toast timing — registration itself is unchanged, still runs in the background, and the manual "register" button in Firebase settings is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)