### PR TITLE
fix: auto-open the keyboard when launching into a chat, without fighting Back

### DIFF
--- a/lib/app/layouts/conversation_view/pages/conversation_view.dart
+++ b/lib/app/layouts/conversation_view/pages/conversation_view.dart
@@ -12,6 +12,7 @@ import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
 import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window_effect.dart';
@@ -207,6 +208,20 @@ class ConversationViewState extends State<ConversationView> with ThemeHelpers<Co
   void dispose() {
     routeObserver.unsubscribe(this);
     controller.saveReplyToMessageState(); // P8bda
+    // Free the controller when its view is permanently gone. close() only runs on an
+    // explicit Back (PopScope); a route torn down another way — a shortcut replacing the
+    // view, rapid navigation — would otherwise leave the controller (and its FocusNodes,
+    // KeyboardVisibility subscription and animation listeners) registered forever, to be
+    // reused after disposal by a later open and crash the render tree. Skip if this chat
+    // is still the foreground one (the view is being rebuilt, not left) or if a newer
+    // controller already replaced ours. Desktop/web keep chats alive out-of-route.
+    if (!kIsDesktop &&
+        !kIsWeb &&
+        ChatsSvc.activeChatGuid.value != chat.guid &&
+        Get.isRegistered<ConversationViewController>(tag: controller.tag) &&
+        identical(Get.find<ConversationViewController>(tag: controller.tag), controller)) {
+      Get.delete<ConversationViewController>(tag: controller.tag);
+    }
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
@@ -55,6 +55,12 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
   /// different chat is viewed, so returning to a chat later re-opens as expected.
   static String? _lastAutoFocusedChatGuid;
 
+  /// Set the first time any composer runs its keyboard retry — a proxy for "how long ago
+  /// this process launched." A shortcut that opens straight into a chat hits this while the
+  /// engine is still restarting its input connection, so those opens get a longer retry
+  /// window (see [_ensureKeyboardShown]).
+  static DateTime? _firstKeyboardAttemptAt;
+
   final recorderController = kIsWeb ? null : RecorderController();
   final localController = ConversationTextFieldLocalController();
   final _emojiScrollController = ScrollController();
@@ -71,6 +77,18 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
   RxBool get showEmojiPicker => controller.showEmojiPicker;
 
   final proxyController = TextEditingController();
+
+  // Stable references so these can be removed in dispose(). The focus nodes and text
+  // controllers live on the ConversationViewController, which outlives this widget and
+  // can be reused when the composer is recreated (e.g. the Flutter surface is destroyed
+  // and rebuilt in split-screen). Disposing those nodes here would leave the reused
+  // controller holding a dead FocusNode, so the next composer's initState crashes with
+  // "A FocusNode was used after being disposed." We therefore only add/remove listeners
+  // here and let the controller own their disposal (see ConversationViewController.onClose).
+  void _focusNodeListener() => focusListener(false);
+  void _subjectFocusNodeListener() => focusListener(true);
+  void _textControllerListener() => textListener(false);
+  void _subjectTextControllerListener() => textListener(true);
 
   @override
   void initState() {
@@ -95,11 +113,11 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
       _autoFocusWhenSettled();
     }
 
-    controller.focusNode.addListener(() => focusListener(false));
-    controller.subjectFocusNode.addListener(() => focusListener(true));
+    controller.focusNode.addListener(_focusNodeListener);
+    controller.subjectFocusNode.addListener(_subjectFocusNodeListener);
 
-    controller.textController.addListener(() => textListener(false));
-    controller.subjectTextController.addListener(() => textListener(true));
+    controller.textController.addListener(_textControllerListener);
+    controller.subjectTextController.addListener(_subjectTextControllerListener);
 
     if (kIsDesktop || kIsWeb) {
       proxyController.addListener(() {
@@ -360,6 +378,15 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
   /// already-open conversation, where this widget is never rebuilt.
   void focusComposerAndShowKeyboard() {
     if (!mounted) return;
+    // This is an explicit request to raise the keyboard for the foreground chat (entry
+    // auto-open, re-open from a shortcut, or resume). Clear any stale overlay/sub-route
+    // flags first: they live on the ConversationViewController, which is reused across
+    // opens, and a value left set by a picker or a details route whose cleanup was skipped
+    // would make _ensureKeyboardShown bail immediately so the keyboard never appears — the
+    // "works a few times then stops" failure. A genuine overlay opened mid-retry still
+    // stops the loop, because it re-sets the flag and the loop re-checks each attempt.
+    controller.showingOverlays = false;
+    controller.showingSubRoute = false;
     _lastAutoFocusedChatGuid = chatGuid;
     controller.focusNode.requestFocus();
     unawaited(_ensureKeyboardShown());
@@ -372,16 +399,25 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
   /// re-creates its input connection several times, and a request that lands in one of
   /// those gaps is dropped without any error. So retry briefly — but only briefly.
   ///
-  /// The retry window MUST stay short. In split-screen / multi-window (common on the
-  /// Fold) the IME doesn't resize this window, so neither `viewInsets.bottom` nor
+  /// The window is short for warm opens and longer for cold (just-launched) opens.
+  ///
+  /// Why short by default: in split-screen / multi-window (common on the Fold) the IME
+  /// doesn't resize this window, so neither `viewInsets.bottom` nor
   /// `KeyboardVisibilityController` ever report the keyboard as visible — the loop can't
-  /// detect success and would run to its full length. Every `TextInput.show` it fires
-  /// after the user has dismissed the keyboard re-raises it, so a long loop makes Back
-  /// appear broken (dismiss → instantly pops back up). Keeping the window to ~1s means
-  /// the retries finish before the user reads and dismisses, so a dismissal sticks.
+  /// detect success. Every `TextInput.show` it fires after the user has dismissed the
+  /// keyboard re-raises it, so a long loop there makes Back appear broken (dismiss →
+  /// instantly pops back up). A ~1s window finishes before the user reads and dismisses.
+  ///
+  /// Why longer when cold: a shortcut that launches straight into a chat races the engine's
+  /// input-connection churn, which lasts longer than 1s, so a short window often misses and
+  /// the keyboard never appears. A cold open is fullscreen (it resizes), so the loop DOES
+  /// get a visibility signal and exits the moment the keyboard is up — a longer window there
+  /// doesn't fight a dismissal. The extra time only applies right after launch.
   Future<void> _ensureKeyboardShown() async {
     const interval = Duration(milliseconds: 250);
-    const maxAttempts = 4; // ~1s — long enough for cold-start churn, short enough not to fight a dismiss
+    _firstKeyboardAttemptAt ??= DateTime.now();
+    final coldStart = DateTime.now().difference(_firstKeyboardAttemptAt!) < const Duration(seconds: 8);
+    final maxAttempts = coldStart ? 20 : 4; // ~5s cold (outlast startup churn), ~1s warm
 
     for (int attempt = 1; attempt <= maxAttempts; attempt++) {
       await Future.delayed(interval);
@@ -418,10 +454,12 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
     unawaited(ChatsSvc.setChatTextFieldText(chat, draftText));
     unawaited(ChatsSvc.setChatTextFieldAttachments(chat, draftAttachments));
 
-    controller.focusNode.dispose();
-    controller.subjectFocusNode.dispose();
-    controller.textController.dispose();
-    controller.subjectTextController.dispose();
+    // Remove only our listeners — the ConversationViewController owns these nodes and
+    // controllers and disposes them in onClose(). See the field comments above.
+    controller.focusNode.removeListener(_focusNodeListener);
+    controller.subjectFocusNode.removeListener(_subjectFocusNodeListener);
+    controller.textController.removeListener(_textControllerListener);
+    controller.subjectTextController.removeListener(_subjectTextControllerListener);
     recorderController?.dispose();
     _emojiScrollController.dispose();
     controller.showAttachmentPicker.value = false;

--- a/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
+++ b/lib/app/layouts/conversation_view/widgets/text_field/conversation_text_field.dart
@@ -21,6 +21,7 @@ import 'package:bluebubbles/utils/logger/logger.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' hide context;
@@ -45,6 +46,15 @@ class ConversationTextField extends CustomStateful<ConversationViewController> {
 
 class ConversationTextFieldState extends CustomState<ConversationTextField, void, ConversationViewController>
     with TickerProviderStateMixin {
+  /// The chat whose composer last auto-opened the keyboard. Tracked statically because
+  /// both the composer's State and its ConversationViewController are recreated while a
+  /// chat stays open (e.g. every time the view insets change when the user dismisses the
+  /// keyboard), so any per-widget or per-controller flag resets and the auto-open re-fires
+  /// — the keyboard "keeps coming back". A static value survives those recreations, so the
+  /// auto-open fires once per *visited* chat and a dismissal sticks. It updates whenever a
+  /// different chat is viewed, so returning to a chat later re-opens as expected.
+  static String? _lastAutoFocusedChatGuid;
+
   final recorderController = kIsWeb ? null : RecorderController();
   final localController = ConversationTextFieldLocalController();
   final _emojiScrollController = ScrollController();
@@ -75,12 +85,14 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
     // Save state
     localController.oldTextFieldSelection.value = controller.textController.selection;
 
+    // Let callers that don't rebuild this widget (re-entering an already-open chat,
+    // app resume) drive the keyboard through the same retry-until-visible path.
+    controller.ensureComposerKeyboard = focusComposerAndShowKeyboard;
+
     if (controller.fromChatCreator) {
       controller.focusNode.requestFocus();
     } else if (SettingsSvc.settings.autoOpenKeyboard.value && !controller.fromSearchResult) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        controller.focusNode.requestFocus();
-      });
+      _autoFocusWhenSettled();
     }
 
     controller.focusNode.addListener(() => focusListener(false));
@@ -311,8 +323,95 @@ class ConversationTextFieldState extends CustomState<ConversationTextField, void
     }
   }
 
+  /// Focuses the composer and makes sure the keyboard actually appears.
+  ///
+  /// `requestFocus()` alone is enough when the user taps a chat from the list, but not
+  /// when the app is launched straight into a conversation from a launcher shortcut or
+  /// an `imessage://` URI. In that case the node does take focus, yet the platform
+  /// never raises the keyboard: the engine's input connection is still being set up
+  /// (and is restarted during startup), which swallows the show request without
+  /// telling the framework — the same engine behaviour the resume path works around in
+  /// [StartupTasks], see https://github.com/flutter/flutter/issues/52599.
+  ///
+  /// So ask for the keyboard explicitly once the connection has settled.
+  ///
+  /// This runs from initState. Both this widget's State and its controller are recreated
+  /// while a chat stays open (view-inset changes recreate them), so a per-widget or
+  /// per-controller flag can't stop the auto-open from re-firing after the user dismisses
+  /// the keyboard. [_lastAutoFocusedChatGuid] is static, so the automatic open fires once
+  /// per visited chat and a dismissal sticks. Explicit re-focus requests (re-entering from
+  /// a shortcut, app resume) still go through focusComposerAndShowKeyboard directly.
+  void _autoFocusWhenSettled() {
+    // Only the active (foreground) chat's composer may auto-open. A previous chat's view
+    // can stay mounted during navigation, and its composer would otherwise fight the
+    // active one for the keyboard — each recreation re-grabbing focus — so the keyboard
+    // ping-pongs and never stays dismissed.
+    if (ChatsSvc.activeChatGuid.value != chatGuid) return;
+    if (_lastAutoFocusedChatGuid == chatGuid) return; // already auto-opened this chat
+    _lastAutoFocusedChatGuid = chatGuid;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || ChatsSvc.activeChatGuid.value != chatGuid) return;
+      focusComposerAndShowKeyboard();
+    });
+  }
+
+  /// Focuses the message field and drives the keyboard up, retrying until it is
+  /// actually visible. Exposed on the controller for callers that re-enter an
+  /// already-open conversation, where this widget is never rebuilt.
+  void focusComposerAndShowKeyboard() {
+    if (!mounted) return;
+    _lastAutoFocusedChatGuid = chatGuid;
+    controller.focusNode.requestFocus();
+    unawaited(_ensureKeyboardShown());
+  }
+
+  /// Nudges the platform for the keyboard a few times to cover cold-start churn, then
+  /// stops.
+  ///
+  /// A single show request is unreliable during startup: the engine tears down and
+  /// re-creates its input connection several times, and a request that lands in one of
+  /// those gaps is dropped without any error. So retry briefly — but only briefly.
+  ///
+  /// The retry window MUST stay short. In split-screen / multi-window (common on the
+  /// Fold) the IME doesn't resize this window, so neither `viewInsets.bottom` nor
+  /// `KeyboardVisibilityController` ever report the keyboard as visible — the loop can't
+  /// detect success and would run to its full length. Every `TextInput.show` it fires
+  /// after the user has dismissed the keyboard re-raises it, so a long loop makes Back
+  /// appear broken (dismiss → instantly pops back up). Keeping the window to ~1s means
+  /// the retries finish before the user reads and dismisses, so a dismissal sticks.
+  Future<void> _ensureKeyboardShown() async {
+    const interval = Duration(milliseconds: 250);
+    const maxAttempts = 4; // ~1s — long enough for cold-start churn, short enough not to fight a dismiss
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      await Future.delayed(interval);
+      if (!mounted) return;
+
+      // Stop if the composer no longer owns focus — the user may have navigated
+      // away, or an overlay/sub-route may have taken over.
+      if (!controller.focusNode.hasFocus) return;
+      if (controller.showingOverlays || controller.showingSubRoute) return;
+
+      // Stop as soon as the keyboard is known to be up. `keyboardOpen` is driven by
+      // KeyboardVisibilityController and is the signal that works when the window does
+      // resize; `viewInsets` is the fallback for contexts that still see the inset.
+      if (controller.keyboardOpen || MediaQuery.of(context).viewInsets.bottom > 0) {
+        Logger.debug('Composer keyboard visible after $attempt attempt(s)', tag: 'ConversationTextField');
+        return; // keyboard is up — done
+      }
+
+      SystemChannels.textInput.invokeMethod('TextInput.show');
+    }
+  }
+
   @override
   void dispose() {
+    // Only clear the hook if it still points at this instance — a replacement
+    // composer may already have registered itself during a rebuild.
+    if (identical(controller.ensureComposerKeyboard, focusComposerAndShowKeyboard)) {
+      controller.ensureComposerKeyboard = null;
+    }
+
     final draftText = controller.textController.text.trim().isNotEmpty ? controller.textController.text : '';
     final draftAttachments = controller.pickedAttachments.where((e) => e.path != null).map((e) => e.path!).toList();
     // Update ChatState synchronously and fire DB save in the background.

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -487,6 +487,14 @@ class StartupTasks {
         if (!_cvc.showingOverlays && !_cvc.showingSubRoute && _cvc.editing.isEmpty) {
           if (kIsDesktop || SettingsSvc.settings.autoOpenKeyboard.value) {
             _cvc.lastFocusedNode.requestFocus();
+            // Focus alone frequently fails to raise the keyboard on Android (the
+            // engine's input-connection restart swallows the show request), so drive
+            // it through the composer's retry-until-visible path when available.
+            // Skip when the subject field was the last focused one — the composer
+            // helper focuses the message field and would move focus off the subject.
+            if (!kIsDesktop && identical(_cvc.lastFocusedNode, _cvc.focusNode)) {
+              _cvc.ensureComposerKeyboard?.call();
+            }
           } else if (_cvc.lastFocusedNode.hasFocus) {
             // The field keeps its focus across a background/resume cycle, but
             // the Android engine fails to restore the keyboard on resume: the

--- a/lib/services/backend/java_dart_interop/intents_service.dart
+++ b/lib/services/backend/java_dart_interop/intents_service.dart
@@ -270,6 +270,13 @@ class IntentsService {
       } else {
         Logger.debug("Chat is already open, not navigating", tag: "IntentsService");
         setPickedAttachments();
+
+        // No navigation means the composer is never rebuilt, so its own auto-focus
+        // never runs. Re-opening a chat the user had dismissed the keyboard in should
+        // still bring it back, exactly as if the view had been pushed fresh.
+        if (SettingsSvc.settings.autoOpenKeyboard.value) {
+          cvc(chat).ensureComposerKeyboard?.call();
+        }
       }
     }
   }

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -67,6 +67,16 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   /// True while any route is pushed on top of the conversation view route (e.g.
   /// ConversationDetails). Used by onAppResume to skip keyboard auto-focus on mobile.
   bool showingSubRoute = false;
+
+  /// Set by the composer while it is mounted. Focuses the message field and keeps
+  /// asking the platform for the keyboard until it is actually on screen.
+  ///
+  /// Needed because a plain `requestFocus()` is not enough to raise the keyboard in
+  /// several situations (cold start, engine input-connection churn), and because
+  /// callers that re-enter an already-open conversation never rebuild the composer,
+  /// so its own initState-time handling does not run for them.
+  void Function()? ensureComposerKeyboard;
+
   bool _subjectWasLastFocused = false; // If this is false, then message field was last focused (default)
 
   FocusNode get lastFocusedNode => _subjectWasLastFocused ? subjectFocusNode : focusNode;
@@ -106,6 +116,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
 
   bool keyboardOpen = false;
   double _keyboardOffset = 0;
+  StreamSubscription<bool>? _keyboardSub;
   Timer? _scrollDownDebounce;
   Future<void> Function(SendData)? sendFunc;
 
@@ -144,10 +155,26 @@ class ConversationViewController extends StatefulController with GetSingleTicker
     super.onInit();
 
     textController.mentionables = mentionables;
-    KeyboardVisibilityController().onChange.listen((bool visible) async {
+    _keyboardSub = KeyboardVisibilityController().onChange.listen((bool visible) async {
+      final wasOpen = keyboardOpen;
       keyboardOpen = visible;
       if (scrollController.hasClients && scrollController.positions.length == 1) {
         _keyboardOffset = scrollController.offset;
+      }
+
+      // When the user dismisses the keyboard (e.g. the Android Back button), release the
+      // composer's focus. Otherwise the still-focused field makes the Flutter engine
+      // immediately re-raise the keyboard (flutter#52599) and Back appears to do nothing.
+      // Android's IME swallows that Back before any PopScope handler runs, so this
+      // visibility transition is the only place we can catch the dismissal.
+      //
+      // Guarded to a genuine open→closed transition on the foreground chat: the initial
+      // `false` emitted on subscribe isn't a dismissal (so entry auto-open is untouched),
+      // and only the active chat's composer should react (a backgrounded chat's leaked
+      // controller must not steal focus handling from the visible one).
+      if (wasOpen && !visible && ChatsSvc.activeChatGuid.value == chat.guid) {
+        if (focusNode.hasFocus) focusNode.unfocus();
+        if (subjectFocusNode.hasFocus) subjectFocusNode.unfocus();
       }
     });
 
@@ -189,6 +216,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
 
   @override
   void onClose() {
+    unawaited(_keyboardSub?.cancel());
     updateSmartReplyLayout(visible: false, height: 0);
     for (PlayerController a in audioPlayers.values) {
       a.pausePlayer();

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -22,14 +22,29 @@ class MessageEditEntry {
   const MessageEditEntry({required this.message, required this.part, required this.controller});
 }
 
-ConversationViewController cvc(Chat chat, {String? tag}) =>
-    Get.isRegistered<ConversationViewController>(tag: tag ?? chat.guid)
-        ? Get.find<ConversationViewController>(tag: tag ?? chat.guid)
-        : Get.put(ConversationViewController(chat, tag_: tag), tag: tag ?? chat.guid);
+ConversationViewController cvc(Chat chat, {String? tag}) {
+  final resolvedTag = tag ?? chat.guid;
+  if (Get.isRegistered<ConversationViewController>(tag: resolvedTag)) {
+    final existing = Get.find<ConversationViewController>(tag: resolvedTag);
+    // Never hand back a controller that has already been closed: its FocusNodes,
+    // animation tickers and text controllers are disposed, and a freshly-mounted
+    // composer that added listeners to them would crash with "used after disposed".
+    // This happens under rapid navigation, where a new view can resolve the controller
+    // in the window between close() and GetX finishing the eviction.
+    if (!existing.disposed) return existing;
+    Get.delete<ConversationViewController>(tag: resolvedTag, force: true);
+  }
+  return Get.put(ConversationViewController(chat, tag_: tag), tag: resolvedTag);
+}
 
 class ConversationViewController extends StatefulController with GetSingleTickerProviderStateMixin {
   final Chat chat;
   late final String tag;
+
+  /// True once [onClose] has run. A closed controller's FocusNodes/tickers/text
+  /// controllers are disposed, so [cvc] must not hand it back to a new view.
+  bool disposed = false;
+
   bool fromChatCreator = false;
   bool fromSearchResult = false;
   bool addedRecentPhotoReply = false;
@@ -216,6 +231,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
 
   @override
   void onClose() {
+    disposed = true;
     unawaited(_keyboardSub?.cancel());
     updateSmartReplyLayout(visible: false, height: 0);
     for (PlayerController a in audioPlayers.values) {
@@ -230,6 +246,14 @@ class ConversationViewController extends StatefulController with GetSingleTicker
       a.player.dispose();
     }
     scrollController.dispose();
+    // These are owned by this controller, not by the composer widget. The composer only
+    // adds/removes listeners; disposing them here (once, when the controller is actually
+    // closed) avoids leaving a reused controller with a dead FocusNode — which crashed a
+    // freshly-mounted composer with "A FocusNode was used after being disposed."
+    focusNode.dispose();
+    subjectFocusNode.dispose();
+    textController.dispose();
+    subjectTextController.dispose();
     super.onClose();
   }
 


### PR DESCRIPTION
### What

When **Auto-open keyboard** is enabled, opening a conversation *directly* — from a notification/URI, a launcher shortcut, or by re-selecting an already-open chat — did not raise the keyboard. A plain `requestFocus()` isn't enough on Android: during startup the engine restarts its input connection and silently drops the `TextInput.show` request.

This adds a composer-owned helper, `ensureComposerKeyboard`, that focuses the message field and retries `TextInput.show` until the keyboard is actually up. It's invoked from the composer's `initState`, the app-resume path (`StartupTasks`), and `IntentsService` when re-opening an already-open chat.

### Retry window: cold vs warm

- **Warm** opens use a short (~1s) window. In split-screen / multi-window (common on foldables) the IME doesn't resize the window, so neither `viewInsets` nor `KeyboardVisibilityController` ever report the keyboard visible; a long loop there would keep firing `TextInput.show` and re-raise the keyboard on every **Back**, making dismissal look broken.
- **Cold** (just-launched) opens use a longer (~5s) window, because a shortcut opening straight into a chat outlasts the engine's input-connection churn. A cold open is fullscreen and reports visibility, so the loop still exits the instant the keyboard is up and doesn't fight a dismiss.

### Don't re-raise after dismiss

`ConversationViewController` releases composer focus on a genuine open→closed keyboard transition (scoped to the foreground chat), so the engine doesn't re-raise the keyboard for the still-focused field (flutter/flutter#52599). Android's IME swallows the dismiss Back before any `PopScope` handler runs, so the keyboard-visibility transition is the only place to catch it.

### Stale overlay/sub-route guard

The retry loop bails while an overlay or sub-route is showing. Those flags live on the reused controller and are toggled by pickers / the details route / the share sheet; a skipped cleanup left one stuck `true` and blocked the keyboard on every later open ("works a few times then stops"). They're now cleared at the single entry point for every explicit keyboard-raise.

### Controller lifecycle / render-crash fixes

Rapid navigation surfaced "FocusNode used after disposed" / "deactivated widget" render crashes, rooted in leaked `ConversationViewController`s:

- FocusNodes and text controllers are now owned and disposed by the controller (`onClose`), not by the composer widget — so a reused controller never hands a freshly-mounted composer a disposed `FocusNode`.
- Controllers are disposed when their view is permanently gone (previously `close()` ran only on an explicit Back), and `cvc()` never returns a controller whose `onClose()` already ran.

### Files
- `conversation_text_field.dart` — `ensureComposerKeyboard` / bounded, cold-aware retry loop; stale-flag reset; listeners added/removed (not disposing controller-owned nodes).
- `conversation_view_controller.dart` — exposes the hook; unfocus-on-dismiss; owns FocusNode/controller disposal; `disposed` guard; cancels the keyboard-visibility subscription.
- `conversation_view.dart` — dispose the controller when its view is gone (mobile).
- `startup_tasks.dart` — drive the keyboard through the composer helper on resume.
- `intents_service.dart` — raise the keyboard when re-opening an already-open chat.

### Testing
Verified on a Samsung Fold (One UI), in split-screen and fullscreen, on a **release/profile** build: shortcut launches raise the keyboard reliably, Back dismisses without it popping back, and rapid back-and-forth no longer throws render errors.

Supersedes #3201.