### PR TITLE
Auto-play send effects with age and recency gating

### DIFF
--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -62,6 +62,10 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
   Timer? _setStateDebouncer;
   StreamSubscription? _eventSubscription;
 
+  // Fires when the app resumes onto this (already open) chat, so a screen effect
+  // that arrived while it was backgrounded gets its chance to play.
+  Worker? _aliveWorker;
+
   // Managers for different responsibilities
   late final SmartRepliesManager smartRepliesManager;
   late final DropZoneManager dropZoneManager;
@@ -96,6 +100,18 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
       // Trigger a rebuild to display the messages.
       setState(() {});
     });
+
+    // Messages that arrive while the app is backgrounded are added to the list
+    // with their screen effect left unplayed (MessagesService refuses to play
+    // into a chat that isn't active). Re-evaluate once the chat is live again.
+    // Bubble effects need no equivalent — they animate on their bubble's first
+    // laid-out frame, which is already deferred until the view is visible.
+    final chatState = ChatsSvc.getChatState(chat.guid);
+    if (chatState != null) {
+      _aliveWorker = ever(chatState.isAlive, (bool alive) {
+        if (alive && mounted && isMessagesServiceInitialized) messageService.playPendingScreenEffect();
+      });
+    }
 
     _eventSubscription = EventDispatcherSvc.stream.listen((e) async {
       if (!mounted) return;
@@ -187,6 +203,12 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
         // Notify SendAnimation that handlers + list key are fully ready so that
         // any pending send fires after the rebuilt SliverAnimatedList is mounted.
         controller.markMessagesViewReady();
+
+        // Play the screen effect on the newest message of the initial page, if
+        // it was sent with one and hasn't been played yet. Only the initial page
+        // is evaluated — paging further back never brings in a newer message, so
+        // scrolling through history can't set this off.
+        messageService.playPendingScreenEffect();
       }
 
       // If this is a search result, load surrounding context and scroll/highlight it
@@ -240,6 +262,7 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
     // Controllers are now disposed by MessagesService.onClose()
     _setStateDebouncer?.cancel();
     _eventSubscription?.cancel();
+    _aliveWorker?.dispose();
     _listVersion.dispose();
     super.dispose();
   }
@@ -476,6 +499,11 @@ class MessagesViewState extends State<MessagesView> with MessagesServiceMixin, T
     Future.delayed(duration, () {
       animationOrchestrator.clearAnimating(message, mounted: mounted);
     });
