### PR TITLE
fix: hard-exit on Linux when quitting from the system tray

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -304,25 +304,9 @@ class DesktopWindowListener extends WindowListener {
     if (await windowManager.isPreventClose()) {
       await windowManager.hide();
     } else if (Platform.isLinux) {
-      quitLinuxDesktopApp();
+      exit(0);
     }
   }
-}
-
-/// Quit the desktop process immediately.
-///
-/// On Linux (especially Wayland), `window_manager.close()` does not reliably
-/// fire [DesktopWindowListener.onWindowClose] once the window is already
-/// hidden by close-to-tray. `setPreventClose(false)` can also race so
-/// [onWindowClose] still sees prevent-close and calls `hide()` again. The
-/// title-bar path already hard-exits on Linux; tray "Close App" must do the
-/// same or the process stays alive until SIGKILL.
-void quitLinuxDesktopApp() {
-  if (!Platform.isLinux) return;
-  try {
-    Logger.info("Exiting desktop process", tag: "Desktop");
-  } catch (_) {}
-  exit(0);
 }
 
 class Main extends StatelessWidget {
@@ -637,9 +621,7 @@ class _HomeState extends State<Home> with WidgetsBindingObserver, TrayListener {
         await windowManager.hide();
         break;
       case 'close_app':
-        if (Platform.isLinux) {
-          quitLinuxDesktopApp();
-        }
+        if (Platform.isLinux) exit(0);
         await windowManager.setPreventClose(false);
         await windowManager.close();
         break;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -304,9 +304,25 @@ class DesktopWindowListener extends WindowListener {
     if (await windowManager.isPreventClose()) {
       await windowManager.hide();
     } else if (Platform.isLinux) {
-      exit(0);
+      quitLinuxDesktopApp();
     }
   }
+}
+
+/// Quit the desktop process immediately.
+///
+/// On Linux (especially Wayland), `window_manager.close()` does not reliably
+/// fire [DesktopWindowListener.onWindowClose] once the window is already
+/// hidden by close-to-tray. `setPreventClose(false)` can also race so
+/// [onWindowClose] still sees prevent-close and calls `hide()` again. The
+/// title-bar path already hard-exits on Linux; tray "Close App" must do the
+/// same or the process stays alive until SIGKILL.
+void quitLinuxDesktopApp() {
+  if (!Platform.isLinux) return;
+  try {
+    Logger.info("Exiting desktop process", tag: "Desktop");
+  } catch (_) {}
+  exit(0);
 }
 
 class Main extends StatelessWidget {
@@ -621,6 +637,9 @@ class _HomeState extends State<Home> with WidgetsBindingObserver, TrayListener {
         await windowManager.hide();
         break;
       case 'close_app':
+        if (Platform.isLinux) {
+          quitLinuxDesktopApp();
+        }
         await windowManager.setPreventClose(false);
         await windowManager.close();
         break;


### PR DESCRIPTION
Closes #3247

## Summary

Linux tray **Close App** does not quit the process when Close-to-Tray has already hidden the window (especially on Wayland). `windowManager.close()` never reliably reaches the Linux `exit(0)` in `onWindowClose`.

This matches the existing title-bar Linux special case: hard-exit instead of depending on a GTK close event for a hidden window.

## Changes

- Add `quitLinuxDesktopApp()` which `exit(0)`s on Linux.
- Call it from the tray **Close App** handler before `windowManager.close()`.
- Route the existing Linux `onWindowClose` exit through the same helper.

Windows/macOS tray close is unchanged.

## Test plan

- [x] Reproduced on KDE Wayland with v2.1.1+91: D-Bus click on tray **Close App** left the process running.
- [x] After this change, the same click exits the process in ~2s.
- [ ] Linux: Close-to-Tray on → X hides to tray → tray **Close App** quits.
- [ ] Linux: Close-to-Tray off → X still quits (existing `exit(0)` path).
- [ ] Windows tray **Close App** still works (no `exit(0)` on that branch).
