### PR TITLE
fix: stop connectivity listener churn and settings back-button crash on desktop

### DIFF
--- a/lib/app/layouts/settings/settings_page.dart
+++ b/lib/app/layouts/settings/settings_page.dart
@@ -76,6 +76,15 @@ class _SettingsPageState extends State<SettingsPage> with ThemeHelpers {
   }
 
   @override
+  void dispose() {
+    // Nothing is selected once the page is gone. The pane observer only fires when
+    // the right pane pops back to its placeholder, which doesn't happen when the
+    // whole settings page is closed with a sub-page still open.
+    NavigationSvc.activeSettingsPage.value = null;
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     if (!showAltLayout && NavigationSvc.activeSettingsPage.value != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) => NavigationSvc.activeSettingsPage.value = null);
@@ -235,15 +244,16 @@ class _SettingsPageState extends State<SettingsPage> with ThemeHelpers {
                     NavigationSvc.maxWidthSettings = constraints.maxWidth;
                     return PopScope(
                       canPop: false,
-                      onPopInvokedWithResult: <T>(bool _, T? _) async {
-                        Get.until((route) {
-                          if (route.settings.name == "initial") {
-                            Get.back();
-                          } else {
-                            Get.back(id: 3);
-                          }
-                          return true;
-                        }, id: 3);
+                      // `canPop: false` only intercepts back gestures and system back —
+                      // an imperative Navigator.pop() (the list pane's back button, or
+                      // anything closing settings outright) still pops this route and
+                      // then reports it here with didPop == true. Stepping the settings
+                      // navigator again at that point pops a second, unrelated route and
+                      // reaches for a nested navigator that is already on its way out,
+                      // which threw GetX's "contextless navigation" error.
+                      onPopInvokedWithResult: <T>(bool didPop, T? _) {
+                        if (didPop) return;
+                        NavigationSvc.backSettingsPane(context);
                       },
                       child: Navigator(
                         key: Get.nestedKey(3),

--- a/lib/services/network/socket_service.dart
+++ b/lib/services/network/socket_service.dart
@@ -168,9 +168,26 @@ class SocketService {
     Logger.debug("Initialized socket service");
   }
 
+  /// Attaches the process-lifetime listener on [Connectivity.onConnectivityChanged].
+  ///
+  /// Idempotent on purpose, and deliberately never torn down. `connectivity_plus`
+  /// backs that stream with a broadcast controller whose `onListen`/`onCancel`
+  /// start and stop a platform watcher, so re-subscribing churns that watcher —
+  /// and the Linux implementation cannot survive the churn: its `onListen` nulls
+  /// out its NetworkManager client from `onCancel` while still suspended on
+  /// `client.connect()`, then dereferences it with `!` on resume. That throws
+  /// "Null check operator used on a null value" from inside the plugin's own
+  /// unawaited future, where no `onError` of ours can catch it — it only ever
+  /// surfaces as an unhandled zone exception.
+  ///
+  /// Every caller here used to cancel and re-listen (init() right after
+  /// startSocket(), and startSocket() right after closeSocket()), which hit that
+  /// race on every launch and every socket restart. There is nothing to re-arm:
+  /// the callback below is stateless with respect to the socket, and already
+  /// no-ops while a reconnect is unwanted via [_shouldReconnectOnNetworkChange].
   void _startConnectivitySubscription() {
     if (kIsDesktop && Platform.isWindows) return;
-    _connectivitySubscription?.cancel();
+    if (_connectivitySubscription != null) return;
     _connectivitySubscription = Connectivity().onConnectivityChanged.listen((event) {
       if (!event.contains(ConnectivityResult.wifi) &&
           !event.contains(ConnectivityResult.ethernet) &&
@@ -324,9 +341,9 @@ class SocketService {
       s.on("new-findmy-location", (data) => EventDispatcherSvc.emit('new-findmy-location', data)),
     ]);
 
-    // Re-arm connectivity monitoring — closeSocket()/disconnect() tear it down, and
-    // without this it would stay dead for the rest of the process after the first
-    // restart, silently stranding the localhost origin override on a cellular switch.
+    // Arm connectivity monitoring. init() covers the case where this method bails
+    // out above on an unconfigured server, so by the time a server exists the
+    // listener is usually already attached — the call is idempotent and cheap.
     _startConnectivitySubscription();
 
     // Report the attempt before making it. closeSocket() leaves the state at
@@ -392,8 +409,9 @@ class SocketService {
     _connectivityReconnectTimer?.cancel();
     _connectivityReconnectTimer = null;
     socket?.disconnect();
-    _connectivitySubscription?.cancel();
-    _connectivitySubscription = null;
+    // The connectivity listener stays attached — see [_startConnectivitySubscription].
+    // It cannot resurrect the socket on its own: _shouldReconnectOnNetworkChange
+    // reads connectionDesired, which was just cleared above.
     state.value = SocketState.disconnected;
   }
 
@@ -424,8 +442,7 @@ class SocketService {
     _connectivityReconnectTimer = null;
     internetConnectionListener?.cancel();
     internetConnectionListener = null;
-    _connectivitySubscription?.cancel();
-    _connectivitySubscription = null;
+    // The connectivity listener stays attached — see [_startConnectivitySubscription].
     _clearEventHandlers();
     socket?.dispose();
     // Drop the reference too: the FCM handler reads `socket?.connected` to decide

--- a/lib/services/ui/navigator/navigator_service.dart
+++ b/lib/services/ui/navigator/navigator_service.dart
@@ -46,6 +46,16 @@ class NavigatorService {
       SettingsSvc.settings.tabletMode.value &&
       context.width > 600;
 
+  /// Whether the settings split view's right-hand navigator is live and safe to drive.
+  ///
+  /// `Get.keys.containsKey(3)` alone is not enough: GetX never removes a nested key
+  /// once registered, so it keeps reading true after the settings page is gone. Any
+  /// `id: 3` call made on that stale key throws GetX's "contextless navigation
+  /// without a GetMaterialApp" error from `Get.global()`, which is what the split
+  /// view's own back handling used to do while the page was on its way out.
+  bool hasSettingsNavigator(BuildContext context) =>
+      Get.keys[3]?.currentContext != null && isTabletMode(context);
+
   /// grab the available screen width, returning the split screen width if applicable
   /// this should *always* be used in place of context.width or similar
   double width(BuildContext context) {
@@ -88,7 +98,7 @@ class NavigatorService {
 
   /// Push a new route onto the settings navigator
   Future<dynamic> pushSettings(BuildContext context, Widget widget, {Bindings? binding}) async {
-    if (Get.keys.containsKey(3) && isTabletMode(context)) {
+    if (hasSettingsNavigator(context)) {
       return await Get.to(() => widget, transition: Transition.rightToLeft, id: 3, binding: binding);
     } else {
       binding?.dependencies();
@@ -128,7 +138,7 @@ class NavigatorService {
   /// Push a new route, popping all previous routes, on the settings navigator
   void pushAndRemoveSettingsUntil(BuildContext context, Widget widget, bool Function(Route) predicate,
       {Bindings? binding}) {
-    if (Get.keys.containsKey(3) && isTabletMode(context)) {
+    if (hasSettingsNavigator(context)) {
       activeSettingsPage.value = widget.runtimeType;
       // we only want to offUntil when in landscape, otherwise when the user presses back, the previous page will be the chat list
       Get.offUntil(
@@ -149,16 +159,28 @@ class NavigatorService {
     }
   }
 
+  /// Steps back one level inside the settings split view.
+  ///
+  /// From a settings sub-page this pops the right pane back towards its placeholder;
+  /// from the placeholder itself ("initial") there is nothing left to pop, so the
+  /// whole settings page comes off the outer navigator instead.
+  ///
+  /// No-ops when the right-hand navigator isn't live — see [hasSettingsNavigator].
+  void backSettingsPane(BuildContext context) {
+    if (!hasSettingsNavigator(context)) return;
+    Get.until((route) {
+      if (route.settings.name == "initial") {
+        Get.back();
+      } else {
+        Get.back(id: 3);
+      }
+      return true;
+    }, id: 3);
+  }
+
   void backConversationView(BuildContext context) {
-    if (Get.keys.containsKey(3) && Get.keys[3]?.currentContext != null && isTabletMode(context)) {
-      Get.until((route) {
-        if (route.settings.name == "initial") {
-          Get.back();
-        } else {
-          Get.back(id: 3);
-        }
-        return true;
-      }, id: 3);
+    if (hasSettingsNavigator(context)) {
+      backSettingsPane(context);
     } else if (Get.keys.containsKey(2) && Get.keys[2]?.currentContext != null && isTabletMode(context)) {
       if (Get.currentRoute.isEmpty) {
         Get.back();
@@ -190,7 +212,7 @@ class NavigatorService {
   }
 
   void closeSettings(BuildContext context) {
-    if (Get.keys.containsKey(3) && Get.keys[3]?.currentContext != null && isTabletMode(context)) {
+    if (hasSettingsNavigator(context)) {
       Get.until((route) => route.isFirst, id: 3);
       Get.back(closeOverlays: true);
     } else {
@@ -208,7 +230,7 @@ class NavigatorService {
   }
 
   void backSettings(BuildContext context, {dynamic result, bool closeOverlays = false}) {
-    if (Get.keys.containsKey(3) && isTabletMode(context)) {
+    if (hasSettingsNavigator(context)) {
       Get.back(result: result, closeOverlays: closeOverlays, id: 3);
     } else {
       Get.back(result: result, closeOverlays: closeOverlays);


### PR DESCRIPTION
Two unrelated unhandled exceptions from a Linux desktop log.

Connectivity: the socket service cancelled and re-listened on
Connectivity().onConnectivityChanged on every launch and every socket
restart (init() right after startSocket(), startSocket() right after
closeSocket()). That toggles connectivity_plus' broadcast controller
between onListen and onCancel, and its Linux implementation cannot
survive it — onListen suspends on NetworkManagerClient.connect() while
onCancel nulls the client out from under it, then dereferences it with
`!` on resume. The throw happens inside the plugin's own unawaited
future, so no onError of ours can catch it; it only ever surfaces as an
unhandled zone exception. Attach the listener once for the process
lifetime instead: it is stateless with respect to the socket, and the
reconnect it schedules already no-ops via _shouldReconnectOnNetworkChange.

Settings navigation: the split view's PopScope ran its pane-back logic
unconditionally, including when didPop was true. `canPop: false` only
intercepts back gestures and system back, so an imperative
Navigator.pop() from the list pane's back button still popped the route
and then reported it — at which point the handler popped a second,
unrelated route and drove a nested navigator on its way out, throwing
GetX's "contextless navigation without a GetMaterialApp" error. Bail on
didPop, and route the remaining case through a new
NavigatorService.backSettingsPane() guarded by hasSettingsNavigator().

That guard replaces the Get.keys.containsKey(3) checks throughout
NavigatorService. GetX never removes a nested key once registered, so
containsKey keeps reading true after the settings page is gone and every
id: 3 call behind it could throw the same way; requiring a live
currentContext falls back to the outer navigator instead. Also clear
activeSettingsPage on dispose, since the pane observer no longer fires
when settings closes with a sub-page open.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RN7cGwmY1UXJ4iZhDME19P