### PR TITLE
fix: use permission_handler for battery optimization checks

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,15 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" tools:replace="android:maxSdkVersion"/>
 
+    <!--
+         Declared here rather than pulled in by manifest merger. This used to arrive via the
+         disable_battery_optimization plugin's manifest; permission_handler replaced that
+         plugin and ships an empty manifest by design, so the app must declare it itself.
+         Without it, Permission.ignoreBatteryOptimizations silently reports denied and
+         request() never opens the system prompt.
+    -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <!-- Features -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4608M
 android.useAndroidX=true
-android.enableJetifier=true
 android.builtInKotlin=false
 android.newDsl=false

--- a/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
+++ b/lib/app/layouts/settings/pages/misc/troubleshoot_panel.dart
@@ -13,11 +13,11 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/share.dart';
-import 'package:disable_battery_optimization/disable_battery_optimization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:universal_io/io.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -28,7 +28,7 @@ class TroubleshootPanel extends StatefulWidget {
   State<StatefulWidget> createState() => _TroubleshootPanelState();
 }
 
-class _TroubleshootPanelState extends State<TroubleshootPanel> with ThemeHelpers {
+class _TroubleshootPanelState extends State<TroubleshootPanel> with ThemeHelpers, WidgetsBindingObserver {
   final RxnBool resyncingHandles = RxnBool();
   final RxnBool resyncingChats = RxnBool();
   final RxInt logFileCount = 0.obs;
@@ -41,13 +41,28 @@ class _TroubleshootPanelState extends State<TroubleshootPanel> with ThemeHelpers
   void initState() {
     super.initState();
     _refreshLogStats();
+    WidgetsBinding.instance.addObserver(this);
+    _refreshBatteryOptimizationStatus();
+  }
 
-    // Check if battery optimizations are disabled
-    if (Platform.isAndroid) {
-      DisableBatteryOptimization.isAllBatteryOptimizationDisabled.then((value) {
-        optimizationsDisabled.value = value ?? false;
-      });
-    }
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Toggling the exemption happens in the system settings app, so the only signal we
+    // get that it changed is coming back to the foreground.
+    if (state == AppLifecycleState.resumed) _refreshBatteryOptimizationStatus();
+  }
+
+  Future<void> _refreshBatteryOptimizationStatus() async {
+    if (!Platform.isAndroid) return;
+    final isDisabled = await isBatteryOptimizationDisabled();
+    if (!mounted) return;
+    optimizationsDisabled.value = isDisabled;
   }
 
   void _refreshLogStats() {
@@ -255,28 +270,34 @@ class _TroubleshootPanelState extends State<TroubleshootPanel> with ThemeHelpers
                   SettingsHeader(iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: "Optimizations"),
                 if (Platform.isAndroid)
                   SettingsSection(backgroundColor: tileColor, children: [
-                    SettingsTile(
+                    Obx(() => SettingsTile(
                         onTap: () async {
+                          // Android exposes no API to revoke the exemption — the system
+                          // prompt only ever grants it. To turn optimizations back on the
+                          // user has to do it themselves, so send them to app settings and
+                          // pick the status back up on resume.
                           if (optimizationsDisabled.value) {
-                            showSnackbar(
-                                "Already Disabled", "Battery optimizations are already disabled for BlueBubbles");
+                            await openAppSettings();
                             return;
                           }
 
                           final optsDisabled = await disableBatteryOptimizations();
+                          await _refreshBatteryOptimizationStatus();
                           if (!optsDisabled) {
                             showSnackbar("Error", "Battery optimizations were not disabled. Please try again.");
                           }
                         },
-                        leading: Obx(() => SettingsLeadingIcon(
-                              iosIcon: CupertinoIcons.battery_25,
-                              materialIcon: Icons.battery_5_bar,
-                              containerColor: optimizationsDisabled.value ? Colors.green : Colors.redAccent,
-                            )),
-                        title: "Disable Battery Optimizations",
-                        subtitle:
-                            "Allow app to run in the background via the OS. This may not do anything on some devices.",
-                        trailing: Obx(() => !optimizationsDisabled.value
+                        leading: SettingsLeadingIcon(
+                          iosIcon: CupertinoIcons.battery_25,
+                          materialIcon: Icons.battery_5_bar,
+                          containerColor: optimizationsDisabled.value ? Colors.green : Colors.redAccent,
+                        ),
+                        title: "Battery Optimizations",
+                        isThreeLine: true,
+                        subtitle: optimizationsDisabled.value
+                            ? "Disabled — the OS lets BlueBubbles run in the background. Tap to open system settings if you want to turn optimizations back on."
+                            : "Enabled — the OS may stop BlueBubbles in the background. Tap to allow it to keep running. This may not do anything on some devices.",
+                        trailing: !optimizationsDisabled.value
                             ? const NextButton()
                             : Icon(Icons.check, color: context.theme.colorScheme.outline))),
                   ]),

--- a/lib/app/layouts/setup/pages/setup_checks/battery_optimization.dart
+++ b/lib/app/layouts/setup/pages/setup_checks/battery_optimization.dart
@@ -1,41 +1,103 @@
 import 'package:bluebubbles/helpers/backend/settings_helpers.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/layouts/setup/pages/page_template.dart';
-import 'package:disable_battery_optimization/disable_battery_optimization.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shimmer/shimmer.dart';
 
-class BatteryOptimizationCheck extends StatelessWidget {
+class BatteryOptimizationCheck extends StatefulWidget {
   const BatteryOptimizationCheck({super.key});
 
   @override
+  State<BatteryOptimizationCheck> createState() => _BatteryOptimizationCheckState();
+}
+
+class _BatteryOptimizationCheckState extends State<BatteryOptimizationCheck> with WidgetsBindingObserver {
+  /// Null until the first check resolves, so we don't flash "Enabled" on the way in
+  bool? _disabled;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _refreshStatus();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // The exemption is granted in a system dialog, so returning to the foreground is the
+    // only signal we get that the answer changed.
+    if (state == AppLifecycleState.resumed) _refreshStatus();
+  }
+
+  Future<void> _refreshStatus() async {
+    final isDisabled = await isBatteryOptimizationDisabled();
+    if (!mounted) return;
+    setState(() => _disabled = isDisabled);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final disabled = _disabled;
     return SetupPageTemplate(
       title: "Battery Optimization",
       subtitle:
           "We recommend disabling battery optimization for BlueBubbles to ensure you receive all your notifications.",
-      belowSubtitle: FutureBuilder<bool?>(
-        future: DisableBatteryOptimization.isAllBatteryOptimizationDisabled,
-        initialData: false,
-        builder: (context, snapshot) {
-          bool disabled = snapshot.data != null && snapshot.data == true;
-          if (disabled) {
-            return Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text("Battery Optimization: ${disabled ? "Disabled" : "Enabled"}",
-                    style: context.theme.textTheme.bodyLarge!
-                        .apply(
-                          fontSizeDelta: 1.5,
-                          color: disabled ? Colors.green : context.theme.colorScheme.error,
-                        )
-                        .copyWith(height: 2)),
-              ),
-            );
-          } else {
-            return Padding(
+      // Full width so the status row stays left-aligned in both states — without it the
+      // column shrinks to the status row alone once the button is gone, and the parent
+      // centers it.
+      belowSubtitle: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                Icon(
+                  disabled == null
+                      ? Icons.hourglass_empty
+                      : disabled
+                          ? Icons.check_circle
+                          : Icons.error_outline,
+                  color: disabled == null
+                      ? context.theme.colorScheme.outline
+                      : disabled
+                          ? Colors.green
+                          : context.theme.colorScheme.error,
+                  size: 24,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  disabled == null
+                      ? "Battery Optimization: Checking…"
+                      : "Battery Optimization: ${disabled ? "Disabled" : "Enabled"}",
+                  style: context.theme.textTheme.bodyLarge!
+                      .apply(
+                        fontSizeDelta: 1.5,
+                        color: disabled == null
+                            ? context.theme.colorScheme.outline
+                            : disabled
+                                ? Colors.green
+                                : context.theme.colorScheme.error,
+                      )
+                      .copyWith(height: 2),
+                ),
+              ],
+            ),
+          ),
+          // Nothing to prompt for once we already have the exemption — Android has no API
+          // to revoke it, so undoing this is a trip to system settings the user makes on
+          // their own. The status above updates when they come back either way.
+          if (disabled == false)
+            Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 13),
               child: Align(
                 alignment: Alignment.centerLeft,
@@ -62,6 +124,7 @@ class BatteryOptimizationCheck extends StatelessWidget {
                     ),
                     onPressed: () async {
                       final optimizationsDisabled = await disableBatteryOptimizations();
+                      await _refreshStatus();
                       if (!optimizationsDisabled) {
                         showSnackbar("Error", "Battery optimizations were not disabled. Please try again.");
                       }
@@ -83,9 +146,8 @@ class BatteryOptimizationCheck extends StatelessWidget {
                   ),
                 ),
               ),
-            );
-          }
-        },
+            ),
+        ],
       ),
     );
   }