+
+    // Play this message's screen effect if it has one — waiting out the
+    // insertion animation so the bubble is settled before it fires. Its bubble
+    // effect, if any, plays itself once BubbleEffects builds below.
+    messageService.playPendingScreenEffect(delay: duration + const Duration(milliseconds: 100));
 
     if (insertIndex == 0 && smartRepliesEnabled) {
       smartRepliesManager.addMessageToContext(message);

--- a/lib/app/layouts/conversation_view/widgets/effects/CLAUDE.md
+++ b/lib/app/layouts/conversation_view/widgets/effects/CLAUDE.md
@@ -14,7 +14,21 @@ The animation classes and renderers live in `lib/app/animations/` → `CLAUDE.md
 Effect name ↔ Apple code mapping: `lib/helpers/types/constants.dart` (`effectMap`).
 
 ## Trigger
-Effect playback is triggered from `MessagesView` when an incoming or outgoing message has a non-null `expressiveSendStyleId`.
+`ScreenEffectsWidget` plays whatever arrives on the `play-effect` event (`{'type': <effect name>,
+'size': <bubble Rect>}`). The only emitter is `BubbleEffects` (part 0 of a message), which owns the
+bubble's `GlobalKey` and therefore its rect.
+
+Two things reach it:
+- **Auto-play** — `MessagesService.playPendingScreenEffect()` bumps `MessageState.playScreenEffect`
+  for the newest unplayed screen-effect message when a chat is opened, when a message arrives, or on
+  app resume. Only the newest one, since these cover the whole conversation, and only within
+  `effectMaxAge` (72h) of arrival. (Bubble effects share that age cutoff but not the newest-only
+  rule: every unplayed one plays, handled by `BubbleEffects` itself.)
+- **Manual replay** — tapping "sent with \<effect\>" in `MessageProperties`, which calls
+  `MessageState.triggerEffect()`.
+
+`echo` never reaches this widget (`MessageEffect.isScreen` excludes it): there is no renderer for it,
+and a selection this widget can't clear would block every effect after it.
 
 ## Related
 - Animation renderers: `lib/app/animations/CLAUDE.md`

--- a/lib/app/layouts/conversation_view/widgets/effects/send_effect_picker.dart
+++ b/lib/app/layouts/conversation_view/widgets/effects/send_effect_picker.dart
@@ -385,6 +385,9 @@ void sendEffectAction(
                                             messageState: previewState,
                                             globalKey: key,
                                             part: 0,
+                                            // Unsent stand-in message — animate
+                                            // it, but never persist it as played.
+                                            isPreview: true,
                                               showTail: true,
                                               child: ClipPath(
                                                 clipper: TailClipper(

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -634,7 +634,7 @@ class _MessageHolderState extends State<MessageHolder> with AutomaticKeepAliveCl
                                         ? EdgeInsets.only(left: 35.0 * avatarScale)
                                         : EdgeInsets.zero,
                                     child:
-                                        MessageProperties(globalKey: keys.length > index ? keys[index] : null, part: e),
+                                        MessageProperties(part: e),
                                   ),
                                 ],
                               ),

--- a/lib/app/layouts/conversation_view/widgets/message/misc/CLAUDE.md
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/CLAUDE.md
@@ -45,4 +45,25 @@ Called once per `MessagePart` inside the `messageParts.mapIndexed` loop in `Mess
 
 ## Bubble Effects
 
-`BubbleEffects` plays a one-shot animation overlay on top of the bubble. Triggered when `message.expressiveSendStyleId` is set (e.g., `com.apple.MobileSMS.expressivesend.balloons`). Uses `AnimationController` tied to `initState` — effect plays once and disappears.
+`BubbleEffects` wraps every bubble and owns **both** kinds of send effect for that message:
+
+- **Bubble effects** (slam, loud, gentle) — a one-shot animation on the bubble itself. **This widget
+  owns their auto-play**: an unplayed one that passes `isEffectRecent()` animates on its bubble's
+  first laid-out frame and flags itself via `markEffectPlayed()` when it completes. *Every* unplayed
+  recent one plays, because each is confined to its own bubble. A stale one is skipped and left
+  unflagged — it only gets older, so it keeps failing the check on its own. Replays arrive via
+  `MessageState.playEffectPart` matching this widget's part index.
+- **Screen effects** (balloons, confetti, spotlight, ...) — this widget only *dispatches* them. The
+  part-0 widget listens to `MessageState.playScreenEffect` and emits `play-effect` with the bubble's
+  on-screen rect for `ScreenEffectsWidget` to render. It skips registering inside a
+  `MessageCloneScope` so the popup's clone doesn't fire the effect a second time. *When* one plays is
+  decided by `MessagesService.playPendingScreenEffect()` — they cover the whole conversation, so only
+  the newest unplayed one in a chat ever fires.
+- **Invisible ink** is neither: it's a resting state, so it covers the bubble on first appearance
+  regardless of `hasEffectPlayed` *or* age, and clears when swiped (recorded via `datePlayed`).
+
+`isPreview: true` (send-effect picker only) keeps a throwaway preview bubble animating without
+persisting its stand-in `Message` as played.
+
+Use `effectOf(message)` / `effectNameOf(message)` from `helpers/ui/message_effect_helpers.dart` to
+resolve a message's effect — don't re-derive it from `effectMap` inline.

--- a/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
@@ -3,9 +3,10 @@ import 'dart:ui';
 
 import 'package:bluebubbles/app/state/message_state.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/misc/tail_clipper.dart';
+import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/shared/message_clone_scope.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
-import 'package:collection/collection.dart';
+import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:particles_flutter/engine.dart';
@@ -21,6 +22,7 @@ class BubbleEffects extends StatefulWidget {
     required this.globalKey,
     required this.showTail,
     required this.messageState,
+    this.isPreview = false,
   });
 
   final Widget child;
@@ -28,6 +30,14 @@ class BubbleEffects extends StatefulWidget {
   final GlobalKey? globalKey;
   final bool showTail;
   final MessageState messageState;
+
+  /// Whether this bubble is a throwaway preview (the send-effect picker) rather
+  /// than a real message in a conversation.
+  ///
+  /// A preview still animates, but must never call
+  /// [MessageState.markEffectPlayed] — its `Message` is an unsent stand-in, and
+  /// marking it played would persist it to the database.
+  final bool isPreview;
 
   @override
   State<StatefulWidget> createState() => _BubbleEffectsState();
@@ -37,6 +47,7 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
   late MovieTween tween;
   final rxControl = Rx<Control>(Control.stop);
   late final Worker _effectWorker;
+  Worker? _screenEffectWorker;
 
   /// True while an auto-triggered animation is in-flight. Set to false once
   /// the animation completes and [MessageState.markEffectPlayed] has been
@@ -60,11 +71,11 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
     );
     _fadeAnimation = _fadeController;
 
-    // Auto-play invisible ink on first appearance.
+    // Invisible ink always covers its bubble on first appearance — it is a
+    // resting state rather than a one-shot animation, so it is gated on neither
+    // hasEffectPlayed nor age the way the other effects are.
     final message = widget.messageState.message;
-    final effectStr =
-        effectMap.entries.firstWhereOrNull((e) => e.value == message.expressiveSendStyleId)?.key ?? "unknown";
-    final effect = stringToMessageEffect[effectStr] ?? MessageEffect.none;
+    final effect = effectOf(message);
     if (effect == MessageEffect.invisibleInk) {
       // Set size first, then flip rxControl so the single Obx rebuild
       // that fires has the correct dimensions and BackdropFilter covers
@@ -74,7 +85,12 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
         _fadeController.value = 1.0;
         rxControl.value = Control.play;
       });
