### PR TITLE
feat: distinguish new, unchanged, and failed firebase url fetches

### DIFF
--- a/lib/app/layouts/settings/pages/server/connection_panel/connection_panel_helpers.dart
+++ b/lib/app/layouts/settings/pages/server/connection_panel/connection_panel_helpers.dart
@@ -517,9 +517,17 @@ mixin ConnectionPanelHelpersMixin {
               subtitle: "Forcefully fetch latest URL from Firebase",
               backgroundColor: tileColor,
               onTap: () async {
+                // read before fetching — fetchNewUrl saves the new URL over this value.
+                final String? oldUrl = sanitizeServerAddress(address: SettingsSvc.settings.serverAddress.value);
                 await fdb.fetchFirebaseConfig();
                 String? newUrl = await fdb.fetchNewUrl(restartSocket: false);
-                showSnackbar("Notice", "Fetched URL: $newUrl");
+                if (newUrl == null) {
+                  showSnackbar("Error", "Failed to fetch URL");
+                } else if (newUrl == oldUrl) {
+                  showSnackbar("Notice", "URL is already up to date");
+                } else {
+                  showSnackbar("Notice", "New URL found: $newUrl");
+                }
                 SocketSvc.restartSocket();
               },
             ),


### PR DESCRIPTION
New here, thought I'd start by working on something simple real quick.

Fetching latest URL from Firebase showed "Fetched URL: $newUrl" whether or not the URL had actually changed. A failed fetch rendered as "Fetched URL: null".

The button now shows if the URL that was fetched is a new URL, the same URL, or the result of a failed fetch.

Tested all three cases by manually setting the URL from Firebase web console to the same one, a new one, and empty string.

Closes #2849