### PR TITLE
feat: match Find My Friend identities against Handles / ContactV2s

### DIFF
--- a/lib/app/layouts/findmy/CLAUDE.md
+++ b/lib/app/layouts/findmy/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Files
 - `findmy_page.dart` — main screen (map + list tabs)
 - `findmy_controller.dart` — state and logic: location polling, device/friend tracking
+- `findmy_handle_matcher.dart` — friend → handle/contact identity
 - `findmy_location_clipper.dart` — custom `CustomClipper` for location shape
 - `findmy_pin_clipper.dart` — custom `CustomClipper` for map pin shape
 

--- a/lib/app/layouts/findmy/findmy_controller.dart
+++ b/lib/app/layouts/findmy/findmy_controller.dart
@@ -14,6 +14,7 @@ import 'package:sliding_up_panel2/sliding_up_panel2.dart';
 import 'package:universal_io/io.dart';
 import 'package:flutter/foundation.dart';
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_handle_matcher.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_location_clipper.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_pin_clipper.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -53,10 +54,18 @@ class FindMyController extends GetxController {
   StreamSubscription? _redactedModeListener;
   StreamSubscription? _hideContactInfoListener;
   StreamSubscription? _findMyLocationListener;
+  StreamSubscription? _contactIndexListener;
 
   @override
   void onInit() {
     super.onInit();
+    _contactIndexListener = FindMyHandleMatcher.indexCleared.listen((_) {
+      if (!_isAlive) return;
+      _rebuildAllMarkers();
+      friends.refresh();
+      friendsWithLocation.refresh();
+      friendsWithoutLocation.refresh();
+    });
     getLocations();
 
     // Listen via the event dispatcher rather than the socket itself — the socket is
@@ -315,6 +324,7 @@ class FindMyController extends GetxController {
 
   void buildFriendMarker(FindMyFriend friend) {
     final markerKey = friend.stableId ?? randomString(6);
+    final identity = FindMyHandleMatcher.resolveIdentity(friend);
     markers[markerKey] = Marker(
       key: ValueKey('friend-$markerKey'),
       point: markerPointForFriend(friend),
@@ -326,7 +336,10 @@ class FindMyController extends GetxController {
           child: Padding(
             padding: const EdgeInsets.all(3),
             child: ContactAvatarWidget(
-                editable: false, handle: friend.handle ?? Handle(address: friend.title ?? "Unknown")),
+              editable: false,
+              handle: identity.handle,
+              contact: identity.contact,
+            ),
           ),
         ),
       ),
@@ -391,6 +404,7 @@ class FindMyController extends GetxController {
     _redactedModeListener?.cancel();
     _hideContactInfoListener?.cancel();
     _findMyLocationListener?.cancel();
+    _contactIndexListener?.cancel();
     locationSub?.cancel();
     mapController.dispose();
     popupController.dispose();

--- a/lib/app/layouts/findmy/findmy_handle_matcher.dart
+++ b/lib/app/layouts/findmy/findmy_handle_matcher.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+
+import 'package:bluebubbles/database/database.dart';
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/models/models.dart' show HandleLookupKey;
+import 'package:flutter/foundation.dart';
+
+/// A Find My friend's matching chat [Handle] and/or address-book [ContactV2].
+/// Used by the list, map markers, and popups for name and avatar.
+class FindMyFriendIdentity {
+  const FindMyFriendIdentity({this.handle, this.contact});
+
+  final Handle? handle;
+  final ContactV2? contact;
+
+  /// Contact name, then handle name, then the formatted Find My address.
+  String displayName(FindMyFriend friend) {
+    if (contact != null && !isNullOrEmpty(contact!.computedDisplayName)) {
+      return contact!.computedDisplayName;
+    }
+    if (handle != null) return handle!.displayName;
+    final raw = friend.handleAddress ?? friend.title;
+    if (isNullOrEmpty(raw)) return 'Unknown Friend';
+    return raw!.contains('@') ? raw : formatPhoneNumber(raw);
+  }
+}
+
+/// Resolves a Find My friend to a [Handle] and/or [ContactV2].
+///
+/// Find My identifies friends by Apple ID email (or phone). Sometimes, this may not
+/// have a corresponding chat, or may be linked to a different handle.
+///
+/// 1. Look up a [Handle] with this exact address
+/// 2. Otherwise look up a [ContactV2] that lists this email or phone.
+/// 3. If that contact has a handle already linked to a 1:1 chat, use that
+///    handle instead. Otherwise fall back to any other handle on the contact.
+/// 
+/// If nothing matches, [FindMyFriendIdentity.displayName] uses the raw Find My
+/// address. 
+/// 
+/// The email/phone → contact index is process-lifetime; contact sync
+/// calls [clearContactIndex], which emits [indexCleared] so Find My can refresh.
+/// 
+class FindMyHandleMatcher {
+  FindMyHandleMatcher._();
+
+  static Map<String, ContactV2>? _index;
+  static final _indexCleared = StreamController<void>.broadcast(sync: true);
+
+  /// Broadcast after [clearContactIndex] so Find My can rebuild names/avatars.
+  static Stream<void> get indexCleared => _indexCleared.stream;
+
+  /// Drops the cached contact index and emits [indexCleared]. Called after contact sync.
+  static void clearContactIndex() {
+    _index = null;
+    _indexCleared.add(null);
+  }
+
+  /// Returns the [Handle] and/or [ContactV2] for [friend], following the class lookup order.
+  static FindMyFriendIdentity resolveIdentity(FindMyFriend friend) {
+    final handle = friend.handle ?? _findHandle(friend);
+    if (handle != null) return FindMyFriendIdentity(handle: handle);
+
+    final contact = _findContact(friend);
+    if (contact == null) return const FindMyFriendIdentity();
+    return FindMyFriendIdentity(handle: _linkedHandle(contact, friend), contact: contact);
+  }
+
+  /// Exact iMessage, then SMS, handle for any address on [friend].
+  static Handle? _findHandle(FindMyFriend friend) {
+    for (final addr in _addresses(friend)) {
+      final iMessage = Handle.findOne(addressAndService: HandleLookupKey(addr, 'iMessage'));
+      if (iMessage != null) return iMessage;
+      final sms = Handle.findOne(addressAndService: HandleLookupKey(addr, 'SMS'));
+      if (sms != null) return sms;
+    }
+    return null;
+  }
+
+  /// Contact whose indexed emails/phones include an address on [friend].
+  static ContactV2? _findContact(FindMyFriend friend) {
+    final index = _contactIndex();
+    if (index == null) return null;
+    for (final addr in _addresses(friend)) {
+      if (addr.contains('@')) {
+        final hit = index[ContactV2.normalizeEmail(addr)];
+        if (hit != null) return hit;
+      } else {
+        final hit = index[ContactV2.normalizePhoneNumber(addr)];
+        if (hit != null) return hit;
+      }
+    }
+    return null;
+  }
+
+  /// Distinct addresses from [FindMyFriend.handleAddress] and [FindMyFriend.title].
+  /// Truncates at `/` — some Find My payloads use `address/suffix`.
+  static Iterable<String> _addresses(FindMyFriend friend) {
+    return {friend.handleAddress, friend.title}
+        .whereType<String>()
+        .map((value) {
+          final trimmed = value.trim();
+          return trimmed.contains('/') ? trimmed.split('/').first : trimmed;
+        })
+        .where((addr) => addr.isNotEmpty);
+  }
+
+  /// Lazy map of normalized contact email/phone → [ContactV2]. Null on web.
+  static Map<String, ContactV2>? _contactIndex() {
+    if (kIsWeb) return null;
+    if (_index != null) return _index;
+
+    final index = <String, ContactV2>{};
+    for (final contact in Database.contactsV2.getAll()) {
+      for (final address in contact.addresses) {
+        if (address.contains('@')) {
+          final email = ContactV2.normalizeEmail(address);
+          if (email.isNotEmpty) index[email] = contact;
+        } else {
+          final phone = ContactV2.normalizePhoneNumber(address);
+          if (phone.isNotEmpty) index[phone] = contact;
+        }
+      }
+    }
+    return _index = index;
+  }
+
+  /// Best [Handle] already linked to [contact] after a contact-only match.
+  /// Skips [friend]'s Find My address; prefers a 1:1 iMessage chat, then SMS, then any other.
+  static Handle? _linkedHandle(ContactV2 contact, FindMyFriend friend) {
+    final skip = {
+      for (final addr in _addresses(friend)) _normalizeAddress(addr),
+    };
+
+    Handle? inChatIMessage;
+    Handle? inChatSms;
+    Handle? anyIMessage;
+    Handle? anySms;
+    for (final handle in contact.handles) {
+      if (skip.contains(_normalizeAddress(handle.address))) continue;
+      final used = _usedInDirectChat(handle);
+      if (handle.service == 'iMessage') {
+        if (used) {
+          inChatIMessage ??= handle;
+        } else {
+          anyIMessage ??= handle;
+        }
+      } else if (used) {
+        inChatSms ??= handle;
+      } else {
+        anySms ??= handle;
+      }
+    }
+    return inChatIMessage ?? inChatSms ?? anyIMessage ?? anySms;
+  }
+
+  static String _normalizeAddress(String address) {
+    return address.contains('@') ? ContactV2.normalizeEmail(address) : ContactV2.normalizePhoneNumber(address);
+  }
+
+  /// Whether [handle] appears in a 1:1 chat guid (`service;-;address`). Group chats are ignored.
+  static bool _usedInDirectChat(Handle handle) {
+    if (kIsWeb || handle.address.isEmpty) return false;
+    final query = Database.chats.query(Chat_.guid.contains(';-;${handle.address}')).build();
+    query.limit = 1;
+    final found = query.findFirst() != null;
+    query.close();
+    return found;
+  }
+}

--- a/lib/app/layouts/findmy/findmy_handle_matcher.dart
+++ b/lib/app/layouts/findmy/findmy_handle_matcher.dart
@@ -87,8 +87,10 @@ class FindMyHandleMatcher {
         final hit = index[ContactV2.normalizeEmail(addr)];
         if (hit != null) return hit;
       } else {
-        final hit = index[ContactV2.normalizePhoneNumber(addr)];
-        if (hit != null) return hit;
+        for (final key in getPhoneNumberVariants(addr)) {
+          final hit = index[key];
+          if (hit != null) return hit;
+        }
       }
     }
     return null;
@@ -118,8 +120,9 @@ class FindMyHandleMatcher {
           final email = ContactV2.normalizeEmail(address);
           if (email.isNotEmpty) index[email] = contact;
         } else {
-          final phone = ContactV2.normalizePhoneNumber(address);
-          if (phone.isNotEmpty) index[phone] = contact;
+          for (final key in getPhoneNumberVariants(address)) {
+            if (key.isNotEmpty) index[key] = contact;
+          }
         }
       }
     }

--- a/lib/app/layouts/findmy/widgets/findmy_friend_list_tile.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_friend_list_tile.dart
@@ -1,5 +1,6 @@
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
 import 'package:bluebubbles/app/layouts/findmy/findmy_controller.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_handle_matcher.dart';
 import 'package:bluebubbles/app/layouts/findmy/widgets/findmy_raw_data_dialog.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -34,17 +35,18 @@ class FindMyFriendListTile extends StatelessWidget {
               ? ("${item.shortAddress ?? "No location found"}$lastUpdatedSuffix")
               : (item.longAddress ?? "No location found");
 
-      final handleState = item.handle != null ? HandleSvc.getOrCreateHandleState(item.handle!) : null;
+      final identity = FindMyHandleMatcher.resolveIdentity(item);
+      final handleState = identity.handle != null ? HandleSvc.getOrCreateHandleState(identity.handle!) : null;
       final displayName = hideContactInfo
           ? (handleState?.fakeName ?? 'Contact')
-          : (item.handle?.displayName ?? item.title ?? "Unknown Friend");
+          : identity.displayName(item);
 
       final hasLocation = item.latitude != null && item.longitude != null;
       final markerPoint = hasLocation ? controller.markerPointForFriend(item) : null;
 
       return ListTile(
         mouseCursor: MouseCursor.defer,
-        leading: ContactAvatarWidget(handle: item.handle),
+        leading: ContactAvatarWidget(handle: identity.handle, contact: identity.contact),
         title: Text(displayName),
         subtitle: Text(displayLocation),
         trailing: withLocation && hasLocation

--- a/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
+++ b/lib/app/layouts/findmy/widgets/findmy_map_widget.dart
@@ -1,4 +1,5 @@
 import 'package:bluebubbles/app/layouts/findmy/findmy_controller.dart';
+import 'package:bluebubbles/app/layouts/findmy/findmy_handle_matcher.dart';
 import 'package:bluebubbles/app/wrappers/trackpad_bug_wrapper.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -118,10 +119,11 @@ class FindMyMapWidget extends StatelessWidget {
   Widget _buildFriendPopup(BuildContext context, FindMyFriend item) {
     return Obx(() {
       final hideContactInfo = shouldRedactFindMyContactInfo();
-      final handleState = item.handle != null ? HandleSvc.getOrCreateHandleState(item.handle!) : null;
+      final identity = FindMyHandleMatcher.resolveIdentity(item);
+      final handleState = identity.handle != null ? HandleSvc.getOrCreateHandleState(identity.handle!) : null;
       final displayName = hideContactInfo
           ? (handleState?.fakeName ?? 'Contact')
-          : (item.handle?.displayName ?? item.title ?? "Unknown Friend");
+          : identity.displayName(item);
 
       return Padding(
         padding: const EdgeInsets.only(bottom: 5.0),

--- a/lib/helpers/types/helpers/contact_helpers.dart
+++ b/lib/helpers/types/helpers/contact_helpers.dart
@@ -30,6 +30,56 @@ String formatPhoneNumber(dynamic item) {
   return formatted ?? address;
 }
 
+/// Generate multiple normalized variants of a phone number to handle country code mismatches
+///
+/// Returns a set of normalized phone numbers including:
+/// - The original normalized number (digits + plus sign only)
+/// - Variant without country code (if one exists)
+/// - Variant with country code removed but assuming it started with +
+///
+/// This handles cases where:
+/// - Contact has "1234567890" but Handle has "+11234567890"
+/// - Contact has "+11234567890" but Handle has "1234567890"
+/// - Works with any country code, not just +1
+Set<String> getPhoneNumberVariants(String phone) {
+  final variants = <String>{};
+  final normalized = ContactV2.normalizePhoneNumber(phone);
+
+  if (normalized.isEmpty) return variants;
+
+  // Always include the base normalized version
+  variants.add(normalized);
+
+  // If it starts with +, add variant without the +
+  if (normalized.startsWith('+')) {
+    variants.add(normalized.substring(1));
+
+    // Also try removing common country codes (1-3 digits after +)
+    // Country codes can be 1-3 digits (e.g., +1, +44, +852, +1246)
+    for (int i = 1; i <= 3 && i < normalized.length; i++) {
+      final withoutCountryCode = normalized.substring(i + 1);
+      if (withoutCountryCode.isNotEmpty) {
+        variants.add(withoutCountryCode);
+      }
+    }
+  } else {
+    // If no +, try adding + and common country code lengths
+    // This handles cases where the stored number doesn't have + but the contact does
+    variants.add('+$normalized');
+
+    // Try removing 1-3 digit prefixes as potential country codes
+    for (int i = 1; i <= 3 && i < normalized.length; i++) {
+      final withoutPrefix = normalized.substring(i);
+      if (withoutPrefix.isNotEmpty) {
+        variants.add(withoutPrefix);
+        variants.add('+$withoutPrefix');
+      }
+    }
+  }
+
+  return variants;
+}
+
 List<String> getUniqueNumbers(Iterable<String> numbers) {
   List<String> phones = [];
   for (String phone in numbers) {

--- a/lib/models/html/contact_v2.dart
+++ b/lib/models/html/contact_v2.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:bluebubbles/database/html/handle.dart';
 import 'package:flutter/material.dart';
 
 /// Web stub for ContactV2 - minimal implementation for web compatibility
@@ -17,6 +18,8 @@ class ContactV2 {
   String nativeContactId;
   String? avatarPath;
   List<String> addresses;
+
+  String get computedDisplayName => displayName;
 
   // Stub properties for web
   Widget? _fakeAvatar;
@@ -45,6 +48,8 @@ class ContactV2 {
   static String normalizeEmail(String email) {
     return email.toLowerCase().trim();
   }
+
+  List<Handle> get handles => const [];
 
   bool hasMatchingAddress(String address) {
     final normalized = address.contains('@') ? normalizeEmail(address) : normalizePhoneNumber(address);

--- a/lib/services/backend/actions/contact_v2_actions.dart
+++ b/lib/services/backend/actions/contact_v2_actions.dart
@@ -20,56 +20,6 @@ class ContactV2Actions {
   /// Completer to ensure syncContactsToHandles only runs once at a time
   static Completer<_ContactSyncStats>? _syncCompleter;
 
-  /// Generate multiple normalized variants of a phone number to handle country code mismatches
-  ///
-  /// Returns a set of normalized phone numbers including:
-  /// - The original normalized number (digits + plus sign only)
-  /// - Variant without country code (if one exists)
-  /// - Variant with country code removed but assuming it started with +
-  ///
-  /// This handles cases where:
-  /// - Contact has "1234567890" but Handle has "+11234567890"
-  /// - Contact has "+11234567890" but Handle has "1234567890"
-  /// - Works with any country code, not just +1
-  static Set<String> _getPhoneNumberVariants(String phone) {
-    final variants = <String>{};
-    final normalized = ContactV2.normalizePhoneNumber(phone);
-
-    if (normalized.isEmpty) return variants;
-
-    // Always include the base normalized version
-    variants.add(normalized);
-
-    // If it starts with +, add variant without the +
-    if (normalized.startsWith('+')) {
-      variants.add(normalized.substring(1));
-
-      // Also try removing common country codes (1-3 digits after +)
-      // Country codes can be 1-3 digits (e.g., +1, +44, +852, +1246)
-      for (int i = 1; i <= 3 && i < normalized.length; i++) {
-        final withoutCountryCode = normalized.substring(i + 1);
-        if (withoutCountryCode.isNotEmpty) {
-          variants.add(withoutCountryCode);
-        }
-      }
-    } else {
-      // If no +, try adding + and common country code lengths
-      // This handles cases where the stored number doesn't have + but the contact does
-      variants.add('+$normalized');
-
-      // Try removing 1-3 digit prefixes as potential country codes
-      for (int i = 1; i <= 3 && i < normalized.length; i++) {
-        final withoutPrefix = normalized.substring(i);
-        if (withoutPrefix.isNotEmpty) {
-          variants.add(withoutPrefix);
-          variants.add('+$withoutPrefix');
-        }
-      }
-    }
-
-    return variants;
-  }
-
   /// Fetch all contacts from device and match them to existing handles
   /// This is the main operation described in Section II.A of FR-1.md
   ///
@@ -226,13 +176,13 @@ class ContactV2Actions {
             }
           } else {
             // For phones, generate all variants and map them
-            final variants = _getPhoneNumberVariants(handle.address);
+            final variants = getPhoneNumberVariants(handle.address);
             for (final variant in variants) {
               phoneHandleMap.putIfAbsent(variant, () => []).add(handle);
             }
 
             if (handle.formattedAddress != null) {
-              final formattedVariants = _getPhoneNumberVariants(handle.formattedAddress!);
+              final formattedVariants = getPhoneNumberVariants(handle.formattedAddress!);
               for (final variant in formattedVariants) {
                 phoneHandleMap.putIfAbsent(variant, () => []).add(handle);
               }
@@ -408,7 +358,7 @@ class ContactV2Actions {
               }
             } else {
               // For phones, check all variants
-              final variants = _getPhoneNumberVariants(address);
+              final variants = getPhoneNumberVariants(address);
               for (final variant in variants) {
                 final handles = phoneHandleMap[variant];
                 if (handles != null) {

--- a/lib/services/ui/contact_service_v2.dart
+++ b/lib/services/ui/contact_service_v2.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:bluebubbles/app/layouts/findmy/findmy_handle_matcher.dart';
 import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
@@ -298,6 +299,7 @@ class ContactServiceV2 {
   /// Notify the UI that certain handles have been updated.
   /// Pushes fresh DB data into the HandleState registry so reactive Obx() widgets rebuild.
   void notifyHandlesUpdated(List<int> handleIds) {
+    FindMyHandleMatcher.clearContactIndex();
     if (handleIds.isEmpty) return;
 
     // Push refreshed Handle data into the HandleState registry


### PR DESCRIPTION
This PR solves #2619 / Contacts not showing in Find My friends

It takes the given email/phone identities and resolves them to a Handle or ContactV2.

Resolution order:
1. Exact handle (directly matches a conversation handle: iMessage, then SMS)
2. ContactV2 email/phone fields
3. If the ContactV2 has another associated handle being used in a conversation, prefer that handle
This solves the issue of FindMy giving you an email address for a contact but your conversations use the phone number, or vice versa (#2619)
4. Fall back to the formatted Find My address, if nothing matches

If a user does not have a person's email and phone number under the same contact, then there is no way to link those two to the same contact.

I can also personally verify it successfully linked an email identity to an existing conversation handle / contact in my testing

<details>
<summary>File Changes</summary>

`lib/app/layouts/findmy/findmy_handle_matcher.dart` — new matcher and FindMyFriendIdentity type
`lib/app/layouts/findmy/findmy_controller.dart` — resolve map-marker identity; refresh on contact-index clear
`lib/app/layouts/findmy/widgets/findmy_friend_list_tile.dart` — list name/avatar from identity
`lib/app/layouts/findmy/widgets/findmy_map_widget.dart` — popup name from identity
`lib/helpers/types/helpers/contact_helpers.dart` — extracted `getPhoneNumberVariants` for reuse
`lib/services/backend/actions/contact_v2_actions.dart` — use the shared helper
`lib/services/ui/contact_service_v2.dart` — clear the Find My contact index after sync
`lib/models/html/contact_v2.dart` — web stubs for `handles` and `computedDisplayName`

</details>