-    } else if (effect.isBubble && !widget.messageState.hasEffectPlayed.value) {
+    } else if (effect.isBubble && !widget.messageState.hasEffectPlayed.value && isEffectRecent(message)) {
+      // Bubble effects animate their own bubble, so every unplayed one plays on
+      // its own as it appears — unlike screen effects, which take over the whole
+      // conversation and so are limited to the newest one by
+      // [MessagesService.playPendingScreenEffect]. Both share the same staleness
+      // cutoff; a stale one is left unflagged, since it only gets older.
       _pendingAutoPlay = true;
       _whenSized((s) {
         _size.value = s;
@@ -88,6 +104,25 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
         _fadeController.value = 1.0;
         rxControl.value = Control.playFromStart;
       }
+    });
+
+    // One bubble per message dispatches the full-screen effect — the popup's
+    // clone shares this MessageState, and both firing would emit the event
+    // twice with two different rects.
+    if (widget.part == 0 && !MessageCloneScope.of(context)) {
+      _screenEffectWorker = ever(widget.messageState.playScreenEffect, (_) => _playScreenEffect());
+    }
+  }
+
+  /// Hands the message's full-screen effect to [ScreenEffectsWidget], along with
+  /// the bubble's on-screen rect — spotlight, love and lasers animate around it.
+  void _playScreenEffect() {
+    if (!mounted) return;
+    final message = widget.messageState.message;
+    if (!effectOf(message).isScreen) return;
+    EventDispatcherSvc.emit('play-effect', {
+      'type': effectNameOf(message),
+      'size': widget.globalKey?.globalPaintBounds(context),
     });
   }
 
@@ -116,6 +151,7 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
   @override
   void dispose() {
     _effectWorker.dispose();
+    _screenEffectWorker?.dispose();
     _fadeController.dispose();
     super.dispose();
   }
