### PR TITLE
Gate message list mutations during send animation

### DIFF
--- a/docs/MESSAGE_RECEIVE_FLOW.md
+++ b/docs/MESSAGE_RECEIVE_FLOW.md
@@ -194,9 +194,33 @@ When a `ChatState` does exist:
 5. **If `oldGuid != null`** (tempGuid → realGuid swap): removes `messageStates[oldGuid]` and inserts `messageStates[realGuid]` pointing to the same state object
 6. Sets `messageUpdateTrigger[realGuid]` to the current timestamp — widgets that observe the trigger rather than individual fields are notified to rebuild
 
-**`MessagesSvc(chatGuid).addNewMessage(Message message)`** is the counterpart used for genuinely new messages (see Step 4's `_dispatchNewMessage` three-way branch) — it's a no-op if the GUID is already known to the struct.
+**`MessagesSvc(chatGuid).addNewMessage(Message message)`** is the counterpart used for genuinely new messages (see Step 4's `_dispatchNewMessage` three-way branch) — it's a no-op if the GUID is already known to the struct. It funnels into `_handleNewMessage()`, which updates the struct and `MessageState` map and then calls `newFunc` — the callback `MessagesView` registered as `handleNewMessage` (see Step 8b).
 
 **Key file:** `lib/services/ui/message/messages_service.dart`
+
+---
+
+### Step 8b — Message List Gate (`message_list_gate.dart`)
+
+`MessagesView.handleNewMessage` does not insert into the list directly. It submits the insertion to `ConversationViewController.messageListGate`, a per-conversation FIFO gate that `SendAnimation` holds while its bubble is in flight.
+
+The send animation flies a bubble from the text field to the bottom of the message list, and computes its landing target (`_animationBottomOffset`) from the live layout of everything below the list — text field, typing indicator row, smart reply row. A message landing mid-flight inserts into the `SliverAnimatedList`, can trigger smart reply generation, and can shift the typing indicator; each of those moves the target while `AnimatedPositioned` is still animating toward the old one, so the bubble lands short and snaps.
+
+**Gate semantics:**
+
+- **Open (the normal case):** work runs inline, synchronously — identical to not having a gate.
+- **Held:** work is queued and replayed in submission order the instant the gate opens. Nothing ever blocks or awaits on it; it cannot delay a send.
+- **Held by:** `SendAnimation.send()`, from just before the outgoing text message is queued until the animated bubble is torn down (~650ms: 450ms flight + 200ms hold). Also released by `SendAnimation.dispose()`, and by a watchdog timer if a release is ever lost.
+
+**Bypasses the gate:**
+
+- **Messages this device is sending** (`Message.isSending` — outgoing with a `temp-` GUID). The animation lands *on* the real bubble, so it must already be in the list when the flight ends, and a second send fired mid-animation must never be deferred. Insertion is order-independent — `_applyNewMessage` re-sorts `_messages` and derives `insertIndex` from the sorted position — so a bypassing insert and a deferred one produce the same final list regardless of arrival order.
+- **`handleUpdatedMessage`** — changes a list entry in place without changing list structure, and deferring it would delay the tempGuid → realGuid swap that ends the sending state.
+- **`handleDeletedMessage`** — deliberately ungated. `retryFailedMessage` calls `removeFunc` immediately followed by `newFunc` on the same message, which by then carries a temp GUID and bypasses; deferring only the removal would invert that pair and drop the retried message from the list.
+
+Also gated: the `typing-indicator` socket event in `action_handler.dart`, since that row sits between the list and the text field and feeds the same offset calculation.
+
+**Key files:** `lib/services/ui/chat/message_list_gate.dart`, `lib/app/layouts/conversation_view/pages/messages_view.dart`, `lib/app/layouts/conversation_view/widgets/message/send_animation.dart`
 
 ---
 
@@ -225,5 +249,7 @@ Because each field is its own observable, `Obx()` rebuilds only the widget that 
 | Isolate actions | `lib/services/backend/actions/chat_actions.dart` | `addMessageToChat()` (runs in isolate) |
 | Chat state update | `lib/services/ui/chat/chats_service.dart` | `updateChat()`, `addChat()`, `updateChatLatestMessage()` |
 | Message state update | `lib/services/ui/message/messages_service.dart` | `updateMessage()`, `addNewMessage()` |
+| Message list gate | `lib/services/ui/chat/message_list_gate.dart` | `hold()`, `run()`, `release()` |
+| List insertion | `lib/app/layouts/conversation_view/pages/messages_view.dart` | `handleNewMessage()` → `_applyNewMessage()` |
 | Reactive state | `lib/app/state/chat_state.dart` | `updateFromChat()`, `update*Internal()` |
 | Reactive state | `lib/app/state/message_state.dart` | `updateFromMessage()`, `update*Internal()` |

--- a/docs/MESSAGE_RECEIVE_FLOW.md
+++ b/docs/MESSAGE_RECEIVE_FLOW.md
@@ -220,6 +220,8 @@ The send animation flies a bubble from the text field to the bottom of the messa
 
 Also gated: the `typing-indicator` socket event in `action_handler.dart`, since that row sits between the list and the text field and feeds the same offset calculation.
 
+**Frozen target (the other half of the fix).** The gate stops new events from starting a layout transition mid-flight, but it can't rewind one that was already running when the user hit send — `TypingIndicator` takes ~480ms to settle on hide (280ms paint-only `ScaleTransition`, *then* a 200ms `AnimatedSize` height collapse), so an event landing shortly before the send is still moving the row during the flight. `SendAnimation` therefore snapshots the whole offset into `_frozenBottomOffset` when the animation starts and clears it on teardown, so `AnimatedPositioned` animates toward a constant. This generalizes what `_textFieldSize` already did for the composer. Relatedly, `_typingIndicatorOffset` resolves a hidden indicator from `showTypingIndicator` rather than the RenderBox — measuring during the settle tail returns the stale pre-collapse height and would freeze the target ~55px too high.
+
 **Key files:** `lib/services/ui/chat/message_list_gate.dart`, `lib/app/layouts/conversation_view/pages/messages_view.dart`, `lib/app/layouts/conversation_view/widgets/message/send_animation.dart`
 
 ---

--- a/docs/MESSAGE_SEND_FLOW.md
+++ b/docs/MESSAGE_SEND_FLOW.md
@@ -78,7 +78,9 @@ The tempGuid format is always `temp-` followed by 8 random alphanumeric characte
 
 Queue item types are explicit and compile-time safe: `OutgoingMessage` (plain text), `OutgoingReaction` (tapbacks, with required `selectedMessage` + `reaction`), `OutgoingAttachment` (file/audio, with required `attachment` + `isAudioMessage`), `OutgoingMultipartMessage` (attributed/mention text).
 
-**Key file:** `lib/app/layouts/conversation_view/widgets/message/send_animation.dart`
+Immediately before the text/multipart item is queued, `send()` also closes `ConversationViewController.messageListGate` and holds it until the animated bubble is torn down (~650ms later). This keeps incoming messages, and the typing indicator, from mutating the message list while the bubble is flying toward a target derived from the current layout. The gate never delays the send — the outgoing message queued on the very next line bypasses it. See **Step 8b** of `docs/MESSAGE_RECEIVE_FLOW.md` for the full semantics.
+
+**Key files:** `lib/app/layouts/conversation_view/widgets/message/send_animation.dart`, `lib/services/ui/chat/message_list_gate.dart`
 
 ---
 

--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -407,7 +407,28 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
     }
   }
 
