### PR TITLE
feat: restore previous chat filters when toggling off the other chats chip

### DIFF
--- a/lib/app/layouts/conversation_list/widgets/filters/custom_group_filter_chip_row.dart
+++ b/lib/app/layouts/conversation_list/widgets/filters/custom_group_filter_chip_row.dart
@@ -122,13 +122,10 @@ class CustomGroupFilterChipRow extends StatelessWidget {
                         key: const ValueKey('ungrouped-chip'),
                         selected: filters.showUngroupedOnly,
                         unreadCount: ungroupedUnreadCount,
-                        onPressed: () {
-                          final f = ChatsSvc.chatListFilters.value;
-                          ChatsSvc.chatListFilters.value = f.copyWith(
-                            customGroupIds: <int>{},
-                            showUngroupedOnly: !f.showUngroupedOnly,
-                          );
-                        },
+                        // Toggling goes through the service so the filters
+                        // active before the chip was tapped are stashed and
+                        // restored when it's tapped again.
+                        onPressed: ChatsSvc.toggleUngroupedOnly,
                       ),
               ),
             ),

--- a/lib/services/ui/chat/chats_service.dart
+++ b/lib/services/ui/chat/chats_service.dart
@@ -72,6 +72,17 @@ class ChatsService {
   /// sheet — see [saveChatListFiltersAsDefault].
   final Rx<ChatListFilters> chatListFilters = const ChatListFilters().obs;
 
+  /// Filter selection captured the last time the "other chats" (ungrouped) chip
+  /// was activated via [toggleUngroupedOnly], restored when it's toggled back
+  /// off. Session-only — never persisted, and dropped once used.
+  ChatListFilters? _filtersBeforeUngroupedOnly;
+
+  /// The exact filter value [toggleUngroupedOnly] wrote when it activated the
+  /// ungrouped chip. If the current selection no longer matches it, the user
+  /// changed filters some other way in the meantime, so the snapshot above is
+  /// discarded instead of clobbering that newer selection.
+  ChatListFilters? _ungroupedOnlyApplied;
+
   /// Timer for debouncing chatListVersion updates to prevent rapid UI rebuilds
   Timer? _listVersionUpdateTimer;
 
@@ -477,6 +488,41 @@ class ChatsService {
     final pruned = current.customGroupIds.intersection(validIds);
     if (pruned.length != current.customGroupIds.length) {
       chatListFilters.value = current.copyWith(customGroupIds: pruned);
+    }
+    // The stash held for the ungrouped chip isn't in `chatListFilters` yet, so
+    // prune it separately — otherwise toggling the chip back off could restore
+    // a group that has since been deleted.
+    final stash = _filtersBeforeUngroupedOnly;
+    if (stash != null) {
+      final prunedStash = stash.customGroupIds.intersection(validIds);
+      if (prunedStash.length != stash.customGroupIds.length) {
+        _filtersBeforeUngroupedOnly = stash.copyWith(customGroupIds: prunedStash);
+      }
+    }
+  }
+
+  /// Toggles the "other chats" (ungrouped) filter used by the custom group
+  /// chip row.
+  ///
+  /// Turning it on stashes whatever was selected beforehand (typically one or
+  /// more custom groups) and replaces it with the ungrouped-only selection;
+  /// turning it back off restores that stash, so a quick peek at ungrouped
+  /// chats doesn't cost the user their previous filter. The stash is only
+  /// honored if the filters still match what was applied on activation — any
+  /// change made elsewhere (the filter sheet, another chip, "Clear Filters")
+  /// wins, and toggling off then just drops the ungrouped flag.
+  void toggleUngroupedOnly() {
+    final current = chatListFilters.value;
+    if (current.showUngroupedOnly) {
+      final restore = current == _ungroupedOnlyApplied ? _filtersBeforeUngroupedOnly : null;
+      _filtersBeforeUngroupedOnly = null;
+      _ungroupedOnlyApplied = null;
+      chatListFilters.value = restore ?? current.copyWith(showUngroupedOnly: false);
+    } else {
+      _filtersBeforeUngroupedOnly = current;
+      final applied = current.copyWith(customGroupIds: <int>{}, showUngroupedOnly: true);
+      _ungroupedOnlyApplied = applied;
+      chatListFilters.value = applied;
     }
   }
 


### PR DESCRIPTION
Tapping the "other chats" (ungrouped) chip now stashes the filter selection
that was active beforehand and restores it when the chip is tapped again, so
peeking at chats outside every custom group no longer loses the previous
group selection.

The stash lives in ChatsService for the session only and is honored just once
per activation, and only while the filters still match what activating the
chip applied — a change made through the filter sheet, another group chip, or
"Clear Filters" wins, and toggling the chip off then only drops the ungrouped
flag. Stale custom group ids are pruned out of the stash alongside the live
filter so a deleted group can't come back on restore.