@@ -180,9 +216,7 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
   @override
   Widget build(BuildContext context) {
     final message = widget.messageState.message;
-    final effectStr =
-        effectMap.entries.firstWhereOrNull((e) => e.value == message.expressiveSendStyleId)?.key ?? "unknown";
-    final effect = stringToMessageEffect[effectStr] ?? MessageEffect.none;
+    final effect = effectOf(message);
     if (message.expressiveSendStyleId == null) return widget.child;
     if (effect == MessageEffect.invisibleInk) {
       return NotificationListener<SizeChangedLayoutNotification>(
@@ -264,7 +298,7 @@ class _BubbleEffectsState extends State<BubbleEffects> with SingleTickerProvider
               rxControl.value = Control.stop;
               if (_pendingAutoPlay) {
                 _pendingAutoPlay = false;
-                widget.messageState.markEffectPlayed();
+                if (!widget.isPreview) widget.messageState.markEffectPlayed();
               }
             }
           },

--- a/lib/app/layouts/conversation_view/widgets/message/misc/message_properties.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/message_properties.dart
@@ -15,11 +15,9 @@ class MessageProperties extends StatefulWidget {
   const MessageProperties({
     super.key,
     required this.part,
-    this.globalKey,
   });
 
   final MessagePart part;
-  final GlobalKey? globalKey;
 
   @override
   State<StatefulWidget> createState() => _MessagePropertiesState();
@@ -43,26 +41,17 @@ class _MessagePropertiesState extends State<MessageProperties> with ThemeHelpers
     final properties = <TextSpan>[];
     final replyList = service.struct.threads(message.guid!, widget.part.part, returnOriginator: false);
     if (message.expressiveSendStyleId != null) {
-      final effect =
-          effectMap.entries.firstWhereOrNull((element) => element.value == message.expressiveSendStyleId)?.key ??
-              "unknown";
+      final effectName = effectNameOf(message) ?? "unknown";
       properties.add(TextSpan(
-          text: "↺ sent with $effect",
+          text: "↺ sent with $effectName",
           recognizer: TapGestureRecognizer()
             ..onTap = () {
-              if (stringToMessageEffect[effect] == MessageEffect.echo) {
+              if (effectOf(message) == MessageEffect.echo) {
                 showSnackbar("Notice", "Echo animation is not supported at this time.");
                 return;
               }
               HapticFeedback.mediumImpact();
-              if ((stringToMessageEffect[effect] ?? MessageEffect.none).isBubble) {
-                MessageStateScope.of(context).triggerBubbleEffect(widget.part.part);
-              } else if (widget.globalKey != null) {
-                EventDispatcherSvc.emit('play-effect', {
-                  'type': effect,
-                  'size': widget.globalKey!.globalPaintBounds(context),
-                });
-              }
+              MessageStateScope.of(context).triggerEffect(part: widget.part.part);
             }));
     }
     if (replyList.isNotEmpty) {

--- a/lib/app/layouts/conversation_view/widgets/message/text/text_bubble.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/text/text_bubble.dart
@@ -3,7 +3,6 @@ import 'package:bluebubbles/app/state/message_state_scope.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:simple_animations/simple_animations.dart';
@@ -29,9 +28,7 @@ class _TextBubbleState extends State<TextBubble> with ThemeHelpers {
 
   MessagePart get part => widget.message;
   Message get message => controller.message;
-  String get effectStr =>
-      effectMap.entries.firstWhereOrNull((e) => e.value == message.expressiveSendStyleId)?.key ?? "unknown";
-  MessageEffect get effect => stringToMessageEffect[effectStr] ?? MessageEffect.none;
+  MessageEffect get effect => effectOf(message);
 
   late MovieTween tween;
   final rxAnim = Rx<Control>(Control.stop);

--- a/lib/app/state/CLAUDE.md
+++ b/lib/app/state/CLAUDE.md
@@ -35,6 +35,14 @@ ObjectBox entities are heavy (lazy-loaded relations, DB context required). Re-qu
 ## MessageState Observable Fields
 Key observables: `guid`, `text`, `dateDelivered`, `dateRead`, `dateEdited`, `error`, `hasReactions`, `associatedMessages`, `isSending`, `isSent`, `hasError`, `isReaction`.
 
+Send effects are driven through three of them — `playEffectPart` (bubble animation, per part),
+`playScreenEffect` (full-screen animation), and `hasEffectPlayed` (persisted "already seen" flag,
+shared by both kinds since a message carries exactly one effect). Call `triggerEffect()` to play
+whichever kind the message carries. *When* that happens differs: `BubbleEffects` auto-plays every
+unplayed bubble effect itself, while `MessagesService.playPendingScreenEffect()` limits screen
+effects to the newest unplayed one. Both skip anything older than `effectMaxAge` (72h); invisible
+ink is exempt from all of it, since it renders until swiped rather than playing once.
+
 Also owns `attachmentStates: Map<String, AttachmentState>` keyed by attachment GUID.
 
 ## AttachmentState Observable Fields

--- a/lib/app/state/message_state.dart
+++ b/lib/app/state/message_state.dart
@@ -4,6 +4,8 @@ import 'package:bluebubbles/app/state/attachment_state.dart';
 import 'package:bluebubbles/app/state/handle_state.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/helpers/types/extensions/extensions.dart';
+import 'package:bluebubbles/helpers/ui/message_effect_helpers.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -79,9 +81,20 @@ class MessageState extends StatefulController {
   /// the animation has been kicked off so it can be retriggered later.
   final RxnInt playEffectPart = RxnInt(null);
 
-  /// Whether the bubble effect for this message has already been auto-played
-  /// once. Prevents the animation from firing again on subsequent renders.
-  /// Manual replay via the replay button always works regardless of this flag.
+  /// Bumped to play this message's full-screen effect (balloons, confetti,
+  /// spotlight, ...).  Deliberately carries no part index: the animation covers
+  /// the whole conversation, and the only per-part input it needs is the
+  /// bubble's on-screen rect.  [BubbleEffects] for part 0 owns that rect (via
+  /// its GlobalKey) and is what turns this into a `play-effect` event.
+  final RxInt playScreenEffect = 0.obs;
+
+  /// Whether this message's send effect has already been played once — the flag
+  /// that stops effects replaying every time the chat is opened.  Persisted, and
+  /// shared by both kinds of effect, which is unambiguous because a message
+  /// carries exactly one: for a bubble effect it is set once that message's own
+  /// animation has run, for a screen effect only on the *newest* such message in
+  /// the chat (see [pendingScreenEffectMessage]).  Manual replay from the message
+  /// properties row always works regardless of this flag.
   final RxBool hasEffectPlayed;
 
   /// Increment to trigger a re-download of all attachments in this message.
@@ -227,10 +240,25 @@ class MessageState extends StatefulController {
     playEffectPart.value = part;
   }
 
-  /// Marks this message's bubble effect as having been played once.
+  /// Plays whatever send effect this message carries, routing to the bubble
+  /// animation or the full-screen animation as appropriate.  Does nothing for a
+  /// message without an effect, or with one this client cannot render (echo).
+  ///
+  /// [part] targets a specific part's bubble — pass it when replaying from a
+  /// tapped part.  It defaults to the last part, which is where the effect label
+  /// sits for the common attachment-then-text message.  Screen effects ignore it.
+  void triggerEffect({int? part}) {
+    final effect = effectOf(message);
+    if (effect.isScreen) {
+      playScreenEffect.value++;
+    } else if (effect.isBubble) {
+      triggerBubbleEffect(part ?? parts.lastOrNull?.part ?? 0);
+    }
+  }
+
+  /// Marks this message's send effect as having been played once.
   /// Persists the flag to the database so it survives app restarts.
-  /// Only called after an auto-triggered animation completes — manual
-  /// replays do not call this.
+  /// Only called for auto-played effects — manual replays do not call this.
   void markEffectPlayed() {
     if (hasEffectPlayed.value) return;
     hasEffectPlayed.value = true;

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -898,6 +898,14 @@ class Message {
       existing.hasReactions = newMessage.hasReactions;
     }
 
+    // Send effects only ever play once, so the flag is sticky from either side.
+    // Without this, a temp -> real GUID swap (merge is called with the server's
+    // record as `existing`) would clear the flag on a message whose effect just
+    // played, and it would play again the next time the chat was opened.
+    if (newMessage.hasEffectPlayed) {
+      existing.hasEffectPlayed = true;
+    }
+
     // Update chat
     if (!existing.chat.hasValue && newMessage.chat.hasValue) {
       existing.chat.target = newMessage.chat.target;

--- a/lib/helpers/CLAUDE.md
+++ b/lib/helpers/CLAUDE.md
@@ -6,6 +6,7 @@ Import via barrel: `package:bluebubbles/helpers/helpers.dart` (re-exports most f
 - `ui_helpers.dart` — general UI utilities (back button, safe area, etc.)
 - `theme_helpers.dart` — `ThemeHelpers` mixin; mixed into `CustomState`; provides `iOS`, `material`, `samsung` skin booleans
 - `message_widget_helpers.dart` — message-specific UI utilities
+- `message_effect_helpers.dart` — send effect resolution + which effect in a chat should auto-play
 - `reaction_helpers.dart` — tapback emoji display helpers
 - `dialog_helpers.dart` — shared dialog builders
 - `findmy_helpers.dart` — Find My UI helpers

--- a/lib/helpers/helpers.dart
+++ b/lib/helpers/helpers.dart
@@ -12,6 +12,7 @@ export 'types/helpers/misc_helpers.dart';
 export 'types/helpers/string_helpers.dart';
 export 'types/constants.dart';
 export 'ui/async_task.dart';
+export 'ui/message_effect_helpers.dart';
 export 'ui/message_widget_helpers.dart';
 export 'ui/oauth_helpers.dart';
 export 'ui/reaction_helpers.dart';

--- a/lib/helpers/types/extensions/extensions.dart
+++ b/lib/helpers/types/extensions/extensions.dart
@@ -105,6 +105,14 @@ extension EffectHelper on MessageEffect {
       this == MessageEffect.loud ||
       this == MessageEffect.gentle ||
       this == MessageEffect.invisibleInk;
+
+  /// Effects that animate over the whole conversation rather than the bubble.
+  ///
+  /// [MessageEffect.echo] is deliberately excluded even though it is one of
+  /// Apple's screen effects: it has no renderer here, and handing it to
+  /// `ScreenEffectsWidget` would leave that widget holding a selection it never
+  /// clears — blocking every effect that comes after it.
+  bool get isScreen => this != MessageEffect.none && this != MessageEffect.echo && !isBubble;
 }
 
 /// Used when playing iMessage effects

--- a/lib/helpers/ui/CLAUDE.md
+++ b/lib/helpers/ui/CLAUDE.md
@@ -9,6 +9,7 @@ Pure helper functions and small utility classes for the UI layer. No service dep
 | `ui_helpers.dart` | General widget utilities; custom back button with gesture support |
 | `theme_helpers.dart` | `HexColor` (hex string → `Color`), `BubbleColors` theme extension, desktop window effects (Mica/acrylic) |
 | `message_widget_helpers.dart` | `buildMessageSpans()` — rich text rendering with emoji scaling, mention detection, and styled spans for message bubbles |
+| `message_effect_helpers.dart` | `effectOf()` / `effectNameOf()` — resolve a message's send effect; `newestScreenEffectMessage()` / `pendingScreenEffectMessage()` — pick the one screen effect in a chat that should auto-play |
 | `attributed_body_helpers.dart` | Extracts audio transcripts from `AttributedBody` rich text; parses `Run` objects by part number |
 | `reaction_helpers.dart` | `ReactionTypes` — string constants for iMessage tapbacks (`love`, `like`, `dislike`, `laugh`, `emphasize`, `question`) and their verb forms |
 | `facetime_helpers.dart` | `showFaceTimeOverlay()` / `hideFaceTimeOverlay()` — incoming FaceTime call UI overlay |
@@ -26,6 +27,15 @@ Pure helper functions and small utility classes for the UI layer. No service dep
 **Bubble colors** — `BubbleColors` is a `ThemeExtension`; access via `Theme.of(context).extension<BubbleColors>()`. Don't hardcode bubble colors.
 
 **Hex colors** — `HexColor("#RRGGBB")` or `HexColor("#AARRGGBB")` converts hex strings to Flutter `Color` objects.
+
+**Send effects** — resolve a message's effect with `effectOf(message)` rather than looking its
+`expressiveSendStyleId` up in `effectMap` inline. `MessageEffect.isBubble` / `.isScreen` split the
+two kinds, which auto-play under different rules: every unplayed bubble effect plays (handled by
+`BubbleEffects`), but only the newest unplayed screen effect does. Both are gated on
+`isEffectRecent()` (`effectMaxAge`, 72h) so a stale effect never ambushes the user;
+`pendingScreenEffectMessage()` is the pure selection rule for screen effects, applied by
+`MessagesService.playPendingScreenEffect()`. Invisible ink is exempt from all of it — it's a resting
+state, not a one-shot animation.
 
 **Reaction type constants** — use `ReactionTypes.LOVE`, `ReactionTypes.LIKE`, etc. instead of raw strings. The verb map (`reactionToVerb`) maps type → "loved", "liked", etc. for display.
 

--- a/lib/helpers/ui/message_effect_helpers.dart
+++ b/lib/helpers/ui/message_effect_helpers.dart
@@ -1,0 +1,89 @@
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/helpers/types/constants.dart';
+import 'package:bluebubbles/helpers/types/extensions/extensions.dart';
+import 'package:collection/collection.dart';
+
+/// The iMessage effect name (as keyed in [effectMap]) a message was sent with,
+/// or `null` when it carries no expressive send style.
+String? effectNameOf(Message message) {
+  if (message.expressiveSendStyleId == null) return null;
+  return effectMap.entries.firstWhereOrNull((e) => e.value == message.expressiveSendStyleId)?.key;
+}
+
+/// The [MessageEffect] a message was sent with.
+///
+/// Returns [MessageEffect.none] when the message carries no expressive send
+/// style, or one this client doesn't recognise.
+MessageEffect effectOf(Message message) => stringToMessageEffect[effectNameOf(message)] ?? MessageEffect.none;
+
+/// The newest message in [messages] that was sent with a **screen** effect,
+/// regardless of whether that effect has already been played.
+///
+/// Bubble effects are deliberately not considered here: they animate their own
+/// bubble, so every unplayed one plays independently (see `BubbleEffects`).
+/// Screen effects take over the whole conversation, so only one can meaningfully
+/// play at a time.
+///
+/// [messages] may be in any order — it is scanned rather than assumed sorted,
+/// so it is safe to pass a chat's loaded messages straight from `ChatMessages`.
+Message? newestScreenEffectMessage(Iterable<Message> messages) {
+  Message? newest;
+  for (final message in messages) {
+    // Message.sort dereferences dateCreated, which an in-flight send may not
+    // have set yet.
+    if (message.dateCreated == null || !effectOf(message).isScreen) continue;
+    if (newest == null || Message.sort(message, newest) < 0) newest = message;
+  }
+  return newest;
+}
+
+/// How recently a message must have arrived for its send effect to still be
+/// worth playing.
+///
+/// An effect is a "look what just came in" flourish. Firing one off for a
+/// message the sender sent last week isn't a celebration, it's a jump scare. It
+/// also bounds the first launch after this auto-play behaviour ships, when a
+/// backlog of historical effects is sitting unflagged in every chat.
+const effectMaxAge = Duration(hours: 72);
+
+/// Whether [message] arrived recently enough for its send effect to auto-play.
+///
+/// Invisible ink is exempt, and is filtered out by the caller rather than here:
+/// it is a resting state that hides its bubble until swiped, not a one-shot
+/// animation, so it renders at any age.
+bool isEffectRecent(Message message, {Duration maxAge = effectMaxAge}) {
+  final created = message.dateCreated;
+  // Nothing to judge by (an in-flight send) — don't suppress.
+  if (created == null) return true;
+
+  // Some Macs report an incorrect dateCreated (see Message.sort, which takes the
+  // *earlier* of created/delivered to keep ordering stable). This is a
+  // suppression gate rather than an ordering, so it wants the opposite: take the
+  // latest timestamp available, so a wrong-but-old dateCreated on a message that
+  // was just delivered still counts as having arrived now.
+  final delivered = message.dateDelivered;
+  final arrived = (delivered != null && delivered.isAfter(created)) ? delivered : created;
+
+  return DateTime.now().difference(arrived.toLocal()) <= maxAge;
+}
+
+/// The one message whose screen effect should auto-play for [messages], or
+/// `null` when there is nothing to play.
+///
+/// Only the *newest* screen-effect message is ever a candidate, and it is the
+/// only one that ever gets flagged as played. That single flag is what stops the
+/// whole chat's history from replaying: an older screen effect can never become
+/// the newest one again, so a chat whose newest one has been played stays quiet
+/// no matter how many unplayed ones sit behind it. It also means a message that
+/// arrives while the chat is closed (or backgrounded) still plays the next time
+/// the chat is opened or resumed, because nothing marked it played — as long as
+/// that is within [maxAge].
+Message? pendingScreenEffectMessage(Iterable<Message> messages, {Duration maxAge = effectMaxAge}) {
+  final newest = newestScreenEffectMessage(messages);
+  if (newest == null || newest.hasEffectPlayed) return null;
+  // Stale. Deliberately not flagged played: it only gets older, so it will keep
+  // failing this check on its own, and leaving the flag alone keeps it meaning
+  // "was played" rather than "was considered".
+  if (!isEffectRecent(newest, maxAge: maxAge)) return null;
+  return newest;
+}

--- a/lib/services/ui/message/CLAUDE.md
+++ b/lib/services/ui/message/CLAUDE.md
@@ -26,6 +26,8 @@ One instance per chat GUID. Accessed via `MessagesSvc(chatGuid)`.
 - `getOrCreateMessageState(String guid)` → `MessageState` — same but keyed by GUID
 - `getMessageStateIfExists(String guid)` → `MessageState?` — non-creating lookup
 
+- `playPendingScreenEffect({delay})` — auto-plays the chat's newest screen effect if it hasn't been played
+
 **Convenience getters:**
 - `mostRecentSent` — the most recently sent outgoing message
 - `mostRecent` — the most recent message in the thread
@@ -35,5 +37,40 @@ One instance per chat GUID. Accessed via `MessagesSvc(chatGuid)`.
 - Never write `MessageState` fields directly from UI — always go through `MessagesService.updateMessage()`
 - Widgets should observe `messageUpdateTrigger[guid]` in an `Obx()` to know when to re-query state
 - For bulk initial load, use `addMessages()` which skips per-field update overhead
+
+## Send Effect Auto-Play
+
+The two kinds of send effect have deliberately different auto-play policies, but share one
+persisted flag (`Message.hasEffectPlayed`) — a message carries exactly one effect, so there is
+never a row where both meanings apply — and one staleness cutoff, `effectMaxAge` (72h).
+
+| | Bubble effects (slam, loud, gentle) | Screen effects (balloons, confetti, spotlight, ...) |
+|---|---|---|
+| What plays | Every unplayed one | Only the newest one |
+| Age cutoff | `effectMaxAge` | `effectMaxAge` |
+| Who decides | `BubbleEffects.initState` per bubble | `MessagesService.playPendingScreenEffect()` |
+| Flagged played | Each message, when its animation completes | Only the newest screen-effect message |
+
+**Invisible ink is neither** — it's a resting state that hides its bubble until swiped, not a
+one-shot animation, so it renders on every appearance regardless of age or `hasEffectPlayed`.
+
+Bubble effects need no coordination: each animates its own bubble, so it plays when its message
+appears and flags itself. Screen effects animate over the whole conversation, so only one can
+meaningfully play — `playPendingScreenEffect()` is called from `MessagesView` on the chat's initial
+load, on a message arriving in the open chat, and on the app resuming onto an already-open chat, and
+behaves the same way for all three:
+
+1. Take the **newest** screen-effect message in the chat (`pendingScreenEffectMessage`, in
+   `helpers/ui/message_effect_helpers.dart`). Older ones are never candidates.
+2. If it has already been played, or is older than `effectMaxAge` (72h), do nothing.
+3. Otherwise wait out `delay` (so the bubble is laid out — spotlight/love/lasers need its rect),
+   play it via `MessageState.triggerEffect()`, and flag it played.
+
+Only that newest message ever gets flagged, and that is deliberate: it acts as a high-water mark, so
+a chat full of never-played historical screen effects stays quiet, while one that arrived while the
+chat was closed or backgrounded still plays on the next open or resume. Playback is skipped — and
+crucially *not* flagged — in two cases: while `ChatsSvc.isChatActive(chat.guid)` is false (which is
+what defers a backgrounded chat's screen effect to resume), and when the message is too old (which
+needs no flag, since it only gets older).
 
 **For the full update flow**, see `docs/MESSAGE_RECEIVE_FLOW.md`.

--- a/lib/services/ui/message/messages_service.dart
+++ b/lib/services/ui/message/messages_service.dart
@@ -5,6 +5,7 @@ import 'package:bluebubbles/app/state/attachment_state.dart';
 import 'package:bluebubbles/app/state/message_state.dart';
 import 'package:bluebubbles/helpers/types/extensions/extensions.dart';
 import 'package:bluebubbles/helpers/types/constants.dart';
+import 'package:bluebubbles/helpers/ui/message_effect_helpers.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/services/backend/interfaces/sync_interface.dart';
@@ -105,6 +106,63 @@ class MessagesService extends GetxController {
 
   Message? get mostRecentReceived =>
       (struct.messages.where((e) => !e.isFromMe!).toList()..sort(Message.sort)).firstOrNull;
+
+  // ========== Screen Effect Auto-Play ==========
+
+  /// The [MessageState] whose screen effect is waiting out [_effectTimer].
+  MessageState? _scheduledEffectState;
+  Timer? _effectTimer;
+
+  /// Plays the screen effect (balloons, confetti, spotlight, ...) of the newest
+  /// message in this chat carrying one, unless it has already been played.
+  ///
+  /// Only screen effects are centralized here, because they animate over the
+  /// whole conversation and only one can meaningfully play at a time. Bubble
+  /// effects are per-bubble, so `BubbleEffects` plays each unplayed one itself as
+  /// its message appears — no coordination needed.
+  ///
+  /// Called whenever the loaded messages might have gained a screen effect the
+  /// user hasn't seen: when a chat is first opened, when a message arrives in the
+  /// open chat, and when the app resumes onto a chat that was already open. Which
+  /// of those it is doesn't change the decision — only the newest screen-effect
+  /// message is ever a candidate, it has to have arrived within
+  /// [effectMaxAge], and it has to be unplayed. So paging back through
+  /// history can't resurrect an old one, re-opening a chat whose newest one
+  /// already played stays quiet, and a chat left unopened for days doesn't
+  /// ambush the user on the way back in. See [pendingScreenEffectMessage].
+  ///
+  /// [delay] gives the bubble time to be laid out first: spotlight, love and
+  /// lasers animate around its on-screen rect, and a bubble that is still sliding
+  /// into the list would give them the wrong one.
+  void playPendingScreenEffect({Duration delay = const Duration(seconds: 1)}) {
+    if (!_init) return;
+
+    final message = pendingScreenEffectMessage(struct.messages);
+    if (message?.guid == null) return;
+
+    final state = messageStates[message!.guid!];
+    if (state == null || state.hasEffectPlayed.value) return;
+    // Already queued from an earlier call — don't restart its delay.
+    if (identical(state, _scheduledEffectState)) return;
+    // Backgrounded, or the user is looking at another chat. Leave it unplayed so
+    // it fires when they come back.
+    if (!ChatsSvc.isChatActive(chat.guid)) return;
+
+    _scheduledEffectState = state;
+    _effectTimer?.cancel();
+    _effectTimer = Timer(delay, () {
+      _scheduledEffectState = null;
+      if (state.hasEffectPlayed.value) return;
+      // The chat may have been closed or backgrounded during the delay.
+      if (!ChatsSvc.isChatActive(chat.guid)) return;
+      Logger.debug("Auto-playing ${effectNameOf(state.message)} screen effect for message ${state.guid.value}",
+          tag: "MessageEffects");
+      state.triggerEffect();
+      state.markEffectPlayed();
+    });
+  }
+
+  // ========== End Screen Effect Auto-Play ==========
 
   // ========== MessageState Management ==========
 
@@ -715,6 +773,8 @@ class MessagesService extends GetxController {
 
   @override
   void onClose() {
+    _effectTimer?.cancel();
+    _scheduledEffectState = null;
     if (_init) {
       _webMessageSub?.cancel();
       _redactedModeListener?.cancel();
@@ -736,6 +796,8 @@ class MessagesService extends GetxController {
       Get.delete<MessagesService>(tag: tag, force: true);
     }
 
+    _effectTimer?.cancel();
+    _scheduledEffectState = null;
     struct.flush();
     messagesLoaded = false;
     messageUpdateTrigger.clear();


### PR DESCRIPTION
## Summary
Implements intelligent auto-play for iMessage send effects (balloons, confetti, spotlight, etc.) with separate policies for bubble vs. screen effects, age-based staleness filtering, and proper handling of backgrounded chats.

## Key Changes

**New helper module** (`message_effect_helpers.dart`):
- `effectOf()` / `effectNameOf()` — resolve a message's send effect type
- `newestScreenEffectMessage()` — find the newest screen-effect message in a chat
- `pendingScreenEffectMessage()` — determine which screen effect should auto-play
- `isEffectRecent()` — gate effects older than 72 hours from auto-playing
- `effectMaxAge` constant (72h) — shared staleness cutoff for both effect types

**Screen effect auto-play** (`MessagesService`):
- `playPendingScreenEffect()` — centralized auto-play for screen effects only
- Queues with configurable delay so bubbles are laid out before spotlight/love/lasers animate around them
- Skips play if chat is backgrounded (`ChatsSvc.isChatActive()`) — defers to app resume
- Only the *newest* screen-effect message ever plays (acts as high-water mark)
- Triggered on: chat open, message arrival in open chat, app resume onto open chat

**Bubble effect auto-play** (unchanged ownership, improved gating):
- `BubbleEffects` continues to own bubble-effect auto-play (slam, loud, gentle)
- Now gates on `isEffectRecent()` — stale ones skip without flagging
- Every unplayed recent one plays (no newest-only rule, since each animates its own bubble)

**Unified effect triggering** (`MessageState`):
- New `triggerEffect()` method routes to bubble or screen animation as appropriate
- `playScreenEffect` observable — bumped to trigger full-screen animation
- `playEffectPart` remains for bubble-specific replays

**Message merge safety** (`Message.merge()`):
- Preserves `hasEffectPlayed` flag across temp→real GUID swaps
- Prevents effects from replaying after send completes

**UI integration**:
- `MessagesView` calls `playPendingScreenEffect()` on initial load and message arrival
- Listens to `ChatState.isAlive` to re-evaluate when app resumes onto backgrounded chat
- `MessageProperties` simplified to use `triggerEffect()` instead of inline routing
- `BubbleEffects` dispatches screen effects via `play-effect` event with bubble rect

**Effect type classification** (`MessageEffect` extension):
- New `isScreen` getter — excludes `echo` (no renderer) and bubble effects
- Complements existing `isBubble` getter

## Notable Details

- **Invisible ink exempt**: Not a one-shot animation, so it renders on every appearance regardless of age or `hasEffectPlayed`
- **Single flag, two meanings**: `Message.hasEffectPlayed` is shared because a message carries exactly one effect; for bubbles it's set per-message, for screens only on the newest one
- **Stale effects left unflagged**: Deliberately not marked played, so they keep failing the age check on their own rather than requiring explicit suppression
- **Preview safety**: `BubbleEffects` with `isPreview: true` (send-effect picker) animates without persisting its stand-in message
- **Part-0 ownership**: Only the part-0 bubble dispatches screen effects, preventing duplicate emissions from multi-part messages

https://claude.ai/code/session_01BtmCBaEu61s3UMhyrZrNYL