-  void handleNewMessage(Message message) async {
+  /// Entry point registered as [MessagesService.newFunc].
+  ///
+  /// Insertion is routed through [ConversationViewController.messageListGate]
+  /// so that a message arriving while a send animation is in flight waits until
+  /// the animated bubble has landed and been torn down. Inserting mid-flight
+  /// grows the list and can toggle the smart reply / typing indicator rows,
+  /// which moves the target `SendAnimation` is animating toward — the bubble
+  /// then lands short and snaps into place.
+  ///
+  /// Messages this device is currently sending bypass the gate entirely. The
+  /// animation lands *on* the real bubble, so it has to already be in the list
+  /// by the time the flight ends, and a send must never be delayed — including
+  /// a second send fired while the first is still animating.
+  void handleNewMessage(Message message) {
+    if (message.isSending) {
+      _applyNewMessage(message);
+      return;
+    }
+    controller.messageListGate.run(() => _applyNewMessage(message));
+  }
+
+  void _applyNewMessage(Message message) async {
     // Check if widget is still mounted before processing
     if (!mounted) {
       return;
@@ -501,6 +522,19 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
     }
   }
 
+  /// Deliberately NOT routed through [ConversationViewController.messageListGate].
+  ///
+  /// Removal is not order-independent with insertion the way [handleNewMessage]
+  /// is: [MessagesService.retryFailedMessage] calls `removeFunc` immediately
+  /// followed by `newFunc` on the same message, which by then carries a temp
+  /// GUID and so bypasses the gate. Deferring only the removal would invert that
+  /// pair — the re-insert would run first, see the entry already present and
+  /// skip as a duplicate, then the deferred removal would delete it, dropping
+  /// the retried message from the list.
+  ///
+  /// Deletions are also user-initiated rather than something that races a send
+  /// by arriving from the network, so they don't exhibit the timing collision
+  /// the gate exists to solve.
   void handleDeletedMessage(Message message) {
     // Check if widget is still mounted before processing
     if (!mounted) return;

--- a/lib/app/layouts/conversation_view/widgets/message/send_animation.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/send_animation.dart
@@ -123,6 +123,15 @@ class _SendAnimationState extends CustomState<SendAnimation, SendData, Conversat
     }
   }
 
