### PR TITLE
chore: target android 16 (api level 36)

### DIFF
--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -21,5 +21,10 @@ Flutter side: `lib/services/backend/java_dart_interop/`
 - `background_isolate.dart` — background Dart execution
 
 ## Build Config
-- Target SDK: 35 | NDK: 27.0 | Java/Kotlin compat: version 21
+- Compile/Target SDK: 36 | Min SDK: 26 | NDK: 28.2 | Java/Kotlin compat: version 21
 - Gradle with Kotlin plugin
+
+Targeting API 36 means Android 16 behavior changes apply: edge-to-edge is mandatory
+(no opt-out), predictive back is on by default, and on `sw600dp`+ screens the system
+ignores orientation/resizability restrictions — including
+`SystemChrome.setPreferredOrientations` from Dart.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -60,7 +60,7 @@ android {
     defaultConfig {
         applicationId "com.bluebubbles.messaging"
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode 20002000 + flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,8 +53,17 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 
+    <!--
+         enableOnBackInvokedCallback is already the default at targetSdk 36, but it is
+         declared explicitly so the predictive-back contract doesn't silently flip if the
+         target level is ever lowered. Everything back-related must go through
+         OnBackPressedDispatcher: onBackPressed() is never called and KEYCODE_BACK is not
+         dispatched. Flutter's embedding and the app's PopScope handlers already use the
+         dispatcher, so no activity may override onBackPressed().
+    -->
     <application
         tools:replace="android:label"
+        android:enableOnBackInvokedCallback="true"
         android:allowBackup="false"
         android:memtagMode="async"
         android:name="${applicationName}"


### PR DESCRIPTION
Google Play requires apps to target within one year of the latest Android release. compileSdk was already 36; only targetSdkVersion was left at 35, which is what the Play Console flagged. No dependency was holding this back.

Audited the Android 16 target-36 behavior changes against the app:

- Edge-to-edge enforcement: the app never used windowOptOutEdgeToEdgeEnforcement and already runs SystemUiMode.edgeToEdge with windowDrawsSystemBarBackgrounds=false, so nothing changes.
- Predictive back: onBackPressed() is no longer called and KEYCODE_BACK is no longer dispatched. Neither MainActivity nor BubbleActivity overrides onBackPressed, and the Dart side routes back through PopScope, so the behavior is already correct. Declared enableOnBackInvokedCallback explicitly to pin the contract.
- Large-screen adaptive layouts: no manifest sets screenOrientation or an aspect ratio, resizeableActivity is already true, and both activities declare configChanges for orientation/screenSize/screenLayout/density, so they resize in place instead of being recreated. Deliberately not opting out via PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY: the app is already adaptive, and that escape hatch stops working at API 37.
- Not applicable: scheduleAtFixedRate, MediaStore.getVersion, BODY_SENSORS, elegantTextHeight, and Bluetooth bonding are all unused, and strict intent matching is opt-in only.