### PR TITLE
feat: dynamic columns for Photos & Videos gallery on larger screens

### DIFF
--- a/lib/app/layouts/conversation_details/attachment_section_type.dart
+++ b/lib/app/layouts/conversation_details/attachment_section_type.dart
@@ -24,12 +24,15 @@ EdgeInsets attachmentSectionListPadding({double top = 0, double bottom = 10}) {
   return EdgeInsets.only(left: inset, right: inset, top: top, bottom: bottom);
 }
 
-/// Media grid column count by Material window size class (compact / medium / expanded),
-/// used by the expressive attachment sections instead of `max(2, width ~/ 200)`.
+/// Media grid column count by Material window size class
+/// (compact / medium / expanded / large / extra-large),
+/// used by the details Photos & Videos preview instead of `max(2, width ~/ 200)`.
 int expressiveMediaCrossAxisCount(double width) {
   if (width < 600) return 2;
   if (width < 840) return 3;
-  return 4;
+  if (width < 1200) return 4;
+  if (width < 1600) return 5;
+  return 6;
 }
 
 enum MediaFilter {

--- a/lib/app/layouts/conversation_details/conversation_attachments.dart
+++ b/lib/app/layouts/conversation_details/conversation_attachments.dart
@@ -162,7 +162,6 @@ class _ConversationAttachmentsState extends State<ConversationAttachments> with 
             selected: selected,
             isLoading: isLoadingAttachments,
             fullPage: true,
-            crossAxisCount: 3,
             mediaFilter: _filters.mediaFilter,
             senderFilter: _filters.senderFilter,
             sinceDate: _filters.sinceDate,

--- a/lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart
+++ b/lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart
@@ -89,7 +89,8 @@ class _MediaGridSectionState extends State<MediaGridSection> with ThemeHelpers {
 
   int get _gridCrossAxisCount {
     if (widget.crossAxisCount != null) return widget.crossAxisCount!;
-    return expressiveMediaCrossAxisCount(NavigationSvc.width(context));
+    final width = NavigationSvc.width(context);
+    return expressiveMediaCrossAxisCount(width) + (widget.fullPage ? 1 : 0);
   }
 
   void _loadMore() {

--- a/lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart
+++ b/lib/app/layouts/conversation_details/widgets/sections/media/media_grid_section.dart
@@ -8,7 +8,6 @@ import 'package:bluebubbles/app/layouts/conversation_details/widgets/media_galle
 import 'package:bluebubbles/app/layouts/conversation_details/widgets/sections/media/media_filter_selector.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
-import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -87,9 +86,8 @@ class _MediaGridSectionState extends State<MediaGridSection> with ThemeHelpers {
     return min(kAttachmentPreviewLimit, _filteredMedia.length);
   }
 
-  int get _gridCrossAxisCount {
+  int _gridCrossAxisCountFor(double width) {
     if (widget.crossAxisCount != null) return widget.crossAxisCount!;
-    final width = NavigationSvc.width(context);
     return expressiveMediaCrossAxisCount(width) + (widget.fullPage ? 1 : 0);
   }
 
@@ -226,16 +224,20 @@ class _MediaGridSectionState extends State<MediaGridSection> with ThemeHelpers {
           padding: attachmentSectionListPadding(
             top: widget.fullPage ? 10 : 0,
           ),
-          sliver: SliverGrid(
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: _gridCrossAxisCount,
-              mainAxisSpacing: 10,
-              crossAxisSpacing: 10,
-            ),
-            delegate: SliverChildBuilderDelegate(
-              (context, int index) => _buildGridItem(context, index),
-              childCount: _visibleCount,
-            ),
+          sliver: SliverLayoutBuilder(
+            builder: (context, constraints) {
+              return SliverGrid(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: _gridCrossAxisCountFor(constraints.crossAxisExtent),
+                  mainAxisSpacing: 10,
+                  crossAxisSpacing: 10,
+                ),
+                delegate: SliverChildBuilderDelegate(
+                  (context, int index) => _buildGridItem(context, index),
+                  childCount: _visibleCount,
+                ),
+              );
+            },
           ),
         ),
         if (widget.fullPage && _displayCount < _filteredMedia.length)


### PR DESCRIPTION
The Photos & Videos gallery currently uses a fixed 3-column grid which causes the items to scale poorly on wider screens.

The conversation-details page already dynamically resolves the number of columns for the preview grid; this PR reuses the same logic on the gallery grid and adds more breakpoints for larger screens. It also makes the column count reactive to page resizes.

**Before:**
preview screen: 2-4 columns
full page gallery: 3 columns fixed

<table>
  <tr>
    <td align="center">
<img width="2560" height="1392" alt="bluebubbles_app_UZfpLPMz0H" src="https://github.com/user-attachments/assets/ba9c8395-7220-40f3-97ac-d4fbe2b1c328" />
    </td>
    <td align="center">
<img width="2560" height="1392" alt="bluebubbles_app_0z2SkAKrUF" src="https://github.com/user-attachments/assets/1e2e6dfb-b890-419c-9b3c-a9376915ff83" />
    </td>
  </tr>
</table>


**After**
preview screen: 2-6 columns
full page gallery: 3-7 columns
reactive

<table>
  <tr>
    <td align="center">
<img width="2560" height="1392" alt="bluebubbles_app_fArFLRV2gN" src="https://github.com/user-attachments/assets/0c397f06-e2b5-4fef-8a93-77cba58ff39a" />
    </td>
    <td align="center">
<img width="2560" height="1392" alt="bluebubbles_app_BLOp5GNQqD" src="https://github.com/user-attachments/assets/c23f286c-5858-483e-84b3-c6cc5047875a" />
    </td>
  </tr>
  <tr>
    <td width="50%" align="center">
      <video width="50%" controls src="https://github.com/user-attachments/assets/a003e003-d6b7-4804-a700-229f7e799db0"></video>
    </td>
  </tr>
</table>


## Files touched
- `attachment_section_type.dart` — column helper by window size class (adds columns for large / extra-large breakpoints)
- `media_grid_section.dart` — full-page gallery uses helper + 1; rebuild columns from live sliver width
- `conversation_attachments.dart` — drop the hardcoded 3-column Photos & Videos grid