+  @override
+  void dispose() {
+    // The widget can be torn down mid-flight (user leaves the chat while the
+    // bubble is travelling), in which case onEnd never runs. Open the gate here
+    // so anything deferred behind this send still reaches the list.
+    controller.messageListGate.release();
+    super.dispose();
+  }
+
   Future<void> send(SendData data) async {
     // do not add anything above this line, the attachments must be extracted first
     final attachments = List<PlatformFile>.from(data.attachments);
@@ -258,6 +267,17 @@ class _SendAnimationState extends CustomState<SendAnimation, SendData, Conversat
             ),
         ],
       );
+      // Close the message list gate before the outgoing message is queued, so
+      // that a message arriving during the flight can't insert into the list or
+      // toggle the rows below it and move the landing target computed by
+      // _animationBottomOffset. Nothing waits on this — deferred work replays
+      // as soon as the bubble is torn down below (or on dispose, or via the
+      // gate's watchdog if this frame's onEnd never fires).
+      //
+      // The outgoing message this animation lands on is queued *after* the hold
+      // but bypasses the gate in MessagesView.handleNewMessage, so the send is
+      // never delayed by its own hold.
+      controller.messageListGate.hold();
       OutgoingMsgHandler.queue(
         (_message.attributedBody.isNotEmpty)
             ? OutgoingMultipartMessage(
@@ -298,11 +318,17 @@ class _SendAnimationState extends CustomState<SendAnimation, SendData, Conversat
       onEnd: () async {
         if (message != null) {
           await Future.delayed(const Duration(milliseconds: 200));
+          // If we were disposed during the delay, dispose() has already opened
+          // the gate — bail before touching state.
+          if (!mounted) return;
           setState(() {
             tween = Tween<double>(begin: 1, end: 0);
             control = Control.stop;
             message = null;
           });
+          // Released only once the animated bubble is gone, not when it lands,
+          // so nothing shifts underneath it while it is still overlaid.
+          controller.messageListGate.release();
         }
       },
       child: Visibility(

--- a/lib/app/layouts/conversation_view/widgets/message/send_animation.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/send_animation.dart
@@ -52,23 +52,47 @@ class _SendAnimationState extends CustomState<SendAnimation, SendData, Conversat
   // Extra vertical offset that differs between the iOS skin and Material/Samsung skins.
   double get _platformVerticalOffset => iOS ? -4.0 : 14.5;
 
-  // Offset for typing indicator when it is visible.
+  // Offset for typing indicator when it is settled visible.
+  //
+  // Resolved from the observable rather than the RenderBox when the indicator is
+  // hidden, because the row does not collapse the instant the flag flips: on
+  // hide, TypingIndicator runs a 280ms ScaleTransition (paint-only, so the row
+  // keeps its full layout height throughout) before removing the bubble from the
+  // tree, and only then does its AnimatedSize collapse the height over 200ms.
+  // Measuring during that ~480ms tail returns the *old* height and would freeze
+  // the target ~55px too high. The flag is already the settled end state, so
+  // trust it and skip the measurement entirely.
   double get _typingIndicatorOffset {
+    if (!controller.showTypingIndicator.value) return 0;
     final measured = (controller.typingInfoKey.currentContext?.findRenderObject() as RenderBox?)?.size.height;
     if (measured != null && measured > 0) {
       return measured;
     }
-    return controller.showTypingIndicator.value ? _typingIndicatorFallbackHeight : 0;
+    return _typingIndicatorFallbackHeight;
   }
 
   // Offset for smart reply row when it is visible.
   double get _smartReplyOffset => controller.showSmartReplyRow.value ? controller.smartReplyRowHeight.value : 0;
 
+  // Snapshot of _liveBottomOffset taken when a send animation starts, and cleared
+  // when the bubble is torn down. Null whenever no send is in flight.
+  //
+  // _textFieldSize already freezes the largest moving part of the offset, but the
+  // typing indicator and the focus-info banner are still measured live and both
+  // animate their height (AnimatedSize). The message list gate keeps *new* events
+  // from starting such a transition mid-flight, but it can't rewind one that was
+  // already running when the user hit send. Freezing the whole sum closes that
+  // window: once the flight begins the target is a constant, so AnimatedPositioned
+  // can never chase it regardless of what moves underneath.
+  double? _frozenBottomOffset;
+
   // Total bottom offset for the AnimatedPositioned — how far above the bottom
   // of the Stack the animation bubble should land at the end of its travel.
+  double get _animationBottomOffset => _frozenBottomOffset ?? _liveBottomOffset;
+
   // Uses the stored resting text field height (_textFieldSize) so the target
   // never changes during the animation, even while the field shrinks.
-  double get _animationBottomOffset =>
+  double get _liveBottomOffset =>
       _textFieldSize +
       focusInfoSize +
       _textFieldVerticalPadding +
@@ -290,6 +314,11 @@ class _SendAnimationState extends CustomState<SendAnimation, SendData, Conversat
               ),
       );
       setState(() {
+        // Freeze the landing target for the whole flight. Computed here rather
+        // than in build() so it reflects the layout at the moment of the send —
+        // notably after updateSmartReplyLayout() above has already zeroed the
+        // smart reply row.
+        _frozenBottomOffset = _liveBottomOffset;
         tween = Tween<double>(
           begin: 0.9,
           end: 0,
@@ -322,6 +351,7 @@ class _SendAnimationState extends CustomState<SendAnimation, SendData, Conversat
           // the gate — bail before touching state.
           if (!mounted) return;
           setState(() {
+            _frozenBottomOffset = null;
             tween = Tween<double>(begin: 1, end: 0);
             control = Control.stop;
             message = null;

--- a/lib/services/backend/action_handler.dart
+++ b/lib/services/backend/action_handler.dart
@@ -157,7 +157,11 @@ class ActionHandler extends GetxService {
         final chat = ChatsSvc.findChatByGuid(data["guid"]);
         if (chat != null) {
           final controller = cvc(chat);
-          controller.showTypingIndicator.value = data["display"];
+          // Gated: the typing indicator row sits between the message list and
+          // the text field, so toggling it mid-send moves the target
+          // SendAnimation is flying toward. Runs inline when no send is in
+          // flight, which is the overwhelmingly common case.
+          controller.messageListGate.run(() => controller.showTypingIndicator.value = data["display"]);
         }
         return;
       case "incoming-facetime":

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -26,6 +26,7 @@ export 'network/socket_service.dart';
 export 'ui/chat/chats_service.dart';
 export 'ui/chat/conversation_view_controller.dart';
 export 'ui/chat/custom_groups_service.dart';
+export 'ui/chat/message_list_gate.dart';
 // GlobalChatService merged into ChatsService
 // MessageUpdateCoordinator removed - replaced by MessageState
 // MessageWidgetController merged into MessageState

--- a/lib/services/ui/chat/CLAUDE.md
+++ b/lib/services/ui/chat/CLAUDE.md
@@ -5,6 +5,7 @@
 |------|---------|
 | `chats_service.dart` | Global chat list state — the source of truth for all `ChatState` objects |
 | `conversation_view_controller.dart` | Per-chat controller for the active conversation screen |
+| `message_list_gate.dart` | FIFO gate that defers message list mutations while a send animation is in flight |
 
 ---
 
@@ -50,3 +51,21 @@ GetX controller, one instance per open chat. Accessed via `cvc(chat)` helper or 
 **Lifecycle:** Created when a conversation opens, closed when it pops. A conversation can remain "alive" in the background when in tablet mode.
 
 **Rule:** Never hold a direct reference to `ConversationViewController` across navigations — always re-fetch via `cvc(chat)`.
+
+---
+
+## MessageListGate (`message_list_gate.dart`)
+
+One instance per `ConversationViewController`, reached as `controller.messageListGate`.
+
+`SendAnimation` flies a bubble from the text field to the bottom of the message list, aiming at a target computed from the live layout of the rows below the list. Anything that mutates the list or those rows mid-flight moves that target and makes the bubble land wrong. The gate defers that work instead.
+
+**API:** `hold()` closes it, `run(work)` submits, `release()` opens it and replays the queue in order, `dispose()` releases permanently.
+
+**It is not a lock.** No caller ever awaits it and it can never delay a send. While open (the normal case) `run()` executes inline. While held, work queues and replays in submission order as soon as the gate opens. A watchdog force-releases after 2s so a lost `release()` can't strand queued messages.
+
+**Rules:**
+- Anything representing the send itself must bypass the gate — the send takes precedence over everything.
+- Only submit work that is order-independent with respect to bypassing work. Insertions qualify (`_applyNewMessage` re-sorts and recomputes the index); removals do not — see the comment on `MessagesView.handleDeletedMessage`.
+
+Full rationale and the current list of gated/bypassing call sites: **Step 8b** of `docs/MESSAGE_RECEIVE_FLOW.md`.

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -139,6 +139,15 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   /// Future that resolves once [MessagesView] has fully initialized.
   Future<void> get messagesViewReady => _messagesViewReady.future;
 
+  /// Coordinates message list mutations against the in-flight send animation.
+  ///
+  /// [SendAnimation] holds this for the duration of its flight so that a
+  /// message arriving at the same moment can't insert into the list (or toggle
+  /// the smart reply / typing indicator rows) and move the animation's landing
+  /// target out from under it. Held work replays as soon as the gate opens.
+  /// The send itself is never gated — see [MessageListGate].
+  final MessageListGate messageListGate = MessageListGate();
+
   @override
   void onInit() {
     super.onInit();
@@ -189,6 +198,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
 
   @override
   void onClose() {
+    messageListGate.dispose();
     updateSmartReplyLayout(visible: false, height: 0);
     for (PlayerController a in audioPlayers.values) {
       a.pausePlayer();

--- a/lib/services/ui/chat/message_list_gate.dart
+++ b/lib/services/ui/chat/message_list_gate.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:bluebubbles/utils/logger/logger.dart';
+
+/// A unit of work that mutates the message list. Async bodies are allowed —
+/// the gate starts them in submission order and does not await them, so the
+/// synchronous prefix of each (where list insertion/removal actually happens)
+/// still runs in the order it was submitted.
+typedef GatedWork = FutureOr<void> Function();
+
+/// Defers structural mutations of the message list while a send animation is in
+/// flight.
+///
+/// [SendAnimation] flies a bubble from the text field down to the bottom of the
+/// message list, and its landing target is derived from the live layout of
+/// everything sitting below the list — the text field, the typing indicator row
+/// and the smart reply row. A message arriving mid-flight inserts into the
+/// [SliverAnimatedList], can toggle the smart reply row, and can shift the
+/// typing indicator, all of which move that target while `AnimatedPositioned`
+/// is still animating toward the old one. The bubble then lands in the wrong
+/// place and snaps into position.
+///
+/// This is deliberately **not** a mutual-exclusion lock. No caller ever blocks
+/// on it and it can never delay a send — the send is the thing holding it.
+/// While the gate is held, work passed to [run] is appended to a FIFO queue and
+/// replayed, in submission order, the moment the gate opens. Work submitted
+/// while the gate is open runs inline, synchronously, exactly as if the gate
+/// weren't there.
+///
+/// Callers that represent the send itself (the outgoing message the animation
+/// is landing on) must bypass the gate and mutate the list directly — see
+/// `MessagesViewState.handleNewMessage`.
+class MessageListGate {
+  MessageListGate({Duration? maxHold}) : _maxHold = maxHold ?? const Duration(milliseconds: 2000);
+
+  /// Upper bound on a single hold. The send animation runs ~650ms end to end;
+  /// this only exists so a hold whose release is lost (dropped frame, animation
+  /// callback that never fires) can't strand queued messages forever.
+  final Duration _maxHold;
+
+  final Queue<GatedWork> _deferred = Queue<GatedWork>();
+
+  Timer? _watchdog;
+  bool _held = false;
+  bool _disposed = false;
+
+  /// Whether work submitted right now would be deferred.
+  bool get isHeld => _held;
+
+  /// Number of units of work currently waiting for the gate to open.
+  int get deferredCount => _deferred.length;
+
+  /// Closes the gate. Calling this while already held is a no-op beyond
+  /// restarting the watchdog — a second send extends the current hold rather
+  /// than nesting, and anything already queued stays queued.
+  void hold() {
+    if (_disposed) return;
+    _held = true;
+    _watchdog?.cancel();
+    _watchdog = Timer(_maxHold, () {
+      Logger.warn(
+        'Gate held for ${_maxHold.inMilliseconds}ms without a release — force-releasing '
+        '${_deferred.length} deferred item(s)',
+        tag: 'MessageListGate',
+      );
+      release();
+    });
+  }
+
+  /// Runs [work] now if the gate is open, otherwise queues it until [release].
+  void run(GatedWork work) {
+    if (_held && !_disposed) {
+      _deferred.add(work);
+      return;
+    }
+    _invoke(work);
+  }
+
+  /// Opens the gate and replays everything queued while it was held, in order.
+  void release() {
+    _watchdog?.cancel();
+    _watchdog = null;
+    if (!_held) return;
+    // Open the gate before draining so that work which re-enters run() during
+    // the drain executes inline instead of queueing behind the drain loop.
+    _held = false;
+    _drain();
+  }
+
+  /// Releases the gate permanently. Anything still queued is replayed rather
+  /// than dropped — a deferred message that never reaches the list would be
+  /// missing from the view until the chat is reopened.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _watchdog?.cancel();
+    _watchdog = null;
+    _held = false;
+    _drain();
+  }
+
+  void _drain() {
+    while (_deferred.isNotEmpty) {
+      _invoke(_deferred.removeFirst());
+    }
+  }
+
+  void _invoke(GatedWork work) {
+    try {
+      work();
+    } catch (e, s) {
+      Logger.error('Deferred message list work threw', error: e, trace: s, tag: 'MessageListGate');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Introduces a FIFO gate that defers message list mutations while a send animation is in flight, preventing incoming messages from shifting the animation's landing target and causing the bubble to land in the wrong position.

## Problem
`SendAnimation` flies a bubble from the text field to the bottom of the message list, computing its landing target from the live layout of elements below the list (text field, typing indicator, smart reply row). When a message arrives mid-flight, it inserts into the `SliverAnimatedList`, can trigger smart reply generation, and can shift the typing indicator — each of these moves the target while `AnimatedPositioned` is still animating toward the old one, causing the bubble to land short and snap into place.

## Solution
- **New `MessageListGate` class** (`lib/services/ui/chat/message_list_gate.dart`): A per-conversation FIFO gate that queues work while held and replays it in submission order when released. Not a lock — nothing blocks or awaits on it, and it cannot delay a send. Includes a 2s watchdog to force-release if a release is lost.

- **`SendAnimation` integration**: Holds the gate immediately before queuing the outgoing message and releases it after the animated bubble is torn down (~650ms: 450ms flight + 200ms hold). Also releases on dispose to handle mid-flight widget teardown.

- **`MessagesView.handleNewMessage` routing**: Routes incoming message insertions through the gate via `controller.messageListGate.run()`, but bypasses it for messages this device is sending (`Message.isSending`) since the animation lands *on* the real bubble and it must already be in the list when the flight ends.

- **Typing indicator gating**: The `typing-indicator` socket event in `action_handler.dart` also routes through the gate since that row sits between the list and text field and feeds the same offset calculation.

- **Intentional bypasses**: `handleUpdatedMessage` (in-place changes, no structural mutation) and `handleDeletedMessage` (deliberately ungated to avoid inverting removal/re-insertion pairs in retry flows) do not use the gate.

## Key Implementation Details
- Gate semantics: open (normal case) runs work inline; held queues work; released replays queue in order
- Outgoing messages bypass the gate in `handleNewMessage` by checking `Message.isSending` before submission
- Insertions are order-independent (`_applyNewMessage` re-sorts and recomputes index), so bypassing and deferred insertions produce the same final list regardless of arrival order
- Comprehensive documentation added to `docs/MESSAGE_RECEIVE_FLOW.md` (Step 8b) and `lib/services/ui/chat/CLAUDE.md`

## Files Changed
- `lib/services/ui/chat/message_list_gate.dart` (new)
- `lib/services/ui/chat/conversation_view_controller.dart` (added gate instance)
- `lib/app/layouts/conversation_view/pages/messages_view.dart` (routed insertions through gate)
- `lib/app/layouts/conversation_view/widgets/message/send_animation.dart` (hold/release calls)
- `lib/services/backend/action_handler.dart` (gated typing indicator)
- `docs/MESSAGE_RECEIVE_FLOW.md` (added Step 8b)
- `docs/MESSAGE_SEND_FLOW.md` (updated send flow description)
- `lib/services/services.dart` (exported new gate class)

https://claude.ai/code/session_01498hUenu6TyzV3kEHX2F28