### PR TITLE
bump flutter_contacts to >=2.3.0 to fix MS Exchange contact sync

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -880,10 +880,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: be8e6de65fa7ae4332c812bcd4e8b90c0d74093fbda972ce3ca2f9f34f65e93c
+      sha256: "3a018a04ffc88f8555068f86b7750c7cbc758e9ebccafa985f91353bcb6df496"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.3.1"
   flutter_displaymode:
     dependency: "direct main"
     description:
@@ -3457,4 +3457,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.41.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,13 +63,8 @@ dependencies:
   exif: ^3.3.0
   faker: ^2.2.0
   ffmpeg_kit_flutter_new_min: ^3.6.2
-  flutter_contacts: ^2.3.1  # mobile only. Must be >=2.3.0:
-  # Earlier versions filter getAll() on IN_VISIBLE_GROUP = 1,
-  # which drops contacts stored in accounts that don't mark
-  # their groups visible (e.g. Exchange/MS365)
-  # 2.3.0 queries the provider's default directory instead,
-  # matching what the system Contacts app shows.
-  # See: https://github.com/QuisApp/flutter_contacts/issues/240
+  # Must be >=2.3.0: https://github.com/QuisApp/flutter_contacts/issues/240
+  flutter_contacts: ^2.3.1  # mobile only.
   file_picker: ^11.0.2
   floating_animation: ^1.1.0
   firebase_dart:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,13 @@ dependencies:
   exif: ^3.3.0
   faker: ^2.2.0
   ffmpeg_kit_flutter_new_min: ^3.6.2
-  flutter_contacts: ^2.0.2  # mobile only
+  flutter_contacts: ^2.3.1  # mobile only. Must be >=2.3.0:
+  # Earlier versions filter getAll() on IN_VISIBLE_GROUP = 1,
+  # which drops contacts stored in accounts that don't mark
+  # their groups visible (e.g. Exchange/MS365)
+  # 2.3.0 queries the provider's default directory instead,
+  # matching what the system Contacts app shows.
+  # See: https://github.com/QuisApp/flutter_contacts/issues/240
   file_picker: ^11.0.2
   floating_animation: ^1.1.0
   firebase_dart:


### PR DESCRIPTION
Per this issue (https://github.com/QuisApp/flutter_contacts/issues/240), any contacts stored in groups not marked as "visible" are silently dropped in flutter_contacts versions prior to 2.3.1; this impacts users with Office365/Exchange contacts.