### PR TITLE
fix: improves large message handling in DartWorkManager and DartWorker

### DIFF
--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorkManager.kt
@@ -9,6 +9,8 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
+import java.io.File
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import com.bluebubbles.messaging.Constants
 import com.bluebubbles.messaging.utils.PersistentLog
@@ -19,6 +21,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 object DartWorkManager {
+    // androidx.work caps a serialized Data object at 10 KB (Data.MAX_DATA_BYTES) and throws
+    // IllegalStateException out of build() when that's exceeded. Socket events routinely run
+    // past it (a message with a long attributedBody, a chat with many participants), so
+    // oversized payloads are spilled to a file in cacheDir and read back by the worker.
+    // The threshold is conservative because the cap covers the whole serialized Data object —
+    // keys, the method string, and per-entry overhead — not just the payload value.
+    private const val MAX_INLINE_DATA_BYTES = 8 * 1024
+    private const val PAYLOAD_DIR = "bluebubbles_worker_payloads"
+    private const val PAYLOAD_TTL_MS = 24 * 60 * 60 * 1000L
+
     /// [callback] receives whether the Dart work actually SUCCEEDED. Callers must not
     /// treat completion as success: WorkManager also reaches a finished state on FAILED
     /// and CANCELLED, which is exactly what happens when a cold engine boot fails while
@@ -29,6 +41,17 @@ object DartWorkManager {
         val gson = GsonBuilder()
             .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .create()
+
+        val inputData = try {
+            buildInputData(context, method, gson.toJson(arguments))
+        } catch (e: Exception) {
+            // Dropping the event is the only option left, but it must not kill the caller's
+            // thread — for socket events that thread belongs to socket.io itself.
+            PersistentLog.e(context, Constants.logTag, "Failed to build input data for method $method — dropping event", e)
+            callback(false)
+            return
+        }
+
         val work = OneTimeWorkRequest.Builder(DartWorker::class.java)
             .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             // Retries redeliver dropped events (e.g. notifications). Exponential from the
@@ -36,9 +59,7 @@ object DartWorkManager {
             // long enough to outlast a memory-pressure spike that makes cold engine boots
             // fail repeatedly, while the first retry still lands within seconds.
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
-            .setInputData(Data.Builder()
-                .putString("method", method)
-                .putString("data", gson.toJson(arguments).toString()).build())
+            .setInputData(inputData)
             .addTag(Constants.dartWorkerTag)
             .build()
         WorkManager.getInstance(context).enqueue(work)
@@ -78,6 +99,59 @@ object DartWorkManager {
             } catch (e: Exception) {
                 PersistentLog.e(context, Constants.logTag, "Error observing worker $method", e)
             }
+        }
+    }
+
+    /// Puts [json] straight into the work's input data when it comfortably fits, and spills it
+    /// to disk otherwise. The worker reads back whichever key is present.
+    private fun buildInputData(context: Context, method: String, json: String): Data {
+        val size = json.toByteArray(Charsets.UTF_8).size
+        if (size <= MAX_INLINE_DATA_BYTES) {
+            try {
+                return Data.Builder().putString("method", method).putString("data", json).build()
+            } catch (e: IllegalStateException) {
+                // Data serializes with Java's *modified* UTF-8, which is wider than the UTF-8
+                // the size estimate above measures (supplementary chars — emoji — cost 6 bytes
+                // there vs 4). Spill rather than trust the estimate.
+                PersistentLog.w(context, Constants.logTag, "Payload for method $method exceeded the Data cap despite measuring $size bytes — spilling", e)
+            }
+        }
+
+        val file = writePayload(context, json)
+        PersistentLog.d(context, Constants.logTag, "Payload for method $method is $size bytes — spilled to ${file.name}")
+        return Data.Builder().putString("method", method).putString("dataFile", file.absolutePath).build()
+    }
+
+    private fun writePayload(context: Context, json: String): File {
+        val dir = File(context.cacheDir, PAYLOAD_DIR)
+        dir.mkdirs()
+        prunePayloads(context, dir)
+        val file = File(dir, "${UUID.randomUUID()}.json")
+        file.writeText(json, Charsets.UTF_8)
+        return file
+    }
+
+    /// The worker deletes its own payload once it reaches a terminal state, but a process
+    /// death between enqueue and completion would strand the file. Sweep on every spill —
+    /// that path is rare, unlike enqueue itself.
+    private fun prunePayloads(context: Context, dir: File) {
+        try {
+            val cutoff = System.currentTimeMillis() - PAYLOAD_TTL_MS
+            dir.listFiles()?.forEach { if (it.lastModified() < cutoff) it.delete() }
+        } catch (e: Exception) {
+            PersistentLog.w(context, Constants.logTag, "Failed to prune stale worker payloads", e)
+        }
+    }
+
+    /// Deletes a payload spilled by [buildInputData]. No-op when the payload was inlined
+    /// (i.e. [path] is null). Must only be called once the work is finished for good — a
+    /// retry re-reads the same file.
+    fun deletePayload(context: Context, path: String?) {
+        if (path == null) return
+        try {
+            File(path).delete()
+        } catch (e: Exception) {
+            PersistentLog.w(context, Constants.logTag, "Failed to delete spilled worker payload $path", e)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/backend_ui_interop/DartWorker.kt
@@ -23,6 +23,7 @@ import io.flutter.embedding.engine.loader.ApplicationInfoLoader
 import io.flutter.embedding.engine.loader.FlutterLoader
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.view.FlutterCallbackInformation
+import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -83,104 +84,138 @@ class DartWorker(context: Context, workerParams: WorkerParameters): ListenableWo
     }
 
     override fun startWork(): ListenableFuture<Result> {
-        val method = inputData.getString("method")!!
-        val data = inputData.getString("data")!!
+        return CoroutineScope(Dispatchers.Main).future {
+            val method = inputData.getString("method")
+            if (method == null) {
+                PersistentLog.e(applicationContext, Constants.logTag, "Worker started without a method — dropping")
+                return@future Result.failure()
+            }
+
+            // Payloads too large for WorkManager's 10 KB Data cap are spilled to a file by
+            // DartWorkManager; everything else is inlined under "data".
+            val payloadPath = inputData.getString("dataFile")
+            val data = if (payloadPath != null) {
+                withContext(Dispatchers.IO) {
+                    try {
+                        File(payloadPath).readText(Charsets.UTF_8)
+                    } catch (e: Exception) {
+                        PersistentLog.e(applicationContext, Constants.logTag, "Failed to read spilled payload for method $method", e)
+                        null
+                    }
+                }
+            } else {
+                inputData.getString("data")
+            }
+
+            if (data == null) {
+                PersistentLog.e(applicationContext, Constants.logTag, "Worker for method $method has no payload — dropping")
+                DartWorkManager.deletePayload(applicationContext, payloadPath)
+                return@future Result.failure()
+            }
+
+            val result = runWork(method, data)
+            // A retry re-runs this same worker and re-reads the payload, so the spill file
+            // can only be removed once the work is finished for good.
+            if (result !is Result.Retry) DartWorkManager.deletePayload(applicationContext, payloadPath)
+            return@future result
+        }
+    }
+
+    private suspend fun runWork(method: String, data: String): Result {
         val gson = GsonBuilder()
                 .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
                 .create()
 
-        return CoroutineScope(Dispatchers.Main).future {
-            // Initialize AND select the engine under the same lock so a concurrent
-            // cleanup can't destroy the engine between init and selection.
-            val engineToUse: FlutterEngine? = try {
-                engineReady.withLock {
-                    // MainActivity.getEngine() can be non-null before its Dart isolate has
-                    // registered a method-call handler (the engine object is attached in
-                    // configureFlutterEngine, well before Dart's main() reaches
-                    // MethodChannelService.init()). Invoking into it during that window
-                    // always resolves notImplemented(). Only prefer it once Dart has
-                    // signaled "ready" on it. Otherwise, fall back to (or spin up) the
-                    // dedicated worker engine, which we know is ready before we ever use it.
-                    val mainEngine = MainActivity.getEngine()
-                    val mainEngineDartReady = MainActivity.isDartReady()
-                    val useMainEngine = mainEngine != null && mainEngineDartReady
-                    if (useMainEngine) {
-                        PersistentLog.d(applicationContext, Constants.logTag, "Using MainActivity engine to send to Dart (method=$method)")
+        // Initialize AND select the engine under the same lock so a concurrent
+        // cleanup can't destroy the engine between init and selection.
+        val engineToUse: FlutterEngine? = try {
+            engineReady.withLock {
+                // MainActivity.getEngine() can be non-null before its Dart isolate has
+                // registered a method-call handler (the engine object is attached in
+                // configureFlutterEngine, well before Dart's main() reaches
+                // MethodChannelService.init()). Invoking into it during that window
+                // always resolves notImplemented(). Only prefer it once Dart has
+                // signaled "ready" on it. Otherwise, fall back to (or spin up) the
+                // dedicated worker engine, which we know is ready before we ever use it.
+                val mainEngine = MainActivity.getEngine()
+                val mainEngineDartReady = MainActivity.isDartReady()
+                val useMainEngine = mainEngine != null && mainEngineDartReady
+                if (useMainEngine) {
+                    PersistentLog.d(applicationContext, Constants.logTag, "Using MainActivity engine to send to Dart (method=$method)")
+                } else {
+                    if (mainEngine != null && !mainEngineDartReady) {
+                        PersistentLog.w(applicationContext, Constants.logTag, "MainActivity engine exists but Dart isn't ready yet — using DartWorker engine instead for method $method")
                     } else {
-                        if (mainEngine != null && !mainEngineDartReady) {
-                            PersistentLog.w(applicationContext, Constants.logTag, "MainActivity engine exists but Dart isn't ready yet — using DartWorker engine instead for method $method")
-                        } else {
-                            PersistentLog.d(applicationContext, Constants.logTag, "Using DartWorker engine to send to Dart (method=$method)")
-                        }
-                        if (workerEngine == null) {
-                            PersistentLog.d(applicationContext, Constants.logTag, "Initializing engine for worker with method $method")
-                            initNewEngine()
-                        }
+                        PersistentLog.d(applicationContext, Constants.logTag, "Using DartWorker engine to send to Dart (method=$method)")
                     }
-                    if (useMainEngine) mainEngine else workerEngine
-                }
-            } catch (e: Exception) {
-                PersistentLog.e(applicationContext, Constants.logTag, "Engine init failed for worker with method $method: ${e.message}", e)
-                return@future retryOrFail(method, "engine init failed: ${e.message}")
-            }
-            PersistentLog.d(applicationContext, Constants.logTag, "Sending event, '$method' to Dart")
-
-            try {
-                if (engineToUse == null) {
-                    PersistentLog.d(applicationContext, Constants.logTag, "Engine is null, cannot send method $method to Dart")
-                    return@future retryOrFail(method, "engine was null after init")
-                }
-
-                PersistentLog.d(applicationContext, Constants.logTag, "Invoking method channel...")
-                val callResult = withTimeoutOrNull(120_000L) {
-                    suspendCancellableCoroutine { cont ->
-                        MethodChannel(engineToUse.dartExecutor.binaryMessenger, Constants.methodChannel).invokeMethod(method, gson.fromJson(data, TypeToken.getParameterized(HashMap::class.java, String::class.java, Any::class.java).type), object : MethodChannel.Result {
-                            override fun success(result: Any?) {
-                                // A handler that returns false is asking to be retried (see
-                                // MethodChannelService._callHandler). That is still a *successful*
-                                // method-channel call, so it arrives here rather than in error() —
-                                // ignoring the value silently converted every "retry me" into
-                                // "done", permanently dropping the event.
-                                if (result == false) {
-                                    PersistentLog.w(applicationContext, Constants.logTag, "Worker with method $method asked to be retried")
-                                    if (cont.isActive) cont.resume(retryOrFail(method, "Dart requested a retry"))
-                                } else {
-                                    PersistentLog.d(applicationContext, Constants.logTag, "Worker with method $method completed successfully")
-                                    if (cont.isActive) cont.resume(Result.success())
-                                }
-                                closeEngineIfNeeded()
-                            }
-
-                            override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
-                                PersistentLog.e(applicationContext, Constants.logTag, "Worker with method $method failed! ($errorCode: $errorMessage)")
-                                if (cont.isActive) cont.resume(retryOrFail(method, "Dart returned error $errorCode: $errorMessage"))
-                                closeEngineIfNeeded()
-                            }
-
-                            override fun notImplemented() {
-                                // notImplemented also fires when the Dart side hasn't registered its
-                                // method-call handler yet (engine still starting up), so treat it as transient.
-                                PersistentLog.e(applicationContext, Constants.logTag, "Worker with method $method not implemented on Dart side")
-                                if (cont.isActive) cont.resume(retryOrFail(method, "method not implemented on Dart side"))
-                                closeEngineIfNeeded()
-                            }
-                        })
+                    if (workerEngine == null) {
+                        PersistentLog.d(applicationContext, Constants.logTag, "Initializing engine for worker with method $method")
+                        initNewEngine()
                     }
                 }
-
-                if (callResult == null) {
-                    PersistentLog.e(applicationContext, Constants.logTag, "Method $method invocation timed out after 120s")
-                    closeEngineIfNeeded()
-                    return@future retryOrFail(method, "method invocation timed out after 120s")
-                }
-
-                // callResult carries the outcome resumed by the method-channel callback
-                // (success, retry, or failure) — don't collapse it to success.
-                return@future callResult
-            } catch (e: Exception) {
-                PersistentLog.w(applicationContext, Constants.logTag, "Error sending method $method to Dart: ${e.message}", e)
-                return@future retryOrFail(method, "exception sending to Dart: ${e.message}")
+                if (useMainEngine) mainEngine else workerEngine
             }
+        } catch (e: Exception) {
+            PersistentLog.e(applicationContext, Constants.logTag, "Engine init failed for worker with method $method: ${e.message}", e)
+            return retryOrFail(method, "engine init failed: ${e.message}")
+        }
+        PersistentLog.d(applicationContext, Constants.logTag, "Sending event, '$method' to Dart")
+
+        try {
+            if (engineToUse == null) {
+                PersistentLog.d(applicationContext, Constants.logTag, "Engine is null, cannot send method $method to Dart")
+                return retryOrFail(method, "engine was null after init")
+            }
+
+            PersistentLog.d(applicationContext, Constants.logTag, "Invoking method channel...")
+            val callResult = withTimeoutOrNull(120_000L) {
+                suspendCancellableCoroutine { cont ->
+                    MethodChannel(engineToUse.dartExecutor.binaryMessenger, Constants.methodChannel).invokeMethod(method, gson.fromJson(data, TypeToken.getParameterized(HashMap::class.java, String::class.java, Any::class.java).type), object : MethodChannel.Result {
+                        override fun success(result: Any?) {
+                            // A handler that returns false is asking to be retried (see
+                            // MethodChannelService._callHandler). That is still a *successful*
+                            // method-channel call, so it arrives here rather than in error() —
+                            // ignoring the value silently converted every "retry me" into
+                            // "done", permanently dropping the event.
+                            if (result == false) {
+                                PersistentLog.w(applicationContext, Constants.logTag, "Worker with method $method asked to be retried")
+                                if (cont.isActive) cont.resume(retryOrFail(method, "Dart requested a retry"))
+                            } else {
+                                PersistentLog.d(applicationContext, Constants.logTag, "Worker with method $method completed successfully")
+                                if (cont.isActive) cont.resume(Result.success())
+                            }
+                            closeEngineIfNeeded()
+                        }
+
+                        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                            PersistentLog.e(applicationContext, Constants.logTag, "Worker with method $method failed! ($errorCode: $errorMessage)")
+                            if (cont.isActive) cont.resume(retryOrFail(method, "Dart returned error $errorCode: $errorMessage"))
+                            closeEngineIfNeeded()
+                        }
+
+                        override fun notImplemented() {
+                            // notImplemented also fires when the Dart side hasn't registered its
+                            // method-call handler yet (engine still starting up), so treat it as transient.
+                            PersistentLog.e(applicationContext, Constants.logTag, "Worker with method $method not implemented on Dart side")
+                            if (cont.isActive) cont.resume(retryOrFail(method, "method not implemented on Dart side"))
+                            closeEngineIfNeeded()
+                        }
+                    })
+                }
+            }
+
+            if (callResult == null) {
+                PersistentLog.e(applicationContext, Constants.logTag, "Method $method invocation timed out after 120s")
+                closeEngineIfNeeded()
+                return retryOrFail(method, "method invocation timed out after 120s")
+            }
+
+            // callResult carries the outcome resumed by the method-channel callback
+            // (success, retry, or failure) — don't collapse it to success.
+            return callResult
+        } catch (e: Exception) {
+            PersistentLog.w(applicationContext, Constants.logTag, "Error sending method $method to Dart: ${e.message}", e)
+            return retryOrFail(method, "exception sending to Dart: ${e.message}")
         }
     }
 

--- a/android/app/src/main/kotlin/com/bluebubbles/messaging/services/foreground/SocketIOForegroundService.kt
+++ b/android/app/src/main/kotlin/com/bluebubbles/messaging/services/foreground/SocketIOForegroundService.kt
@@ -195,18 +195,48 @@ class SocketIOForegroundService : Service() {
                 updateNotification(RECONNECT_FAILED)
             }
 
+            // This runs on socket.io's own event thread, outside the try/catch wrapping
+            // onCreate — anything that escapes it takes down the whole process rather than
+            // just the connection, so the body is fully guarded.
             mSocket!!.onAnyIncoming { args ->
-                if (args.isNotEmpty()) {
-                    val event = args[0] as String
-                    val message = args[1] as JSONObject
+                try {
+                    // Never cast the args blindly: payload shape varies by event (most send a
+                    // JSONObject, but `incoming-facetime` sends an already-encoded JSON
+                    // string), and some events carry no payload at all.
+                    val event = args.getOrNull(0) as? String
+                    if (event == null) {
+                        PersistentLog.w(applicationContext, Constants.logTag, "Ignoring Socket.io event with a non-string name")
+                        return@onAnyIncoming
+                    }
+
+                    if (eventBlacklist.contains(event)) {
+                        PersistentLog.d(applicationContext, Constants.logTag, "Ignored event of type $event from Socket.io...")
+                        return@onAnyIncoming
+                    }
+
+                    // The Dart handler decodes this into a Map, so only object-shaped JSON is
+                    // usable — forwarding anything else would just burn five headless engine
+                    // boots on retries before being dropped anyway.
+                    val payload = args.getOrNull(1)
+                    val data = when {
+                        payload is JSONObject -> payload.toString()
+                        payload is String && payload.trimStart().startsWith("{") -> payload
+                        else -> null
+                    }
+
+                    if (data == null) {
+                        PersistentLog.w(
+                            applicationContext,
+                            Constants.logTag,
+                            "Ignoring event $event from Socket.io — payload is not a JSON object (${payload?.javaClass?.simpleName ?: "absent"})"
+                        )
+                        return@onAnyIncoming
+                    }
 
                     PersistentLog.d(applicationContext, Constants.logTag, "Received event of type $event from Socket.io...")
-                    if (!eventBlacklist.contains(event)) {
-                        PersistentLog.d(applicationContext, Constants.logTag, "Received event of type $event from Socket.io...")
-                        DartWorkManager.createWorker(applicationContext, "socket-event", hashMapOf("event" to event, "data" to message.toString())) {}
-                    } else {
-                        PersistentLog.d(applicationContext, Constants.logTag, "Ignored event of type $event from Socket.io...")
-                    }
+                    DartWorkManager.createWorker(applicationContext, "socket-event", hashMapOf("event" to event, "data" to data)) {}
+                } catch (e: Exception) {
+                    PersistentLog.e(applicationContext, Constants.logTag, "Failed to handle incoming Socket.io event", e)
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
- Implement logic to spill oversized payloads to disk when exceeding WorkManager's 10 KB limit.
- Update DartWorker to read payloads from disk if necessary.
- Improve error handling for incoming Socket.io events in SocketIOForegroundService.