--- a/lib/app/layouts/setup/setup_view.dart
+++ b/lib/app/layouts/setup/setup_view.dart
@@ -8,8 +8,8 @@ import 'package:bluebubbles/app/layouts/setup/pages/setup_checks/mac_setup_check
 import 'package:bluebubbles/app/layouts/setup/pages/sync/sync_progress.dart';
 import 'package:bluebubbles/app/layouts/setup/pages/welcome/welcome_page.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
+import 'package:bluebubbles/helpers/backend/settings_helpers.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:disable_battery_optimization/disable_battery_optimization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
@@ -188,8 +188,8 @@ class SetupPages extends StatelessWidget {
         onPageChanged: (page) {
           // skip pages if the things required are already complete
           if (!kIsWeb && !kIsDesktop && page == 2 && controller.currentPage == 2) {
-            DisableBatteryOptimization.isAllBatteryOptimizationDisabled.then((isDisabled) {
-              if (isDisabled ?? false) {
+            isBatteryOptimizationDisabled().then((isDisabled) {
+              if (isDisabled) {
                 controller.pageController.nextPage(
                   duration: const Duration(milliseconds: 300),
                   curve: Curves.easeInOut,

--- a/lib/helpers/backend/settings_helpers.dart
+++ b/lib/helpers/backend/settings_helpers.dart
@@ -3,7 +3,8 @@ import 'package:bluebubbles/helpers/network/network_helpers.dart';
 import 'package:bluebubbles/helpers/network/network_tasks.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/logger/logger.dart';
-import 'package:disable_battery_optimization/disable_battery_optimization.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:universal_io/io.dart';
 
 Future<bool> saveNewServerUrl(String newServerUrl,
     {bool tryRestartForegroundService = true,
@@ -69,16 +70,25 @@ Future<void> clearServerUrl(
   }
 }
 
+/// Whether the OS is currently exempting us from battery optimization
+///
+/// Backed by `PowerManager.isIgnoringBatteryOptimizations()`. Only Android has the
+/// concept, so everywhere else reports true — callers use this to decide whether to
+/// nag the user, and a check that can never pass would nag forever.
+Future<bool> isBatteryOptimizationDisabled() async {
+  if (!Platform.isAndroid) return true;
+  return await Permission.ignoreBatteryOptimizations.isGranted;
+}
+
 /// Prompts the user to disable battery optimizations for the app
 ///
 /// Returns true if the user has disabled battery optimizations
 Future<bool> disableBatteryOptimizations() async {
-  bool? isDisabled = await DisableBatteryOptimization.isAllBatteryOptimizationDisabled;
+  // If battery optimizations are already disabled, return true
+  if (await isBatteryOptimizationDisabled()) return true;
 
-  // If battery optomizations are already disabled, return true
-  if (isDisabled == true) return true;
-
-  // If optimizations are not disabled, prompt the user to disable them
-  isDisabled = await DisableBatteryOptimization.showDisableBatteryOptimizationSettings();
-  return isDisabled ?? false;
+  // If optimizations are not disabled, prompt the user to disable them. Unlike the
+  // old plugin — which reported success as soon as the settings screen opened — this
+  // resolves once the user returns, so the result reflects what they actually chose.
+  return (await Permission.ignoreBatteryOptimizations.request()).isGranted;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,15 +611,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  disable_battery_optimization:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: "996c83bf5f58522ba8da3ce6f44952be7b68171c"
-      resolved-ref: "996c83bf5f58522ba8da3ce6f44952be7b68171c"
-      url: "https://github.com/BlueBubblesApp/Disable-Battery-Optimizations.git"
-    source: git
-    version: "1.1.1"
   dlibphonenumber:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,10 +51,6 @@ dependencies:
   device_info_plus: ^11.3.0
   dice_bear: ^1.0.3
   dio: ^5.9.0
-  disable_battery_optimization: # for jcenter() gradle deprecation
-    git:
-      url: https://github.com/BlueBubblesApp/Disable-Battery-Optimizations.git
-      ref: 996c83bf5f58522ba8da3ce6f44952be7b68171c
   dlibphonenumber: ^1.1.46 # phone number parsing
   dynamic_color: ^1.8.1 # Pinned because of flutter SDK
   easy_debounce: ^2.0.3


### PR DESCRIPTION
Replaces the forked `disable_battery_optimization` plugin with `permission_handler`'s `Permission.ignoreBatteryOptimizations`, which was already a dependency and calls the same `PowerManager.isIgnoringBatteryOptimizations()` / `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` under the hood.

Split out of the Android build work so the Gradle/AGP upgrade can be reviewed separately.

## Why

The plugin was 2,633 lines of Java across 26 files; the app used two methods. The rest is OEM autostart handling reachable only through methods we never call.

The part we *did* use was wrong. `isAllBatteryOptimizationDisabled` ANDed the real OS check with two SharedPreferences flags that cached `!KillerManager.isActionAvailable(...)` on first read and were only ever set by dialog flows the app never invoked. On any device whose OEM ships an autostart settings screen — **Samsung, Xiaomi, Oppo, Huawei** — that cached `false` permanently, so the check reported "not disabled" even after the user granted the exemption. Those are exactly the manufacturers whose battery management makes the check matter.

## Changes

- **Manifest**: declares `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` directly. It used to arrive via the plugin's manifest merger, and `permission_handler_android` ships an empty manifest by design — without this the permission silently disappears and `request()` never opens the system prompt. Also drops the plugin's stray `oppo.permission.OPPO_COMPONENT_SAFE`.
- **Jetifier off**: the plugin's `material-dialogs:0.9.6.0` pulled `com.android.support` and was the only thing keeping `android.enableJetifier` on. With it gone, `./gradlew checkJetifier` reports **57/57 projects clean**. AGP 9.1+ rejects the flag outright, so this had to happen regardless.
- **Live status**: both surfaces re-read on `AppLifecycleState.resumed`. The exemption is granted in a system dialog, so returning to the foreground is the only signal it changed; the setup page previously checked once and never updated.
- **Setup page** now shows status in both states — it rendered nothing at all when optimizations were still enabled.
- **Developer Tools tile** routes to `openAppSettings()` when already exempt. Android has no revoke API, so undoing this has to be a trip to system settings rather than the "Already Disabled" dead end it was.

## Testing

Verified on an Android 16 (API 36) emulator, prod flavor:

- Setup page correctly shows red "Enabled" + button when not exempt
- Tapping through launches the real `com.android.settings/.fuelgauge.RequestIgnoreBatteryOptimizations` dialog
- Allow adds the app to the deviceidle whitelist and the page flips to a green check with no restart
- Revoking via adb and relaunching shows the "Enabled" state again
- Debug + release APKs build; app launches with no `NoClassDefFoundError`

**Not verified:** the Developer Tools tile itself — it sits behind a configured server I don't have. It shares the same helpers as the setup page, which are verified, but the tile UI is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)