### PR TITLE
feat: automatically lazy load gallery photos when in view / scrolling

### DIFF
--- a/lib/app/layouts/conversation_details/widgets/media_gallery_card.dart
+++ b/lib/app/layouts/conversation_details/widgets/media_gallery_card.dart
@@ -78,6 +78,20 @@ class _MediaGalleryCardState extends State<MediaGalleryCard> with AutomaticKeepA
         getVideoPreview(content as PlatformFile);
       }
     }
+
+    // auto-download images. Videos, audios, and other files stay tap-to-download.
+    if (content is Attachment &&
+        attachment.guid != null &&
+        !attachment.guid!.startsWith("temp") &&
+        attachment.mimeStart == "image") {
+      unawaited(_maybeAutoDownload());
+    }
+  }
+
+  Future<void> _maybeAutoDownload() async {
+    if (!await AttachmentsSvc.canAutoDownload()) return;
+    if (!mounted || content is! Attachment) return;
+    _startDownload();
   }
 
   void onComplete(PlatformFile file) {
@@ -92,6 +106,10 @@ class _MediaGalleryCardState extends State<MediaGalleryCard> with AutomaticKeepA
   }
 
   void downloadAttachment() {
+    _startDownload();
+  }
+
+  void _startDownload() {
     setState(() {
       content = AttachmentDownloader.startDownload(attachment, onComplete: onComplete);
       if (content is AttachmentDownloadController) {


### PR DESCRIPTION
Currently, to view any unloaded items in the Photos & Videos gallery, you have to tap to load each one. This can get very tedious with dozens or hundreds of photos.

This PR enables auto-downloading **only** photos (no videos) when they enter the viewport, so as you scroll it lazy loads the next images.

It also uses the existing "Auto-download Attachments" and "Only auto-download Attachments on Wifi" flags in settings.

## Developer Notes
I decided on keeping it photos only because I am worried that videos, audio, and other files would hit the users' storage pretty hard. If requested, I also don't mind making this a separate settings flag (+ that flag can be just photos or all attachments). Feedback welcome

## New behavior - Auto-download photos while scrolling
https://github.com/user-attachments/assets/948eb521-c145-478f-a4f3-ce47d3e91774

## Existing behavior - tap to download each item
https://github.com/user-attachments/assets/d1cc589d-fc20-4da0-b063-6afd61fe6ade


