### PR TITLE
feat: add android auto-update settings for github-sideloaded installs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,8 +58,10 @@
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
+    <!-- Needed to trigger the APK installer for GitHub-sideload auto-updates -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
     <!-- Permission added by external package - remove it here -->
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 
     <application

--- a/android/app/src/prodNoAa/AndroidManifest.xml
+++ b/android/app/src/prodNoAa/AndroidManifest.xml
@@ -2,6 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.bluebubbles.messaging">
+    <!-- GitHub-sideload auto-update is inert on this flavor (it's gated off whenever the
+         install source is the Play Store), so drop the permission that declares this app
+         as capable of installing packages — avoids the extra Play Console review/declaration
+         that permission otherwise triggers for a build that never uses it. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
+
     <application>
         <meta-data
             android:name="com.google.android.gms.car.application"

--- a/lib/app/layouts/settings/pages/advanced/app_updates_panel.dart
+++ b/lib/app/layouts/settings/pages/advanced/app_updates_panel.dart
@@ -1,0 +1,201 @@
+import 'package:animated_size_and_fade/animated_size_and_fade.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/content/next_button.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/models/models.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class AppUpdatesPanel extends StatefulWidget {
+  const AppUpdatesPanel({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _AppUpdatesPanelState();
+}
+
+class _AppUpdatesPanelState extends State<AppUpdatesPanel> with ThemeHelpers {
+  @override
+  void initState() {
+    super.initState();
+    // Refresh availability whenever the page is opened. Manual so it never
+    // touches the auto-check schedule.
+    UpdateSvc.checkForUpdate(manual: true);
+  }
+
+  Future<void> _checkNow() async {
+    await UpdateSvc.checkForUpdate(manual: true);
+    if (mounted && !UpdateSvc.updateAvailable.value) {
+      showSnackbar("Up To Date", "You're already on the latest version.");
+    }
+  }
+
+  Future<void> _install(AppUpdateInfo release) async {
+    final ValueNotifier<double?> progress = ValueNotifier(0);
+    final sub = UpdateSvc.downloadProgress.listen((p) => progress.value = p);
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => ValueListenableBuilder<double?>(
+        valueListenable: progress,
+        builder: (ctx, value, _) => BBProgressDialog(title: "Downloading Update...", progress: value),
+      ),
+    );
+    await UpdateSvc.downloadAndInstall(release);
+    await sub.cancel();
+    if (mounted) Navigator.of(context, rootNavigator: true).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: "App Updates",
+      initialHeader: "App Updates",
+      iosSubtitle: iosSubtitle,
+      materialSubtitle: materialSubtitle,
+      tileColor: tileColor,
+      headerColor: headerColor,
+      bodySlivers: [
+        SliverList(
+          delegate: SliverChildListDelegate([
+            const Padding(
+              padding: EdgeInsets.only(bottom: 8.0, left: 15, top: 8.0, right: 15),
+              child: Text(
+                "Automatically check GitHub for new BlueBubbles releases and install them yourself. "
+                "This is only available when the app was not installed from the Play Store.",
+              ),
+            ),
+            Obx(() {
+              final release = UpdateSvc.availableUpdate.value;
+              return AnimatedSizeAndFade.showHide(
+                show: release != null,
+                child: release == null
+                    ? const SizedBox.shrink()
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SettingsHeader(
+                              iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: "Update Available"),
+                          SettingsSection(
+                            backgroundColor: tileColor,
+                            children: [
+                              SettingsTile(
+                                backgroundColor: tileColor,
+                                title: "Version ${release.version}${release.channelSuffix}",
+                                subtitle: release.latestRelease?.name,
+                                isThreeLine: release.latestRelease?.name != null,
+                                leading: const SettingsLeadingIcon(
+                                  iosIcon: CupertinoIcons.arrow_down_circle_fill,
+                                  materialIcon: Icons.system_update,
+                                  containerColor: Colors.green,
+                                ),
+                              ),
+                              if (release.latestRelease?.htmlUrl != null) ...[
+                                const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                                SettingsTile(
+                                  backgroundColor: tileColor,
+                                  title: "View Changelog",
+                                  trailing: const NextButton(),
+                                  onTap: () async {
+                                    await launchUrl(Uri.parse(release.latestRelease!.htmlUrl!),
+                                        mode: LaunchMode.externalApplication);
+                                  },
+                                ),
+                              ],
+                              const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                              SettingsTile(
+                                backgroundColor: tileColor,
+                                title: "Install Update",
+                                trailing: const NextButton(),
+                                onTap: () async {
+                                  await _install(release);
+                                },
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+              );
+            }),
+            SettingsHeader(
+                iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: "Automatic Update Checks"),
+            SettingsSection(
+              backgroundColor: tileColor,
+              children: [
+                Obx(() => SettingsSwitch(
+                      onChanged: (bool val) async {
+                        SettingsSvc.settings.autoUpdateCheckEnabled.value = val;
+                        await SettingsSvc.settings.saveOneAsync('autoUpdateCheckEnabled');
+                      },
+                      initialVal: SettingsSvc.settings.autoUpdateCheckEnabled.value,
+                      title: "Automatically Check for Updates",
+                      subtitle: "Check for new releases on app startup and resume",
+                      backgroundColor: tileColor,
+                      isThreeLine: true,
+                    )),
+              ],
+            ),
+            Obx(() => AnimatedSizeAndFade.showHide(
+                  show: SettingsSvc.settings.autoUpdateCheckEnabled.value,
+                  child: SettingsSection(
+                    backgroundColor: tileColor,
+                    children: [
+                      SettingsOptions<AppUpdateCheckInterval>(
+                        title: "Check Interval",
+                        initial: SettingsSvc.settings.updateCheckInterval.value,
+                        options: AppUpdateCheckInterval.values,
+                        textProcessing: (i) => i.label,
+                        capitalize: false,
+                        onChanged: (val) async {
+                          if (val == null) return;
+                          SettingsSvc.settings.updateCheckInterval.value = val;
+                          await SettingsSvc.settings.saveOneAsync('updateCheckInterval');
+                        },
+                      ),
+                      const SettingsDivider(padding: EdgeInsets.only(left: 16.0)),
+                      SettingsOptions<AppUpdateChannel>(
+                        title: "Update Track",
+                        initial: SettingsSvc.settings.updateChannel.value,
+                        options: AppUpdateChannel.values,
+                        textProcessing: (c) => c.label,
+                        capitalize: false,
+                        onChanged: (val) async {
+                          if (val == null) return;
+                          SettingsSvc.settings.updateChannel.value = val;
+                          await SettingsSvc.settings.saveOneAsync('updateChannel');
+                        },
+                      ),
+                    ],
+                  ),
+                )),
+            SettingsHeader(iosSubtitle: iosSubtitle, materialSubtitle: materialSubtitle, text: "Manual Check"),
+            SettingsSection(
+              backgroundColor: tileColor,
+              children: [
+                Obx(() => SettingsTile(
+                      backgroundColor: tileColor,
+                      title: "Check for Updates",
+                      subtitle: UpdateSvc.checking.value ? "Checking..." : null,
+                      onTap: UpdateSvc.checking.value
+                          ? null
+                          : () async {
+                              await _checkNow();
+                            },
+                      trailing: UpdateSvc.checking.value
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const NextButton(),
+                    )),
+              ],
+            ),
+          ]),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/layouts/settings/widgets/search/settings_items_list.dart
+++ b/lib/app/layouts/settings/widgets/search/settings_items_list.dart
@@ -1,12 +1,14 @@
 import '../../pages/misc/misc_panel.dart';
 import '../../pages/scheduling/message_reminders_panel.dart';
 import '../../pages/scheduling/scheduled_messages_panel.dart';
+import '../tiles/app_updates_tile.dart';
 import '../tiles/connection_server_tile.dart';
 import '../tiles/private_api_tile.dart';
 import '../tiles/redacted_mode_tile.dart';
 import 'package:bluebubbles/app/layouts/settings/dialogs/version_dialog.dart';
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:bluebubbles/app/components/avatars/contact_avatar_widget.dart';
+import 'package:bluebubbles/app/layouts/settings/pages/advanced/app_updates_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/advanced/notification_providers_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/advanced/private_api_panel.dart';
 import 'package:bluebubbles/app/layouts/settings/pages/advanced/redacted_mode_panel.dart';
@@ -545,6 +547,24 @@ List<Widget> buildSettingItemList({
                 containerColor: Colors.grey,
               ),
             ),
+          ),
+
+        // App Updates Tile (only for Android)
+        if (Platform.isAndroid)
+          SearchableSettingItem(
+            title: "App Updates", // Title to search
+            searchTags: [
+              "Automatic Update Checks",
+              "Check for Updates",
+              "Update Channel",
+              "Update Track",
+              "Beta Updates",
+              "GitHub Release",
+            ],
+            onTap: () async {
+              ns.pushAndRemoveSettingsUntil(context, const AppUpdatesPanel(), (Route route) => route.isFirst);
+            },
+            child: AppUpdatesTile(tileColor: tileColor),
           ),
 
         // Notification Providers Tile

--- a/lib/app/layouts/settings/widgets/tiles/app_updates_tile.dart
+++ b/lib/app/layouts/settings/widgets/tiles/app_updates_tile.dart
@@ -1,0 +1,46 @@
+import 'package:bluebubbles/app/layouts/settings/pages/advanced/app_updates_panel.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/content/next_button.dart';
+import 'package:bluebubbles/app/layouts/settings/widgets/settings_widgets.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Reactive tile for the App Updates settings page — only rebuilds when
+/// update availability changes.
+class AppUpdatesTile extends StatelessWidget {
+  final Color tileColor;
+
+  const AppUpdatesTile({super.key, required this.tileColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(
+      () => SettingsTile(
+        backgroundColor: tileColor,
+        title: "App Updates",
+        activePage: AppUpdatesPanel,
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (UpdateSvc.updateAvailable.value)
+              Text(
+                "Update Available",
+                style: context.theme.textTheme.bodyMedium!.apply(color: Colors.green),
+              ),
+            const SizedBox(width: 5),
+            const NextButton(),
+          ],
+        ),
+        onTap: () async {
+          NavigationSvc.pushAndRemoveSettingsUntil(context, const AppUpdatesPanel(), (Route route) => route.isFirst);
+        },
+        leading: SettingsLeadingIcon(
+          iosIcon: CupertinoIcons.arrow_down_circle,
+          materialIcon: Icons.system_update,
+          containerColor: UpdateSvc.updateAvailable.value ? Colors.green : null,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/database/global/settings.dart
+++ b/lib/database/global/settings.dart
@@ -155,6 +155,12 @@ class Settings {
   final RxBool generateFakeAvatars = false.obs;
   final RxBool hideMessageContent = false.obs;
 
+  // App Update Settings (Android-only, GitHub-sideload installs only)
+  final RxBool autoUpdateCheckEnabled = true.obs;
+  final Rx<AppUpdateChannel> updateChannel = AppUpdateChannel.stable.obs;
+  final Rx<AppUpdateCheckInterval> updateCheckInterval = AppUpdateCheckInterval.daily.obs;
+  final RxInt lastUpdateCheckMillis = 0.obs;
+
   // Unified Push Settings
   final RxBool enableUnifiedPush = false.obs;
   final RxString endpointUnifiedPush = RxString("");
@@ -424,6 +430,10 @@ class Settings {
       'hideContactInfo': hideContactInfo.value,
       'generateFakeAvatars': generateFakeAvatars.value,
       'generateFakeMessageContent': hideMessageContent.value,
+      'autoUpdateCheckEnabled': autoUpdateCheckEnabled.value,
+      'updateChannel': updateChannel.value.index,
+      'updateCheckInterval': updateCheckInterval.value.index,
+      'lastUpdateCheckMillis': lastUpdateCheckMillis.value,
       'enableQuickTapback': enableQuickTapback.value,
       'quickTapbackType': quickTapbackType.value,
       'notificationReactionAction': notificationReactionAction.value,
@@ -646,6 +656,16 @@ class Settings {
         map['generateFakeAvatars'] ?? SettingsSvc.settings.generateFakeAvatars.value;
     SettingsSvc.settings.hideMessageContent.value =
         map['generateFakeMessageContent'] ?? SettingsSvc.settings.hideMessageContent.value;
+    SettingsSvc.settings.autoUpdateCheckEnabled.value =
+        map['autoUpdateCheckEnabled'] ?? SettingsSvc.settings.autoUpdateCheckEnabled.value;
+    SettingsSvc.settings.updateChannel.value = map['updateChannel'] != null
+        ? AppUpdateChannel.values[map['updateChannel']]
+        : SettingsSvc.settings.updateChannel.value;
+    SettingsSvc.settings.updateCheckInterval.value = map['updateCheckInterval'] != null
+        ? AppUpdateCheckInterval.values[map['updateCheckInterval']]
+        : SettingsSvc.settings.updateCheckInterval.value;
+    SettingsSvc.settings.lastUpdateCheckMillis.value =
+        map['lastUpdateCheckMillis'] ?? SettingsSvc.settings.lastUpdateCheckMillis.value;
     SettingsSvc.settings.enableUnifiedPush.value =
         map['enableUnifiedPush'] ?? SettingsSvc.settings.enableUnifiedPush.value;
     SettingsSvc.settings.endpointUnifiedPush.value =
@@ -847,6 +867,13 @@ class Settings {
     s.hideContactInfo.value = map['hideContactInfo'] ?? true;
     s.generateFakeAvatars.value = map['generateFakeAvatars'] ?? false;
     s.hideMessageContent.value = map['generateFakeMessageContent'] ?? false;
+    s.autoUpdateCheckEnabled.value = map['autoUpdateCheckEnabled'] ?? true;
+    s.updateChannel.value =
+        map['updateChannel'] != null ? AppUpdateChannel.values[map['updateChannel']] : AppUpdateChannel.stable;
+    s.updateCheckInterval.value = map['updateCheckInterval'] != null
+        ? AppUpdateCheckInterval.values[map['updateCheckInterval']]
+        : AppUpdateCheckInterval.daily;
+    s.lastUpdateCheckMillis.value = map['lastUpdateCheckMillis'] ?? 0;
     s.enableUnifiedPush.value = map['enableUnifiedPush'] ?? false;
     s.endpointUnifiedPush.value = map['endpointUnifiedPush'] ?? "";
     s.enableFcm.value = map['enableFcm'] ?? true;

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -253,10 +253,11 @@ class StartupTasks {
       return contactServiceV2;
     });
 
-    Logger.info("Registering IntentsService, SyncService, and ThemesService...");
+    Logger.info("Registering IntentsService, SyncService, ThemesService, and AppUpdateService...");
     GetIt.I.registerSingleton<IntentsService>(IntentsService());
     GetIt.I.registerSingleton<SyncService>(SyncService());
     GetIt.I.registerSingleton<ThemesService>(ThemesService());
+    GetIt.I.registerSingleton<AppUpdateService>(AppUpdateService());
 
     // Parallelize independent services for faster startup
     await _step("Loading themes and contacts...", log: "Waiting for parallel services...");
@@ -462,7 +463,14 @@ class StartupTasks {
       }
 
       try {
-        SettingsSvc.checkClientUpdate();
+        // Android sideload/GitHub installs are handled by AppUpdateService instead —
+        // it supersedes this generic check for Android (channel/interval-aware,
+        // APK-asset-aware, and gated on install source via store_checker).
+        if (Platform.isAndroid) {
+          unawaited(UpdateSvc.checkForUpdate());
+        } else {
+          SettingsSvc.checkClientUpdate();
+        }
       } catch (ex, stack) {
         Logger.warn("Failed to check for client update!", error: ex, trace: stack);
       }
@@ -598,6 +606,12 @@ class StartupTasks {
 
     if (kIsDesktop && lifecycle != null) {
       lifecycle.windowFocused = true;
+    }
+
+    // No-ops internally unless the check interval has elapsed and auto-check
+    // is enabled — safe to call unconditionally on every resume.
+    if (Platform.isAndroid) {
+      unawaited(UpdateSvc.checkForUpdate());
     }
   }
 

--- a/lib/helpers/types/constants.dart
+++ b/lib/helpers/types/constants.dart
@@ -130,6 +130,93 @@ enum SwipeDirection {
 
 enum BBTitleBarStyle { native, custom, hidden }
 
+/// Android-only, GitHub-release update channel for [Settings.updateChannel].
+/// Only relevant when the app was not installed from the Play Store.
+///
+/// Each non-stable channel is identified by a tag marker (see
+/// [AppUpdateChannelInfo.tagMarker]) — a release belongs to the first channel
+/// whose marker its tag contains. [stable] is whatever's left over: releases
+/// that don't carry any other channel's marker. Adding a new channel (e.g.
+/// `nightly`) is just a new enum value + marker below; no matching logic
+/// elsewhere needs to change.
+enum AppUpdateChannel {
+  stable,
+  beta,
+}
+
+extension AppUpdateChannelInfo on AppUpdateChannel {
+  /// The tag substring that marks a release as belonging to this channel, or
+  /// `null` for [AppUpdateChannel.stable] — stable has no marker of its own,
+  /// it's just "doesn't match any other channel's marker".
+  String? get tagMarker {
+    switch (this) {
+      case AppUpdateChannel.stable:
+        return null;
+      case AppUpdateChannel.beta:
+        return '-beta';
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case AppUpdateChannel.stable:
+        return "Stable";
+      case AppUpdateChannel.beta:
+        return "Beta";
+    }
+  }
+
+  /// Whether [tag] belongs to this channel. For [stable], that means it
+  /// contains none of the other channels' markers.
+  bool matchesTag(String tag) {
+    final lower = tag.toLowerCase();
+    final marker = tagMarker;
+    if (marker != null) return lower.contains(marker);
+    return AppUpdateChannel.values.every((c) => c.tagMarker == null || !lower.contains(c.tagMarker!));
+  }
+}
+
+/// How often the app should automatically check GitHub for a new release.
+enum AppUpdateCheckInterval {
+  every6Hours,
+  every12Hours,
+  daily,
+  every3Days,
+  weekly,
+}
+
+extension AppUpdateCheckIntervalDuration on AppUpdateCheckInterval {
+  Duration get duration {
+    switch (this) {
+      case AppUpdateCheckInterval.every6Hours:
+        return const Duration(hours: 6);
+      case AppUpdateCheckInterval.every12Hours:
+        return const Duration(hours: 12);
+      case AppUpdateCheckInterval.daily:
+        return const Duration(days: 1);
+      case AppUpdateCheckInterval.every3Days:
+        return const Duration(days: 3);
+      case AppUpdateCheckInterval.weekly:
+        return const Duration(days: 7);
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case AppUpdateCheckInterval.every6Hours:
+        return "Every 6 Hours";
+      case AppUpdateCheckInterval.every12Hours:
+        return "Every 12 Hours";
+      case AppUpdateCheckInterval.daily:
+        return "Daily";
+      case AppUpdateCheckInterval.every3Days:
+        return "Every 3 Days";
+      case AppUpdateCheckInterval.weekly:
+        return "Weekly";
+    }
+  }
+}
+
 /// When the app may contact a linked website to build a preview card.
 ///
 /// Fetching a preview for somebody else's link discloses the user's IP address

--- a/lib/models/app_update_info.dart
+++ b/lib/models/app_update_info.dart
@@ -1,19 +1,53 @@
+import 'package:bluebubbles/helpers/types/constants.dart';
 import 'package:github/github.dart' hide Source;
 
 class AppUpdateInfo {
   final bool available;
-  final Release latestRelease;
+
+  /// Null only when no matching release was found at all (e.g. no beta
+  /// release exists yet on the beta track) — in that case [available] is
+  /// always `false` too, so callers only need to null-check after confirming
+  /// [available].
+  final Release? latestRelease;
+
   final bool isDesktopRelease;
+
+  /// The channel this info was fetched for — `null` means the generic/legacy
+  /// check (desktop), which doesn't distinguish channels at all. Set (Android
+  /// GitHub-sideload auto-update) means [latestRelease] was matched against
+  /// this specific channel's tag marker (see [AppUpdateChannelInfo]).
+  ///
+  /// Kept as the actual channel rather than e.g. an `isBeta` bool so a future
+  /// third+ track (nightly, etc.) doesn't need a new field here — just a new
+  /// [AppUpdateChannel] value.
+  final AppUpdateChannel? channel;
+
   final String version;
   final String code;
   final String buildNumber;
 
+  /// Populated only for the Android GitHub-sideload auto-update flow, where
+  /// [latestRelease] is required to carry an `.apk` asset.
+  final String? apkDownloadUrl;
+  final String? apkAssetName;
+  final int? apkSizeBytes;
+
   AppUpdateInfo({
     required this.available,
-    required this.latestRelease,
+    this.latestRelease,
     required this.isDesktopRelease,
+    this.channel,
     required this.version,
     required this.code,
     required this.buildNumber,
+    this.apkDownloadUrl,
+    this.apkAssetName,
+    this.apkSizeBytes,
   });
+
+  /// " (Beta)"-style suffix for displaying [version] on a non-stable channel,
+  /// or an empty string when there's nothing worth calling out (no channel,
+  /// or the stable channel itself).
+  String get channelSuffix =>
+      channel != null && channel != AppUpdateChannel.stable ? " (${channel!.label})" : "";
 }

--- a/lib/services/backend/actions/app_actions.dart
+++ b/lib/services/backend/actions/app_actions.dart
@@ -1,7 +1,10 @@
+import 'package:bluebubbles/helpers/types/constants.dart';
 import 'package:bluebubbles/services/backend/settings/settings_service.dart';
 
 class AppActions {
-  static Future<Map<String, dynamic>> checkForUpdate() async {
-    return await SettingsSvc.getAppUpdateDict();
+  static Future<Map<String, dynamic>> checkForUpdate(Map<String, dynamic> data) async {
+    final channelIndex = data['channel'] as int?;
+    final channel = channelIndex != null ? AppUpdateChannel.values[channelIndex] : null;
+    return await SettingsSvc.getAppUpdateDict(channel: channel);
   }
 }

--- a/lib/services/backend/interfaces/app_interface.dart
+++ b/lib/services/backend/interfaces/app_interface.dart
@@ -1,4 +1,5 @@
 import 'package:bluebubbles/env.dart';
+import 'package:bluebubbles/helpers/types/constants.dart';
 import 'package:bluebubbles/models/models.dart' show AppUpdateInfo;
 import 'package:bluebubbles/services/backend/actions/app_actions.dart';
 import 'package:get_it/get_it.dart';
@@ -6,21 +7,29 @@ import 'package:bluebubbles/services/isolates/global_isolate.dart';
 import 'package:github/github.dart';
 
 class AppInterface {
-  static Future<AppUpdateInfo> checkForUpdate() async {
+  static Future<AppUpdateInfo> checkForUpdate({AppUpdateChannel? channel}) async {
+    final data = {'channel': channel?.index};
+
     late Map<String, dynamic> response;
     if (isIsolate) {
-      response = await AppActions.checkForUpdate();
+      response = await AppActions.checkForUpdate(data);
     } else {
-      response = await GetIt.I<GlobalIsolate>().send<Map<String, dynamic>>(IsolateRequestType.checkForUpdate);
+      response =
+          await GetIt.I<GlobalIsolate>().send<Map<String, dynamic>>(IsolateRequestType.checkForUpdate, input: data);
     }
 
+    final responseChannelIndex = response['channel'] as int?;
     return AppUpdateInfo(
       available: response['available'] as bool,
-      latestRelease: response['latestRelease'] as Release,
+      latestRelease: response['latestRelease'] as Release?,
       isDesktopRelease: response['isDesktopRelease'] as bool,
+      channel: responseChannelIndex != null ? AppUpdateChannel.values[responseChannelIndex] : null,
       version: (response['parsedVersion'] as Map<String, String>)['version']!,
       code: (response['parsedVersion'] as Map<String, String>)['code']!,
       buildNumber: (response['parsedVersion'] as Map<String, String>)['build']!,
+      apkDownloadUrl: response['apkDownloadUrl'] as String?,
+      apkAssetName: response['apkAssetName'] as String?,
+      apkSizeBytes: response['apkSizeBytes'] as int?,
     );
   }
 }

--- a/lib/services/backend/settings/settings_service.dart
+++ b/lib/services/backend/settings/settings_service.dart
@@ -7,13 +7,13 @@ import 'package:bluebubbles/app/wrappers/scrollbar_wrapper.dart';
 import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
-import 'package:bluebubbles/services/backend/interfaces/app_interface.dart';
 import 'package:bluebubbles/services/backend/interfaces/server_interface.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:collection/collection.dart';
 import 'package:get/get.dart';
 import 'package:github/github.dart' hide Source;
 import 'package:local_auth/local_auth.dart';
@@ -429,7 +429,29 @@ class SettingsService {
     );
   }
 
-  Future<Map<String, dynamic>> getAppUpdateDict() async {
+  /// Fetches the latest matching GitHub release for the app.
+  ///
+  /// With [channel] left `null`, this is the legacy/generic check (desktop):
+  /// picks the newest non-draft, non-prerelease release, exactly as before
+  /// this method learned about channels at all.
+  ///
+  /// With [channel] set, this is the Android GitHub-sideload auto-update
+  /// flow: matches by the channel's tag marker (see [AppUpdateChannelInfo])
+  /// and only considers releases that carry a `.apk` asset, since that's
+  /// what gets installed.
+  ///
+  /// Both are thin wrappers over the shared fetch/parse helpers below — this
+  /// just picks which one owns the request.
+  Future<Map<String, dynamic>> getAppUpdateDict({AppUpdateChannel? channel}) async {
+    return channel != null ? await _getChannelUpdateDict(channel) : await _getLegacyUpdateDict();
+  }
+
+  /// Newest non-draft, non-prerelease release — no channel awareness, no
+  /// APK requirement. Availability requires being sideloaded specifically
+  /// (stricter than [_getChannelUpdateDict]'s "just not the Play Store"),
+  /// then narrows further per-platform: build-code comparison on Android,
+  /// semver comparison everywhere else.
+  Future<Map<String, dynamic>> _getLegacyUpdateDict() async {
     bool available = true;
     if (!kIsDesktop && (kIsWeb || (await StoreChecker.getSource) != Source.IS_INSTALLED_FROM_LOCAL_SOURCE)) {
       available = false;
@@ -438,71 +460,169 @@ class SettingsService {
       available = false;
     }
 
-    final github = GitHub();
-    final stream = github.repositories.listReleases(RepositorySlug('bluebubblesapp', 'bluebubbles-app'));
-    final release = await stream.firstWhere(
+    final releases = await _fetchAppReleases();
+    final release = releases.firstWhereOrNull(
         (element) => !(element.isDraft ?? false) && !(element.isPrerelease ?? false) && element.tagName != null);
-    final version = release.tagName!.split("+").first.replaceAll("v", "");
-    final code = release.tagName!.split("+").last.split('-').first;
-    final isDesktopRelease = release.tagName!.split('+').last.contains('desktop');
+    if (release?.tagName == null) {
+      return _unavailableUpdateDict(release: release, channel: null);
+    }
 
+    final parsed = _parseReleaseTag(release!.tagName!);
     String buildNumber = "";
     if (Platform.isAndroid) {
       buildNumber =
           FilesystemSvc.packageInfo.buildNumber.lastChars(min(4, FilesystemSvc.packageInfo.buildNumber.length));
-      if (int.parse(code) <= int.parse(buildNumber) ||
-          PrefsSvc.server.getClientUpdateCheckCode() == code ||
-          (Platform.isAndroid && isDesktopRelease)) {
+      if (!_isNewerBuild(parsed, buildNumber)) {
         available = false;
       }
     } else {
-      final latestRelease = Version(
-        int.parse(version.split(".")[0]),
-        int.parse(version.split(".")[1]),
-        int.parse(version.split(".")[2]),
-      );
-      final current = Version(
-        int.parse(FilesystemSvc.packageInfo.version.split(".")[0]),
-        int.parse(FilesystemSvc.packageInfo.version.split(".")[1]),
-        int.parse(FilesystemSvc.packageInfo.version.split(".")[2]),
-      );
-      if (current.compareTo(latestRelease) < 0) {
+      final latest = _parseSemver(parsed.version);
+      final current = _parseSemver(FilesystemSvc.packageInfo.version);
+      if (current.compareTo(latest) < 0) {
         available = true;
       }
     }
 
-    return {
-      'available': available,
-      'latestRelease': release,
-      'isDesktopRelease': isDesktopRelease,
-      'parsedVersion': {
-        'version': version,
-        'code': code,
-        'build': buildNumber,
-      }
-    };
-  }
-
-  Future<AppUpdateInfo> checkForUpdate() async {
-    final updateDict = await getAppUpdateDict();
-    return AppUpdateInfo(
-      available: updateDict['available'] as bool,
-      latestRelease: updateDict['latestRelease'] as Release,
-      isDesktopRelease: updateDict['isDesktopRelease'] as bool,
-      version: (updateDict['parsedVersion'] as Map<String, String>)['version']!,
-      code: (updateDict['parsedVersion'] as Map<String, String>)['code']!,
-      buildNumber: (updateDict['parsedVersion'] as Map<String, String>)['build']!,
+    return _updateDict(
+      available: available,
+      release: release,
+      parsed: parsed,
+      buildNumber: buildNumber,
+      channel: null,
     );
   }
 
-  Future<void> checkClientUpdate() async {
-    late AppUpdateInfo updateInfo;
-    if (Platform.isAndroid) {
-      updateInfo = await AppInterface.checkForUpdate();
-    } else {
-      updateInfo = await checkForUpdate();
+  /// Matches a release on [channel]'s track that carries a `.apk` asset.
+  /// Availability requires not being installed from the Play Store (any
+  /// other source is eligible), then a genuinely newer build code.
+  Future<Map<String, dynamic>> _getChannelUpdateDict(AppUpdateChannel channel) async {
+    final available = Platform.isAndroid && (await StoreChecker.getSource) != Source.IS_INSTALLED_FROM_PLAY_STORE;
+
+    final releases = await _fetchAppReleases();
+    ReleaseAsset? apkAsset;
+    final release = releases.firstWhereOrNull((element) {
+      if (element.isDraft ?? false) return false;
+      if (element.tagName == null) return false;
+      if (!channel.matchesTag(element.tagName!)) return false;
+      apkAsset = element.assets?.firstWhereOrNull((a) => (a.name ?? '').toLowerCase().endsWith('.apk'));
+      return apkAsset != null;
+    });
+    if (release?.tagName == null) {
+      return _unavailableUpdateDict(release: release, channel: channel);
     }
-    if (!updateInfo.available) return;
+
+    final parsed = _parseReleaseTag(release!.tagName!);
+    final buildNumber =
+        FilesystemSvc.packageInfo.buildNumber.lastChars(min(4, FilesystemSvc.packageInfo.buildNumber.length));
+
+    return _updateDict(
+      available: available && _isNewerBuild(parsed, buildNumber),
+      release: release,
+      parsed: parsed,
+      buildNumber: buildNumber,
+      channel: channel,
+      apkAsset: apkAsset,
+    );
+  }
+
+  /// Fetches every release for the BlueBubbles app repo (newest first, per
+  /// the GitHub API's default ordering) — the one network round-trip shared
+  /// by both [_getLegacyUpdateDict] and [_getChannelUpdateDict].
+  Future<List<Release>> _fetchAppReleases() async {
+    final github = GitHub();
+    try {
+      return await github.repositories.listReleases(RepositorySlug('bluebubblesapp', 'bluebubbles-app')).toList();
+    } finally {
+      github.dispose();
+    }
+  }
+
+  /// Splits a tag like `v1.2.3+400-desktop` into its numeric version, build
+  /// code, and whether it's a desktop-flavored release.
+  ({String version, String code, bool isDesktopRelease}) _parseReleaseTag(String tagName) {
+    return (
+      version: tagName.split("+").first.replaceAll("v", ""),
+      code: tagName.split("+").last.split('-').first,
+      isDesktopRelease: tagName.split('+').last.contains('desktop'),
+    );
+  }
+
+  /// Whether [parsed]'s build code represents a real update over the running
+  /// app: strictly newer, not already dismissed via [PrefsSvc], and not a
+  /// desktop-flavored release (which would never apply on Android).
+  bool _isNewerBuild(({String version, String code, bool isDesktopRelease}) parsed, String currentBuildNumber) {
+    return int.parse(parsed.code) > int.parse(currentBuildNumber) &&
+        PrefsSvc.server.getClientUpdateCheckCode() != parsed.code &&
+        !parsed.isDesktopRelease;
+  }
+
+  Version _parseSemver(String version) {
+    final parts = version.split(".");
+    return Version(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
+  }
+
+  Map<String, dynamic> _unavailableUpdateDict({required Release? release, required AppUpdateChannel? channel}) {
+    return {
+      'available': false,
+      'latestRelease': release,
+      'isDesktopRelease': false,
+      'channel': channel?.index,
+      'parsedVersion': {'version': '', 'code': '', 'build': ''},
+      'apkDownloadUrl': null,
+      'apkAssetName': null,
+      'apkSizeBytes': null,
+    };
+  }
+
+  Map<String, dynamic> _updateDict({
+    required bool available,
+    required Release release,
+    required ({String version, String code, bool isDesktopRelease}) parsed,
+    required String buildNumber,
+    required AppUpdateChannel? channel,
+    ReleaseAsset? apkAsset,
+  }) {
+    return {
+      'available': available,
+      'latestRelease': release,
+      'isDesktopRelease': parsed.isDesktopRelease,
+      'channel': channel?.index,
+      'parsedVersion': {
+        'version': parsed.version,
+        'code': parsed.code,
+        'build': buildNumber,
+      },
+      'apkDownloadUrl': apkAsset?.browserDownloadUrl,
+      'apkAssetName': apkAsset?.name,
+      'apkSizeBytes': apkAsset?.size,
+    };
+  }
+
+  Future<AppUpdateInfo> checkForUpdate({AppUpdateChannel? channel}) async {
+    final updateDict = await getAppUpdateDict(channel: channel);
+    final channelIndex = updateDict['channel'] as int?;
+    return AppUpdateInfo(
+      available: updateDict['available'] as bool,
+      latestRelease: updateDict['latestRelease'] as Release?,
+      isDesktopRelease: updateDict['isDesktopRelease'] as bool,
+      channel: channelIndex != null ? AppUpdateChannel.values[channelIndex] : null,
+      version: (updateDict['parsedVersion'] as Map<String, String>)['version']!,
+      code: (updateDict['parsedVersion'] as Map<String, String>)['code']!,
+      buildNumber: (updateDict['parsedVersion'] as Map<String, String>)['build']!,
+      apkDownloadUrl: updateDict['apkDownloadUrl'] as String?,
+      apkAssetName: updateDict['apkAssetName'] as String?,
+      apkSizeBytes: updateDict['apkSizeBytes'] as int?,
+    );
+  }
+
+  /// Generic/legacy update check — desktop only. Android uses
+  /// `AppUpdateService` instead (see startup_tasks.dart), which calls through
+  /// the same `AppInterface.checkForUpdate` / [getAppUpdateDict] but with an
+  /// [AppUpdateChannel] so it gets track-matched, APK-asset-backed releases.
+  Future<void> checkClientUpdate() async {
+    final updateInfo = await checkForUpdate();
+    if (!updateInfo.available || updateInfo.latestRelease == null) return;
+    final latestRelease = updateInfo.latestRelease!;
 
     showBBDialog(
       context: Get.context!,
@@ -515,16 +635,18 @@ class SettingsService {
           const Text("Updates available:"),
           const SizedBox(height: 15.0),
           Text(
-            "Version: ${updateInfo.version}\nRelease Date: ${buildDate(updateInfo.latestRelease.createdAt)}\nRelease Name: ${updateInfo.latestRelease.name}",
+            "Version: ${updateInfo.version}\n"
+            "Release Date: ${buildDate(latestRelease.createdAt)}\n"
+            "Release Name: ${latestRelease.name}",
           ),
         ],
       ),
       actions: [
-        if (updateInfo.latestRelease.htmlUrl != null)
+        if (latestRelease.htmlUrl != null)
           BBDialogAction(
             text: "Download",
             onPressed: () async {
-              await launchUrl(Uri.parse(updateInfo.latestRelease.htmlUrl!), mode: LaunchMode.externalApplication);
+              await launchUrl(Uri.parse(latestRelease.htmlUrl!), mode: LaunchMode.externalApplication);
             },
           ),
         BBDialogAction(

--- a/lib/services/backend/update/app_update_service.dart
+++ b/lib/services/backend/update/app_update_service.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+
+import 'package:bluebubbles/helpers/helpers.dart';
+import 'package:bluebubbles/models/models.dart';
+import 'package:bluebubbles/services/backend/interfaces/app_interface.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:bluebubbles/utils/logger/logger.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:get_it/get_it.dart';
+import 'package:open_filex/open_filex.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:universal_io/io.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// ignore: non_constant_identifier_names
+AppUpdateService get UpdateSvc => GetIt.I<AppUpdateService>();
+
+/// Android-only GitHub-release auto-update checker.
+///
+/// Fetches through the same [AppInterface.checkForUpdate] / `getAppUpdateDict`
+/// path the generic/desktop update check uses (see `SettingsService`), just
+/// with an [AppUpdateChannel] so the match is track- and APK-asset-aware.
+/// Only active when the app was not installed from the Play Store, which
+/// `getAppUpdateDict` checks via `store_checker`.
+class AppUpdateService {
+  final RxBool checking = false.obs;
+  final RxBool updateAvailable = false.obs;
+  final Rx<AppUpdateInfo?> availableUpdate = Rx<AppUpdateInfo?>(null);
+
+  /// Download progress in `[0, 1]`, or `null` when no download is in progress.
+  final Rx<double?> downloadProgress = Rx<double?>(null);
+
+  bool _intervalElapsed() {
+    final last = SettingsSvc.settings.lastUpdateCheckMillis.value;
+    if (last == 0) return true;
+    final elapsed = DateTime.now().millisecondsSinceEpoch - last;
+    return elapsed >= SettingsSvc.settings.updateCheckInterval.value.duration.inMilliseconds;
+  }
+
+  /// Checks GitHub for a newer release on the configured track.
+  ///
+  /// When [manual] is `false` (startup / app-resume checks), this respects
+  /// [Settings.autoUpdateCheckEnabled] and the configured check interval, and
+  /// prompts the user with a dialog if a newer release is found and they are
+  /// not currently in a conversation. It also advances
+  /// [Settings.lastUpdateCheckMillis] so the schedule moves forward.
+  ///
+  /// When [manual] is `true` (the "Check for Updates" button in Settings),
+  /// none of that gating applies and the schedule is left untouched — only
+  /// [updateAvailable]/[availableUpdate] are refreshed for the settings page
+  /// to render.
+  Future<void> checkForUpdate({bool manual = false}) async {
+    if (!Platform.isAndroid) return;
+    if (checking.value) return;
+    if (!manual) {
+      if (!SettingsSvc.settings.autoUpdateCheckEnabled.value) return;
+      if (!_intervalElapsed()) return;
+    }
+
+    checking.value = true;
+    try {
+      final channel = SettingsSvc.settings.updateChannel.value;
+      final info = await AppInterface.checkForUpdate(channel: channel);
+
+      if (!manual) {
+        SettingsSvc.settings.lastUpdateCheckMillis.value = DateTime.now().millisecondsSinceEpoch;
+        unawaited(SettingsSvc.settings.saveOneAsync('lastUpdateCheckMillis'));
+      }
+
+      updateAvailable.value = info.available;
+      availableUpdate.value = info.available ? info : null;
+
+      if (info.available && !manual) {
+        _maybeShowUpdateDialog(info);
+      }
+    } catch (ex, stack) {
+      Logger.warn("Failed to check for app update", error: ex, trace: stack, tag: "AppUpdateService");
+    } finally {
+      checking.value = false;
+    }
+  }
+
+  void _maybeShowUpdateDialog(AppUpdateInfo info) {
+    if (ChatsSvc.activeChat != null) return;
+    final context = Get.context;
+    if (context == null) return;
+
+    showBBDialog(
+      context: context,
+      title: "Update Available",
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text("Version ${info.version}${info.channelSuffix} is available."),
+          const SizedBox(height: 8),
+          Text("You're currently on ${FilesystemSvc.packageInfo.version}."),
+        ],
+      ),
+      actions: [
+        BBDialogAction(
+          text: "Not Now",
+          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+        ),
+        if (info.latestRelease?.htmlUrl != null)
+          BBDialogAction(
+            text: "Changelog",
+            onPressed: () async {
+              await launchUrl(Uri.parse(info.latestRelease!.htmlUrl!), mode: LaunchMode.externalApplication);
+            },
+          ),
+        BBDialogAction(
+          text: "Update Now",
+          isDefault: true,
+          onPressed: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            downloadAndInstall(info);
+          },
+        ),
+      ],
+    );
+  }
+
+  /// Downloads [info]'s APK asset and hands it to the system installer via
+  /// `open_filex`, which launches the `ACTION_VIEW` install intent — the app
+  /// acts as the install source for its own update.
+  Future<void> downloadAndInstall(AppUpdateInfo info) async {
+    if (!Platform.isAndroid) return;
+    final apkUrl = info.apkDownloadUrl;
+    if (apkUrl == null) {
+      Logger.warn("No APK asset URL on update info, cannot install", tag: "AppUpdateService");
+      return;
+    }
+
+    final dio = Dio();
+    try {
+      downloadProgress.value = 0;
+      final dir = await getTemporaryDirectory();
+      final path = join(dir.path, info.apkAssetName ?? "bluebubbles-update.apk");
+      await dio.download(
+        apkUrl,
+        path,
+        onReceiveProgress: (received, total) {
+          if (total > 0) downloadProgress.value = received / total;
+        },
+      );
+
+      final result = await OpenFilex.open(path, type: "application/vnd.android.package-archive");
+      if (result.type != ResultType.done) {
+        Logger.warn("Could not open downloaded APK: ${result.message}", tag: "AppUpdateService");
+        showToast("Unable to start the installer: ${result.message}", isError: true);
+      }
+    } catch (ex, stack) {
+      Logger.error("Failed to download app update", error: ex, trace: stack, tag: "AppUpdateService");
+      showToast("Failed to download the update", isError: true);
+    } finally {
+      downloadProgress.value = null;
+      dio.close();
+    }
+  }
+}

--- a/lib/services/isolates/isolate_actions.dart
+++ b/lib/services/isolates/isolate_actions.dart
@@ -30,8 +30,8 @@ class IsolateActons {
       TestActions.executeTestThrowError(data as String);
     },
 
-    // App — no-arg, wrap to accept and ignore the data param
-    IsolateRequestType.checkForUpdate: (_) => AppActions.checkForUpdate(),
+    // App
+    IsolateRequestType.checkForUpdate: (data) => AppActions.checkForUpdate(data as Map<String, dynamic>? ?? {}),
 
     // Server — no-arg, wrap to accept and ignore the data param
     IsolateRequestType.checkForServerUpdate: (_) => ServerActions.checkForServerUpdate(),

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -8,6 +8,7 @@ export 'backend/outgoing_message_handler.dart';
 export 'backend/settings/settings_service.dart';
 export 'backend/settings/shared_preferences_service.dart';
 export 'backend/setup/setup_service.dart';
+export 'backend/update/app_update_service.dart';
 export 'backend/sync/full_sync_manager.dart';
 export 'backend/sync/handle_sync_manager.dart';
 export 'backend/sync/incremental_sync_manager.dart';


### PR DESCRIPTION
Adds a dedicated App Updates settings page (Android only, hidden when
installed from the Play Store) with toggles for automatic update
checking (on by default), a check interval, and an update track
(Stable/Beta, extensible to more tracks later). Built entirely from
the shared settings widgets (SettingsScaffold/Section/Switch/Options/
Tile), so it gets correct M3E styling on Material/Samsung and native
Cupertino styling on iOS skin for free.

Checks GitHub releases for BlueBubblesApp/bluebubbles-app on app
startup and resume once the configured interval has elapsed, matching
a release to the selected track by its tag marker (e.g. `-beta`) and
requiring an attached APK asset. Prompts with the new version and a
changelog link when an update is found and the user isn't in a
conversation; downloads and installs the APK through the system
installer via open_filex, with REQUEST_INSTALL_PACKAGES now declared
so the app can act as its own install source. A manual "check for
updates" in settings never touches the scheduled interval, and
dismissing the prompt still leaves the update visible/installable from
the settings page.

This reuses the app's existing update-check infrastructure rather than
duplicating it: SettingsService.getAppUpdateDict() takes an optional
AppUpdateChannel and is split into thin per-path callers
(_getLegacyUpdateDict for the existing desktop check, unchanged
behavior; _getChannelUpdateDict for this Android flow) over shared
fetch/parse helpers, and both funnel through the same
AppInterface.checkForUpdate() isolate-routed action. AppUpdateInfo
gained channel/apkDownloadUrl/apkAssetName/apkSizeBytes fields so one
model serves both flows. Install-source detection (Play Store vs.
sideload) reuses the store_checker-based check already used by the
existing desktop update flow.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ck4QpGuLPDVZRtQGAQ9FV5