### PR TITLE
fix: save .mov attachments to the gallery instead of Download/Pictures

### DIFF
--- a/lib/services/backend/filesystem/filesystem_service.dart
+++ b/lib/services/backend/filesystem/filesystem_service.dart
@@ -23,6 +23,9 @@ import 'package:get_it/get_it.dart';
 FilesystemService get FilesystemSvc => GetIt.I<FilesystemService>();
 
 class FilesystemService {
+  /// The root of Android's shared external storage.
+  static const String androidExternalStoragePath = '/storage/emulated/0/';
+
   /// The default Android downloads directory path.
   static const String androidDownloadsPath = '/storage/emulated/0/Download/';
 

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -295,13 +295,17 @@ class AttachmentsService extends GetxService {
           lockParentWindow: true,
         );
       } else {
-        if (file.name.toLowerCase().endsWith(".mov")) {
+        if (isDocument && file.name.toLowerCase().endsWith(".mov")) {
+          // Live Photo companions arrive here as .mov with isDocument: true (see downloadLivePhoto in
+          // media_actions.dart), which skips the SaverGallery branch below. Without this they'd land in
+          // the documents folder, so redirect them to the pictures location instead.
           savePath = join(
             FilesystemService.androidExternalStoragePath,
             SettingsSvc.settings.autoSavePicsLocation.value
           );
         } else {
           if (!isDocument) {
+            // SaverGallery branch
             try {
               if (file.path == null && file.bytes != null) {
                 await SaverGallery.saveImage(

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -296,7 +296,10 @@ class AttachmentsService extends GetxService {
         );
       } else {
         if (file.name.toLowerCase().endsWith(".mov")) {
-          savePath = join(FilesystemService.androidDownloadsPath, SettingsSvc.settings.autoSavePicsLocation.value);
+          savePath = join(
+            FilesystemService.androidExternalStoragePath,
+            SettingsSvc.settings.autoSavePicsLocation.value
+          );
         } else {
           if (!isDocument) {
             try {

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -332,7 +332,11 @@ class AttachmentsService extends GetxService {
 
       if (savePath != null) {
         final bytes = file.bytes != null && file.bytes!.isNotEmpty ? file.bytes! : await File(file.path!).readAsBytes();
-        await File(join(savePath, file.name)).writeAsBytes(bytes);
+        final destination = File(join(savePath, file.name));
+        // writeAsBytes won't create missing parents, and a custom save location such as Pictures/BlueBubbles may
+        // not exist yet
+        await destination.parent.create(recursive: true);
+        await destination.writeAsBytes(bytes);
         showSnackbar('Success', 'Saved attachment to ${FilesystemSvc.toDisplayPath(savePath)} folder!');
       } else {
         return showSnackbar('Error', 'You didn\'t select a file path!');

--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -297,15 +297,14 @@ class AttachmentsService extends GetxService {
       } else {
         if (isDocument && file.name.toLowerCase().endsWith(".mov")) {
           // Live Photo companions arrive here as .mov with isDocument: true (see downloadLivePhoto in
-          // media_actions.dart), which skips the SaverGallery branch below. Without this they'd land in
-          // the documents folder, so redirect them to the pictures location instead.
+          // media_actions.dart), which skips the branch below. Without this they'd land in the documents
+          // folder, so redirect them to the pictures location instead.
           savePath = join(
             FilesystemService.androidExternalStoragePath,
             SettingsSvc.settings.autoSavePicsLocation.value
           );
         } else {
           if (!isDocument) {
-            // SaverGallery branch
             try {
               if (file.path == null && file.bytes != null) {
                 await SaverGallery.saveImage(


### PR DESCRIPTION
This PR has some assumptions, please take a look at the question at the end.

## Issues:

Saving a `.mov` attachment on Android currently fails with:

    PathNotFoundException: Cannot open file, path = '/storage/emulated/0/Download/Pictures/IMG_6778.mov'
    (OS Error: No such file or directory, errno = 2)

There's also a second, older problem: even when the write succeeds, saved `.mov` videos don't appear in the gallery until a device restart. (#2846).

This PR has three commits: the exception fix, the gallery fix, and a small guardrail.

## 1. Wrong directory — #3241

`fc7cc051d` ("wip: filesystem improvements") consolidated path literals into `FilesystemService` and swapped:

```dart
- savePath = join("/storage/emulated/0/", SettingsSvc.settings.autoSavePicsLocation.value);
+ savePath = join(FilesystemService.androidDownloadsPath, SettingsSvc.settings.autoSavePicsLocation.value);
```

The two aren't equivalent — `androidDownloadsPath` carries a trailing `Download/` — so the destination became `/storage/emulated/0/Download/Pictures`, which Android doesn't have by default. `writeAsBytes` doesn't create missing parents, so the save throws.

`autoSavePicsLocation` is relative to the external storage root. That commit added `androidDownloadsPath` but no constant for the root itself.

### Fix
This PR adds `androidExternalStoragePath` for the root and documents the distinction.

## 2. `.mov` videos never reach MediaStore — #2846

The `.mov` check in `attachments_service.dart` matches on the .mov extension alone. Based on what I could find in commit history (`1522ccaab`, "Fix live photo download issues"), it exists for Live Photo companions, which arrive with `isDocument: true` and would otherwise land in the documents folder.

Ordinary `.mov` videos (not Live Photo companions) are saved with `isDocument: false`, but matched that same check, so they skipped the `SaverGallery` branch entirely, never registering with MediaStore. So a saved `.mov` would sit on disk without the gallery knowing about it, and only appear after a full device restart.

### Fix
This PR scopes the check to `isDocument` which keeps the Live Photo behaviour but lets ordinary .mov videos through to `SaverGallery`.

## 3. Guardrail

`writeAsBytes` doesn't create missing parents, so if a user sets a custom path, and their first ever download is a Live Photo companion, it would fail. In practice `SaverGallery` creates the custom folder whenever an image is saved there, but is seems nothing guarantees that ordering.

### Fix
This PR uses `Directory.create` with `recursive = true` to create any non-existing path components if the directory doesn't already exist.  

Separate commit, easy to drop if you'd rather not carry it.

## Testing

Galaxy S23, Android 16.

### Commit 1:
- `.mov` video → no longer throws, lands in `Pictures/` instead of trying to write to `Download/Pictures`

### Commit 2:
- `.mov` video → "Saved attachment to gallery!", appears in Samsung Gallery immediately without a reboot, plays fine

### Commit 3:
- temporarily forced all downloads to `isDocument: true` for testing. With the media location set to a folder that didn't exist, the save now creates it and succeeds; without the change the same save throws `PathNotFoundException`

## Notes

Live Photos still won't appear in the gallery without a rescan. That's unchanged here.

Fixes #3241
Refs #2846

## Question

Was the `.mov` branch intended **only** to keep Live Photo companions out of the documents folder, or was there a separate problem with **all** `.mov` files that I'm not seeing? Before `1522ccaab`, plain `.mov` videos reached `SaverGallery` and were MediaStore-registered. After it they take the raw write. #2846 was opened two months later. I'm assuming the Live Photo fix inadvertently caused it.
